### PR TITLE
이메일 인증 및 임시 회원 생성 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/common/data/redis/RedisConfig.java
+++ b/src/main/java/org/ject/support/common/data/redis/RedisConfig.java
@@ -1,0 +1,50 @@
+package org.ject.support.common.data.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(redisHost, redisPort);
+
+        if (!redisPassword.isEmpty()) {
+            redisConfig.setPassword(RedisPassword.of(redisPassword));
+        }
+
+        return new LettuceConnectionFactory(redisConfig);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/org/ject/support/domain/auth/AuthController.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthController.java
@@ -1,0 +1,25 @@
+package org.ject.support.domain.auth;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.auth.AuthDto.AuthCodeResponse;
+import org.ject.support.external.email.EmailDto.VerifyAuthCodeRequest;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/verify-auth-code")
+    public AuthCodeResponse verifyAuthCode(HttpServletResponse response,
+                                           @RequestBody VerifyAuthCodeRequest verifyAuthCodeRequest) {
+        return authService.verifyEmailByAuthCode(response, verifyAuthCodeRequest.getEmail(),
+                verifyAuthCodeRequest.getAuthCode());
+    }
+}

--- a/src/main/java/org/ject/support/domain/auth/AuthDto.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthDto.java
@@ -1,0 +1,14 @@
+package org.ject.support.domain.auth;
+
+import lombok.Data;
+import lombok.Getter;
+
+public class AuthDto {
+
+    @Data
+    @Getter
+    public static class AuthCodeResponse {
+        private final String accessToken;
+        private final String refreshToken;
+    }
+}

--- a/src/main/java/org/ject/support/domain/auth/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthService.java
@@ -1,0 +1,74 @@
+package org.ject.support.domain.auth;
+
+import static org.ject.support.common.security.jwt.JwtTokenProvider.createAccessCookie;
+import static org.ject.support.common.security.jwt.JwtTokenProvider.createRefreshCookie;
+import static org.ject.support.domain.auth.AuthErrorCode.INVALID_AUTH_CODE;
+import static org.ject.support.domain.auth.AuthErrorCode.NOT_FOUND_AUTH_CODE;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.common.security.jwt.JwtTokenProvider;
+import org.ject.support.domain.auth.AuthDto.AuthCodeResponse;
+import org.ject.support.domain.member.Member;
+import org.ject.support.domain.member.MemberDto.TempMemberJoinRequest;
+import org.ject.support.domain.member.MemberRepository;
+import org.ject.support.external.email.MailException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthCodeResponse verifyEmailByAuthCode(HttpServletResponse response, String email, String userInputCode) {
+        verifyAuthCode(email, userInputCode);
+
+        Member member = memberRepository.findByEmail(email).orElse(null);
+        if (member == null) {
+            member = createTempMember(email);
+        }
+
+        Authentication authentication = jwtTokenProvider.getAuthenticationByEmail(email);
+        String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
+
+        addCookie(response, accessToken, refreshToken);
+
+        // TODO: 개발 시에만 json으로 토큰 반환. 추후 HTTPS 적용 및 실제 운영시에는 쿠키로만 전달 예정 (보안 이슈)
+        return new AuthCodeResponse(accessToken, refreshToken);
+    }
+
+    private Member createTempMember(String email) {
+        Member member = TempMemberJoinRequest.toEntity(email);
+
+        return memberRepository.save(member);
+    }
+
+    // 쿠키 추가 메서드
+    private void addCookie(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.addCookie(createAccessCookie(accessToken));
+        response.addCookie(createRefreshCookie(refreshToken));
+    }
+
+    public void verifyAuthCode(String key, String userInputCode) {
+        // redis에서 키 값으로 인증 번호 조회
+        String redisCode = redisTemplate.opsForValue().get(key);
+
+        // 코드 불일치
+        if (!userInputCode.equals(redisCode)) {
+            throw new MailException(INVALID_AUTH_CODE);
+        }
+
+        if (redisCode == null) {
+            throw new MailException(NOT_FOUND_AUTH_CODE);
+        }
+
+        // 인증 성공
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/org/ject/support/domain/auth/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthService.java
@@ -59,13 +59,14 @@ public class AuthService {
         // redis에서 키 값으로 인증 번호 조회
         String redisCode = redisTemplate.opsForValue().get(key);
 
+        // Redis에서 코드가 없는 경우
+        if (redisCode == null) {
+            throw new MailException(NOT_FOUND_AUTH_CODE);
+        }
+
         // 코드 불일치
         if (!userInputCode.equals(redisCode)) {
             throw new MailException(INVALID_AUTH_CODE);
-        }
-
-        if (redisCode == null) {
-            throw new MailException(NOT_FOUND_AUTH_CODE);
         }
 
         // 인증 성공

--- a/src/main/java/org/ject/support/domain/member/MemberDto.java
+++ b/src/main/java/org/ject/support/domain/member/MemberDto.java
@@ -1,0 +1,35 @@
+package org.ject.support.domain.member;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+public class MemberDto {
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    public static class TempMemberJoinRequest {
+
+        @NotNull
+        @Size(max = 30)
+        @Email(regexp = "^[a-zA-Z0-9._%+-]{1,20}@[a-zA-Z0-9.-]{1,10}\\.[a-zA-Z]{2,}$")
+        private String email;
+
+        public static Member toEntity(String email) {
+            return Member.builder()
+                    .name("UNKNOWN")
+                    .phoneNumber(generateRandomPhoneNumber())
+                    .email(email)
+                    .role(Role.TEMP)
+                    .build();
+        }
+
+        private static String generateRandomPhoneNumber() {
+            return "000" + (int) (Math.random() * 100000000);
+        }
+    }
+}

--- a/src/main/java/org/ject/support/external/email/EmailController.java
+++ b/src/main/java/org/ject/support/external/email/EmailController.java
@@ -1,0 +1,21 @@
+package org.ject.support.external.email;
+
+import lombok.RequiredArgsConstructor;
+import org.ject.support.external.email.EmailDto.SendEmailRequest;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/email")
+@RequiredArgsConstructor
+public class EmailController {
+
+    private final EmailSendService emailSendService;
+
+    @PostMapping("/send-auth-email")
+    public void sendAuthEmail(@RequestBody SendEmailRequest sendEmailRequest) {
+        emailSendService.sendAuthCodeEmail(sendEmailRequest.getEmail());
+    }
+}

--- a/src/main/java/org/ject/support/external/email/EmailDto.java
+++ b/src/main/java/org/ject/support/external/email/EmailDto.java
@@ -1,0 +1,21 @@
+package org.ject.support.external.email;
+
+import com.amazonaws.services.dynamodbv2.xspec.S;
+import lombok.Data;
+import lombok.Getter;
+
+public class EmailDto {
+
+    @Data
+    @Getter
+    public static class SendEmailRequest {
+        private String email;
+    }
+
+    @Data
+    @Getter
+    public static class VerifyAuthCodeRequest {
+        private String email;
+        private String authCode;
+    }
+}

--- a/src/main/java/org/ject/support/external/email/EmailSendService.java
+++ b/src/main/java/org/ject/support/external/email/EmailSendService.java
@@ -1,10 +1,12 @@
 package org.ject.support.external.email;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.util.Json2MapSerializer;
-import org.springframework.mail.MailException;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessagePreparator;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,12 @@ public class EmailSendService {
     private final JavaMailSender mailSender;
     private final MessageGenerator messageGenerator;
     private final Json2MapSerializer json2MapSerializer;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final Random random = new Random();
+
+    // 인증 번호 만료 시간 (초)
+    private static final long EXPIRE_TIME = 300;
+    public static final int AUTH_CODE_LENGTH = 6;
 
     /**
      * 단건 email 전송
@@ -37,9 +45,33 @@ public class EmailSendService {
     private void sendMail(final MimeMessagePreparator ...preparators) {
         try {
             mailSender.send(preparators);
-        } catch (MailException e) {
-            throw new MailSendException(MailErrorCode.MAIL_SEND_FAILURE);
+        } catch (org.springframework.mail.MailException e) {
+            throw new MailException(MailErrorCode.MAIL_SEND_FAILURE);
         }
+    }
+
+    public void sendAuthCodeEmail(String email) {
+        // 랜덤 6자리 숫자
+        String authCode = createAuthCode();
+
+        // Redis에 저장 (key: "email:이메일", value: 인증번호)
+        redisTemplate.opsForValue().set(email, authCode, Duration.ofSeconds(EXPIRE_TIME));
+        String storedCode = redisTemplate.opsForValue().get(email);
+        System.out.println("storedCode = " + storedCode); // TODO: 개발 완료 시 제거
+        // TODO: Map.of() 에서 email을 실제 이름으로 변경
+        sendEmail(email, EmailTemplate.CERTIFICATE, Map.of("to", email, "value", authCode));
+
+        // TODO: 인증 번호 전송 횟수 제한 로직 추가
+    }
+
+    private String createAuthCode() {
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < AUTH_CODE_LENGTH; i++) {
+            sb.append(random.nextInt(10));
+        }
+
+        return sb.toString();
     }
 
     public record MailSendRequest(

--- a/src/main/java/org/ject/support/external/email/MailErrorCode.java
+++ b/src/main/java/org/ject/support/external/email/MailErrorCode.java
@@ -8,7 +8,8 @@ import org.ject.support.common.exception.ErrorCode;
 @AllArgsConstructor
 public enum MailErrorCode implements ErrorCode {
     MAIL_SEND_FAILURE("MAIL_SEND_FAILURE", "메일 전송에 실패하였습니다."),
-    MAIL_PARAMETER_PARSE_FAILURE("MAIL_PARAMETER_PARSE_FAILURE", "메일 생성을 위한 객체 변환에 실패했습니다.");
+    MAIL_PARAMETER_PARSE_FAILURE("MAIL_PARAMETER_PARSE_FAILURE", "메일 생성을 위한 객체 변환에 실패했습니다."),
+    MAIL_AUTH_CODE_INVALID("MAIL_AUTH_CODE_INVALID", "인증번호가 일치하지 않습니다.");
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/external/email/MailException.java
+++ b/src/main/java/org/ject/support/external/email/MailException.java
@@ -3,8 +3,8 @@ package org.ject.support.external.email;
 import org.ject.support.common.exception.BusinessException;
 import org.ject.support.common.exception.ErrorCode;
 
-public class MailSendException extends BusinessException {
-    public MailSendException(final ErrorCode errorCode) {
+public class MailException extends BusinessException {
+    public MailException(final ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
@@ -1,0 +1,137 @@
+package org.ject.support.domain.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ject.support.domain.auth.AuthErrorCode.INVALID_AUTH_CODE;
+import static org.ject.support.domain.auth.AuthErrorCode.NOT_FOUND_AUTH_CODE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import org.ject.support.common.security.jwt.JwtTokenProvider;
+import org.ject.support.domain.auth.AuthDto.AuthCodeResponse;
+import org.ject.support.domain.member.Member;
+import org.ject.support.domain.member.MemberRepository;
+import org.ject.support.external.email.MailException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private final String TEST_EMAIL = "test@example.com";
+    private final String TEST_AUTH_CODE = "123456";
+    private final String TEST_ACCESS_TOKEN = "test.access.token";
+    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드 검증 성공 - 신규 회원")
+    void verifyEmailByAuthCode_NewMember_Success() {
+        // given
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        Authentication authentication = mock(Authentication.class);
+        Member newMember = Member.builder()
+            .email(TEST_EMAIL)
+            .build();
+
+        given(valueOperations.get(TEST_EMAIL)).willReturn(TEST_AUTH_CODE);
+        given(memberRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.empty());
+        given(memberRepository.save(any(Member.class))).willReturn(newMember);
+        given(jwtTokenProvider.getAuthenticationByEmail(TEST_EMAIL)).willReturn(authentication);
+        given(jwtTokenProvider.createAccessToken(any(), any())).willReturn(TEST_ACCESS_TOKEN);
+        given(jwtTokenProvider.createRefreshToken(any())).willReturn(TEST_REFRESH_TOKEN);
+
+        // when
+        AuthCodeResponse result = authService.verifyEmailByAuthCode(response, TEST_EMAIL, TEST_AUTH_CODE);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+        assertThat(result.getRefreshToken()).isEqualTo(TEST_REFRESH_TOKEN);
+        verify(redisTemplate).delete(TEST_EMAIL);
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드 검증 성공 - 기존 회원")
+    void verifyEmailByAuthCode_ExistingMember_Success() {
+        // given
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        Authentication authentication = mock(Authentication.class);
+        Member existingMember = Member.builder()
+            .email(TEST_EMAIL)
+            .build();
+
+        given(valueOperations.get(TEST_EMAIL)).willReturn(TEST_AUTH_CODE);
+        given(memberRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(existingMember));
+        given(jwtTokenProvider.getAuthenticationByEmail(TEST_EMAIL)).willReturn(authentication);
+        given(jwtTokenProvider.createAccessToken(any(), any())).willReturn(TEST_ACCESS_TOKEN);
+        given(jwtTokenProvider.createRefreshToken(any())).willReturn(TEST_REFRESH_TOKEN);
+
+        // when
+        AuthCodeResponse result = authService.verifyEmailByAuthCode(response, TEST_EMAIL, TEST_AUTH_CODE);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+        assertThat(result.getRefreshToken()).isEqualTo(TEST_REFRESH_TOKEN);
+        verify(redisTemplate).delete(TEST_EMAIL);
+    }
+
+    @Test
+    @DisplayName("인증 코드 검증 실패 - 잘못된 코드")
+    void verifyAuthCode_InvalidCode_ThrowsException() {
+        // given
+        String wrongCode = "wrong_code";
+        given(valueOperations.get(anyString())).willReturn(TEST_AUTH_CODE);
+
+        // when & then
+        assertThatThrownBy(() -> authService.verifyAuthCode(TEST_EMAIL, wrongCode))
+            .isInstanceOf(MailException.class)
+            .extracting(e -> ((MailException) e).getErrorCode())
+            .isEqualTo(INVALID_AUTH_CODE);
+    }
+
+    @Test
+    @DisplayName("인증 코드 검증 실패 - 만료된 코드")
+    void verifyAuthCode_ExpiredCode_ThrowsException() {
+        // given
+        given(valueOperations.get(anyString())).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> authService.verifyAuthCode(TEST_EMAIL, TEST_AUTH_CODE))
+            .isInstanceOf(MailException.class)
+            .extracting(e -> ((MailException) e).getErrorCode())
+            .isEqualTo(NOT_FOUND_AUTH_CODE);
+    }
+}

--- a/src/test/java/org/ject/support/domain/member/MemberTest.java
+++ b/src/test/java/org/ject/support/domain/member/MemberTest.java
@@ -1,0 +1,65 @@
+package org.ject.support.domain.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("Member 엔티티 생성 성공")
+    void createMember_Success() {
+        // given
+        String name = "John Doe";
+        String phoneNumber = "01012345678";
+        String email = "john@example.com";
+        String semester = "2024-1";
+        JobFamily jobFamily = JobFamily.BE;
+        Role role = Role.USER;
+
+        // when
+        Member member = Member.builder()
+            .name(name)
+            .phoneNumber(phoneNumber)
+            .email(email)
+            .semester(semester)
+            .jobFamily(jobFamily)
+            .role(role)
+            .build();
+
+        // then
+        assertThat(member.getName()).isEqualTo(name);
+        assertThat(member.getPhoneNumber()).isEqualTo(phoneNumber);
+        assertThat(member.getEmail()).isEqualTo(email);
+        assertThat(member.getSemester()).isEqualTo(semester);
+        assertThat(member.getJobFamily()).isEqualTo(jobFamily);
+        assertThat(member.getRole()).isEqualTo(role);
+    }
+
+    @Test
+    @DisplayName("Member 엔티티 생성 - 최소 필수 필드만으로 생성")
+    void createMember_WithRequiredFieldsOnly_Success() {
+        // given
+        String name = "John Doe";
+        String phoneNumber = "01012345678";
+        String email = "john@example.com";
+        Role role = Role.USER;
+
+        // when
+        Member member = Member.builder()
+            .name(name)
+            .phoneNumber(phoneNumber)
+            .email(email)
+            .role(role)
+            .build();
+
+        // then
+        assertThat(member.getName()).isEqualTo(name);
+        assertThat(member.getPhoneNumber()).isEqualTo(phoneNumber);
+        assertThat(member.getEmail()).isEqualTo(email);
+        assertThat(member.getRole()).isEqualTo(role);
+        assertThat(member.getSemester()).isNull();
+        assertThat(member.getJobFamily()).isNull();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #35 

## 📝작업 내용
### #34 PR에 이어 작업한 건으로, 가독성을 위해 #34 PR에 merge 하는 것으로 PR을 생성했습니다. #34 PR이 main에 머지되면, 해당 PR 또한 main 머지로 바꿔질 예정입니다.

### #34 PR 머지 이후 이 PR을 확인해주세요!

- 인증 이메일 발송 기능 구현
- 인증 번호 검증 기능 구현
- 임시 회원 생성 및 등록 기능 구현
- Redis 사용을 위한 Config 클래스 작성
- 테스트 코드 작성

## ✅테스트 결과
![스크린샷 2025-02-11 오전 2 02 23](https://github.com/user-attachments/assets/bec11e47-0ae9-4c25-bf2f-f0e8e1999126)

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->




