### PR TITLE
🚧 파일 업로드 API path 통일 및 인증 로직 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/file/controller/FileController.java
+++ b/src/main/java/org/ject/support/domain/file/controller/FileController.java
@@ -19,15 +19,8 @@ public class FileController {
 
     // TODO 인증 어노테이션 추가
     @PostMapping("/presigned-url")
-    public CreatePresignedUrlResponse createPresignedUrl(final Long memberId,
-                                                         @RequestBody final String fileName) {
-        return s3Service.createPresignedUrl(memberId, fileName);
-    }
-
-    // TODO 인증 어노테이션 추가
-    @PostMapping("/presigned-urls")
-    public List<CreatePresignedUrlResponse> createPresignedUrls(final Long memberId,
-                                                                @RequestBody final List<String> fileNames) {
-        return s3Service.createPresignedUrls(memberId, fileNames);
+    public List<CreatePresignedUrlResponse> createPresignedUrl(final Long memberId,
+                                                               @RequestBody final List<String> fileNames) {
+        return s3Service.createPresignedUrl(memberId, fileNames);
     }
 }

--- a/src/main/java/org/ject/support/domain/file/dto/CreatePresignedUrlResponse.java
+++ b/src/main/java/org/ject/support/domain/file/dto/CreatePresignedUrlResponse.java
@@ -1,6 +1,9 @@
 package org.ject.support.domain.file.dto;
 
+import lombok.Builder;
+
 import java.time.LocalDateTime;
 
+@Builder
 public record CreatePresignedUrlResponse(String keyName, String presignedUrl, LocalDateTime expiration) {
 }

--- a/src/main/java/org/ject/support/external/s3/S3Service.java
+++ b/src/main/java/org/ject/support/external/s3/S3Service.java
@@ -29,17 +29,7 @@ public class S3Service {
     /**
      * 사용자가 첨부한 파일 이름과 해당 사용자의 식별자를 토대로 Pre-signed URL 생성
      */
-    public CreatePresignedUrlResponse createPresignedUrl(Long memberId, String fileName) {
-        String keyName = getKeyName(memberId, fileName);
-        PutObjectPresignRequest presignRequest = getPutObjectPresignRequest(keyName);
-        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
-        return getCreatePresignedUrlResponse(keyName, presignedRequest);
-    }
-
-    /**
-     * 여러 개의 Pre-signed URL 생성
-     */
-    public List<CreatePresignedUrlResponse> createPresignedUrls(Long memberId, List<String> fileNames) {
+    public List<CreatePresignedUrlResponse> createPresignedUrl(Long memberId, List<String> fileNames) {
         return fileNames.stream()
                 .map(fileName -> {
                     String keyName = getKeyName(memberId, fileName);
@@ -69,10 +59,12 @@ public class S3Service {
                 .build();
     }
 
-    private CreatePresignedUrlResponse getCreatePresignedUrlResponse(String keyName, PresignedPutObjectRequest presignedRequest) {
-        return new CreatePresignedUrlResponse(
-                keyName,
-                presignedRequest.url().toExternalForm(),
-                LocalDateTime.ofInstant(presignedRequest.expiration(), ZoneId.systemDefault()));
+    private CreatePresignedUrlResponse getCreatePresignedUrlResponse(String keyName,
+                                                                     PresignedPutObjectRequest presignedRequest) {
+        return CreatePresignedUrlResponse.builder()
+                .keyName(keyName)
+                .presignedUrl(presignedRequest.url().toExternalForm())
+                .expiration(LocalDateTime.ofInstant(presignedRequest.expiration(), ZoneId.systemDefault()))
+                .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #40 

## 📝작업 내용
- 파일 업로드 API path 통일

파일 업로드 API 요청 body에 기본적으로 배열을 전달하는 방식으로 변경했습니다.

## ✅테스트 결과
<img width="369" alt="image" src="https://github.com/user-attachments/assets/9b6bcf37-0de4-4294-bc35-a897d4f6eb59" />
