### PR TITLE
프로젝트 상세 조회 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/common/data/querydsl/QueryDslConfig.java
+++ b/src/main/java/org/ject/support/common/data/querydsl/QueryDslConfig.java
@@ -1,5 +1,6 @@
 package org.ject.support.common.data.querydsl;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -14,6 +15,6 @@ public class QueryDslConfig {
 
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
 }

--- a/src/main/java/org/ject/support/common/security/CustomUserDetailService.java
+++ b/src/main/java/org/ject/support/common/security/CustomUserDetailService.java
@@ -1,15 +1,15 @@
 package org.ject.support.common.security;
 
 
-import static org.ject.support.domain.member.MemberErrorCode.NOT_FOUND_MEMBER;
-
 import lombok.RequiredArgsConstructor;
-import org.ject.support.domain.member.Member;
-import org.ject.support.domain.member.MemberException;
-import org.ject.support.domain.member.MemberRepository;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.exception.MemberException;
+import org.ject.support.domain.member.repository.MemberRepository;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+
+import static org.ject.support.domain.member.exception.MemberErrorCode.NOT_FOUND_MEMBER;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/ject/support/common/security/CustomUserDetails.java
+++ b/src/main/java/org/ject/support/common/security/CustomUserDetails.java
@@ -3,8 +3,8 @@ package org.ject.support.common.security;
 import java.util.ArrayList;
 import java.util.Collection;
 import lombok.Getter;
-import org.ject.support.domain.member.Member;
 import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 

--- a/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
@@ -1,7 +1,11 @@
 package org.ject.support.common.security.jwt;
 
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import java.security.Key;
@@ -9,8 +13,8 @@ import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.exception.GlobalException;
 import org.ject.support.common.security.CustomUserDetails;
-import org.ject.support.domain.member.Member;
 import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -22,13 +26,12 @@ import static org.ject.support.common.exception.GlobalErrorCode.AUTHENTICATION_R
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
+    private final Key secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS512);
     @Value("${spring.jwt.token.access-expiration-time}")
     private long accessExpirationTime;
-
     @Value("${spring.jwt.token.refresh-expiration-time}")
     private long refreshExpirationTime;
 
-    private final Key secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS512);
     /**
      * Access 토큰 생성
      */
@@ -76,7 +79,7 @@ public class JwtTokenProvider {
         String email = claims.getSubject();
         Long memberId = claims.get("memberId", Long.class);
         Role role = Role.valueOf(claims.get("role", String.class).toUpperCase());
-        
+
         CustomUserDetails userDetails = new CustomUserDetails(email, memberId, role);
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }

--- a/src/main/java/org/ject/support/domain/member/JobFamily.java
+++ b/src/main/java/org/ject/support/domain/member/JobFamily.java
@@ -1,5 +1,5 @@
 package org.ject.support.domain.member;
 
 public enum JobFamily {
-    PM, UI, FE, BE
+    PM, PD, FE, BE
 }

--- a/src/main/java/org/ject/support/domain/member/dto/MemberDto.java
+++ b/src/main/java/org/ject/support/domain/member/dto/MemberDto.java
@@ -1,4 +1,4 @@
-package org.ject.support.domain.member;
+package org.ject.support.domain.member.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -8,6 +8,8 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
 
 public class MemberDto {
 

--- a/src/main/java/org/ject/support/domain/member/dto/TeamMemberNames.java
+++ b/src/main/java/org/ject/support/domain/member/dto/TeamMemberNames.java
@@ -1,0 +1,14 @@
+package org.ject.support.domain.member.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.util.List;
+
+public record TeamMemberNames(List<String> projectManagers,
+                              List<String> productDesigners,
+                              List<String> frontendDevelopers,
+                              List<String> backendDevelopers) {
+
+    @QueryProjection
+    public TeamMemberNames {
+    }
+}

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -4,9 +4,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,4 +50,8 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(10)", nullable = false)
     private Role role;
+
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<TeamMember> teamMembers = new ArrayList<>();
 }

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -1,12 +1,20 @@
-package org.ject.support.domain.member;
+package org.ject.support.domain.member.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Role;
 
 @Entity
 @Getter

--- a/src/main/java/org/ject/support/domain/member/entity/Team.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Team.java
@@ -8,10 +8,12 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/ject/support/domain/member/entity/Team.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Team.java
@@ -1,6 +1,10 @@
-package org.ject.support.domain.member;
+package org.ject.support.domain.member.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/org/ject/support/domain/member/entity/TeamMember.java
+++ b/src/main/java/org/ject/support/domain/member/entity/TeamMember.java
@@ -1,6 +1,12 @@
-package org.ject.support.domain.member;
+package org.ject.support.domain.member.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;

--- a/src/main/java/org/ject/support/domain/member/entity/TeamMember.java
+++ b/src/main/java/org/ject/support/domain/member/entity/TeamMember.java
@@ -8,10 +8,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;
 
 @Entity
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamMember extends BaseTimeEntity {
 

--- a/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
@@ -1,4 +1,4 @@
-package org.ject.support.domain.member;
+package org.ject.support.domain.member.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/org/ject/support/domain/member/exception/MemberException.java
+++ b/src/main/java/org/ject/support/domain/member/exception/MemberException.java
@@ -1,4 +1,4 @@
-package org.ject.support.domain.member;
+package org.ject.support.domain.member.exception;
 
 import org.ject.support.common.exception.BusinessException;
 import org.ject.support.common.exception.ErrorCode;

--- a/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepository.java
@@ -1,0 +1,8 @@
+package org.ject.support.domain.member.repository;
+
+import org.ject.support.domain.member.dto.TeamMemberNames;
+
+public interface MemberQueryRepository {
+
+    TeamMemberNames findMemberNamesByTeamId(Long teamId);
+}

--- a/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
@@ -1,0 +1,48 @@
+package org.ject.support.domain.member.repository;
+
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.JPQLQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.member.dto.QTeamMemberNames;
+import org.ject.support.domain.member.dto.TeamMemberNames;
+import org.springframework.stereotype.Repository;
+
+import static org.ject.support.domain.member.JobFamily.BE;
+import static org.ject.support.domain.member.JobFamily.FE;
+import static org.ject.support.domain.member.JobFamily.PD;
+import static org.ject.support.domain.member.JobFamily.PM;
+import static org.ject.support.domain.member.entity.QMember.member;
+import static org.ject.support.domain.member.entity.QTeamMember.teamMember;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryRepositoryImpl implements MemberQueryRepository {
+
+    private final JPQLQueryFactory queryFactory;
+
+    @Override
+    public TeamMemberNames findMemberNamesByTeamId(Long teamId) {
+        return queryFactory.selectFrom(member)
+                .join(member.teamMembers, teamMember)
+                .where(teamMember.team.id.eq(teamId))
+                .transform(GroupBy.groupBy(teamMember.team.id).as(new QTeamMemberNames(
+                        GroupBy.list(new CaseBuilder()
+                                .when(member.jobFamily.eq(PM))
+                                .then(member.name)
+                                .otherwise((String) null)),
+                        GroupBy.list(new CaseBuilder()
+                                .when(member.jobFamily.eq(PD))
+                                .then(member.name)
+                                .otherwise((String) null)),
+                        GroupBy.list(new CaseBuilder()
+                                .when(member.jobFamily.eq(FE))
+                                .then(member.name)
+                                .otherwise((String) null)),
+                        GroupBy.list(new CaseBuilder()
+                                .when(member.jobFamily.eq(BE))
+                                .then(member.name)
+                                .otherwise((String) null))
+                ))).get(teamId);
+    }
+}

--- a/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
-package org.ject.support.domain.member;
+package org.ject.support.domain.member.repository;
 
 import java.util.Optional;
+import org.ject.support.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {

--- a/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 import org.ject.support.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberQueryRepository {
 
     Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/org/ject/support/domain/member/repository/TeamMemberRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/TeamMemberRepository.java
@@ -1,0 +1,7 @@
+package org.ject.support.domain.member.repository;
+
+import org.ject.support.domain.member.entity.TeamMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+}

--- a/src/main/java/org/ject/support/domain/member/repository/TeamRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/TeamRepository.java
@@ -1,5 +1,6 @@
-package org.ject.support.domain.member;
+package org.ject.support.domain.member.repository;
 
+import org.ject.support.domain.member.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {

--- a/src/main/java/org/ject/support/domain/project/controller/ProjectController.java
+++ b/src/main/java/org/ject/support/domain/project/controller/ProjectController.java
@@ -1,12 +1,14 @@
 package org.ject.support.domain.project.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.project.dto.ProjectDetailResponse;
 import org.ject.support.domain.project.dto.ProjectResponse;
 import org.ject.support.domain.project.service.ProjectService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,5 +24,10 @@ public class ProjectController {
     public Page<ProjectResponse> findProjects(@RequestParam String semester,
                                               @PageableDefault(size = 30) Pageable pageable) {
         return projectService.findProjectsBySemester(semester, pageable);
+    }
+
+    @GetMapping("/{projectId}")
+    public ProjectDetailResponse findProjectDetails(@PathVariable Long projectId) {
+        return projectService.findProjectDetails(projectId);
     }
 }

--- a/src/main/java/org/ject/support/domain/project/controller/ProjectController.java
+++ b/src/main/java/org/ject/support/domain/project/controller/ProjectController.java
@@ -5,6 +5,7 @@ import org.ject.support.domain.project.dto.ProjectResponse;
 import org.ject.support.domain.project.service.ProjectService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,7 +19,8 @@ public class ProjectController {
     private final ProjectService projectService;
 
     @GetMapping
-    public Page<ProjectResponse> findProjects(@RequestParam String semester, Pageable pageable) {
+    public Page<ProjectResponse> findProjects(@RequestParam String semester,
+                                              @PageableDefault(size = 30) Pageable pageable) {
         return projectService.findProjectsBySemester(semester, pageable);
     }
 }

--- a/src/main/java/org/ject/support/domain/project/dto/ProjectDetailResponse.java
+++ b/src/main/java/org/ject/support/domain/project/dto/ProjectDetailResponse.java
@@ -1,0 +1,45 @@
+package org.ject.support.domain.project.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import org.ject.support.domain.member.dto.TeamMemberNames;
+import org.ject.support.domain.project.entity.Project;
+
+@Builder
+public record ProjectDetailResponse(
+        String thumbnailUrl,
+        String name,
+        LocalDate startDate,
+        LocalDate endDate,
+        TeamMemberNames teamMemberNames,
+        String techStack,
+        String description,
+        String serviceUrl,
+        List<ProjectIntroResponse> serviceIntros,
+        List<ProjectIntroResponse> devIntros
+) {
+
+    @QueryProjection
+    public ProjectDetailResponse {
+    }
+
+    public static ProjectDetailResponse toResponse(Project project,
+                                                   TeamMemberNames teamMemberNames,
+                                                   List<ProjectIntroResponse> serviceIntros,
+                                                   List<ProjectIntroResponse> devIntros) {
+        return ProjectDetailResponse.builder()
+                .thumbnailUrl(project.getThumbnailUrl())
+                .name(project.getName())
+                .startDate(project.getStartDate())
+                .endDate(project.getEndDate())
+                .teamMemberNames(teamMemberNames)
+                .techStack(project.getTechStack())
+                .description(project.getDescription())
+                .serviceUrl(project.getServiceUrl())
+                .serviceIntros(serviceIntros)
+                .devIntros(devIntros)
+                .build();
+    }
+}

--- a/src/main/java/org/ject/support/domain/project/dto/ProjectIntroResponse.java
+++ b/src/main/java/org/ject/support/domain/project/dto/ProjectIntroResponse.java
@@ -1,0 +1,20 @@
+package org.ject.support.domain.project.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import org.ject.support.domain.project.entity.ProjectIntro;
+
+@Builder
+public record ProjectIntroResponse(String imageUrl, int sequence) {
+
+    @QueryProjection
+    public ProjectIntroResponse {
+    }
+
+    public static ProjectIntroResponse toResponse(ProjectIntro projectIntro) {
+        return ProjectIntroResponse.builder()
+                .imageUrl(projectIntro.getImageUrl())
+                .sequence(projectIntro.getSequence())
+                .build();
+    }
+}

--- a/src/main/java/org/ject/support/domain/project/entity/Project.java
+++ b/src/main/java/org/ject/support/domain/project/entity/Project.java
@@ -1,11 +1,21 @@
 package org.ject.support.domain.project.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-import org.ject.support.domain.base.BaseTimeEntity;
-import org.ject.support.domain.member.Team;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.ject.support.domain.base.BaseTimeEntity;
+import org.ject.support.domain.member.entity.Team;
 
 @Entity
 @Getter

--- a/src/main/java/org/ject/support/domain/project/entity/Project.java
+++ b/src/main/java/org/ject/support/domain/project/entity/Project.java
@@ -8,7 +8,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -53,4 +57,9 @@ public class Project extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)
     private Team team;
+
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
+    @OrderBy("sequence asc")
+    @Builder.Default
+    private List<ProjectIntro> projectIntros = new ArrayList<>();
 }

--- a/src/main/java/org/ject/support/domain/project/entity/ProjectIntro.java
+++ b/src/main/java/org/ject/support/domain/project/entity/ProjectIntro.java
@@ -1,11 +1,26 @@
 package org.ject.support.domain.project.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;
 
 @Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProjectIntro extends BaseTimeEntity {
 
@@ -16,7 +31,22 @@ public class ProjectIntro extends BaseTimeEntity {
     @Column(length = 2083, nullable = false)
     private String imageUrl;
 
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(30)", nullable = false)
+    private Category category;
+
+    @Column
+    private Integer sequence;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id", nullable = false)
     private Project project;
+
+    public boolean isCategory(Category category) {
+        return this.category == category;
+    }
+
+    public enum Category {
+        SERVICE, DEV
+    }
 }

--- a/src/main/java/org/ject/support/domain/project/exception/ProjectErrorCode.java
+++ b/src/main/java/org/ject/support/domain/project/exception/ProjectErrorCode.java
@@ -1,0 +1,15 @@
+package org.ject.support.domain.project.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.ject.support.common.exception.ErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum ProjectErrorCode implements ErrorCode {
+    NOT_FOUND("PROJECT_NOT_FOUND", "프로젝트를 찾을 수 없습니다."),
+    ;
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/ject/support/domain/project/exception/ProjectException.java
+++ b/src/main/java/org/ject/support/domain/project/exception/ProjectException.java
@@ -1,0 +1,10 @@
+package org.ject.support.domain.project.exception;
+
+import org.ject.support.common.exception.BusinessException;
+import org.ject.support.common.exception.ErrorCode;
+
+public class ProjectException extends BusinessException {
+    public ProjectException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepository.java
@@ -1,44 +1,10 @@
 package org.ject.support.domain.project.repository;
 
-import com.querydsl.jpa.impl.JPAQuery;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.project.dto.ProjectResponse;
-import org.ject.support.domain.project.dto.QProjectResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
-import org.springframework.stereotype.Repository;
 
-import java.util.List;
+public interface ProjectQueryRepository {
 
-import static org.ject.support.domain.project.entity.QProject.project;
-
-@Repository
-@RequiredArgsConstructor
-public class ProjectQueryRepository {
-
-    private final JPAQueryFactory queryFactory;
-
-    public Page<ProjectResponse> findProjectsBySemester(final String semester, Pageable pageable) {
-        List<ProjectResponse> content = queryFactory.select(new QProjectResponse(
-                        project.id,
-                        project.thumbnailUrl,
-                        project.name,
-                        project.summary,
-                        project.startDate,
-                        project.endDate
-                ))
-                .from(project)
-                .where(project.semester.eq(semester))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-
-        JPAQuery<Long> countQuery = queryFactory
-                .select(project.count())
-                .from(project);
-
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
-    }
+    Page<ProjectResponse> findProjectsBySemester(final String semester, Pageable pageable);
 }

--- a/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryImpl.java
@@ -1,0 +1,44 @@
+package org.ject.support.domain.project.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.project.dto.ProjectResponse;
+import org.ject.support.domain.project.dto.QProjectResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import static org.ject.support.domain.project.entity.QProject.project;
+
+@Repository
+@RequiredArgsConstructor
+public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ProjectResponse> findProjectsBySemester(final String semester, Pageable pageable) {
+        List<ProjectResponse> content = queryFactory.select(new QProjectResponse(
+                        project.id,
+                        project.thumbnailUrl,
+                        project.name,
+                        project.summary,
+                        project.startDate,
+                        project.endDate
+                ))
+                .from(project)
+                .where(project.semester.eq(semester))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(project.count())
+                .from(project);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/org/ject/support/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/org/ject/support/domain/project/repository/ProjectRepository.java
@@ -3,5 +3,5 @@ package org.ject.support.domain.project.repository;
 import org.ject.support.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProjectRepository extends JpaRepository<Project, Long> {
+public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectQueryRepository {
 }

--- a/src/main/java/org/ject/support/domain/project/service/ProjectService.java
+++ b/src/main/java/org/ject/support/domain/project/service/ProjectService.java
@@ -1,18 +1,32 @@
 package org.ject.support.domain.project.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.member.dto.TeamMemberNames;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.project.dto.ProjectDetailResponse;
+import org.ject.support.domain.project.dto.ProjectIntroResponse;
 import org.ject.support.domain.project.dto.ProjectResponse;
+import org.ject.support.domain.project.entity.Project;
+import org.ject.support.domain.project.entity.ProjectIntro;
+import org.ject.support.domain.project.entity.ProjectIntro.Category;
+import org.ject.support.domain.project.exception.ProjectErrorCode;
+import org.ject.support.domain.project.exception.ProjectException;
 import org.ject.support.domain.project.repository.ProjectRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.ject.support.domain.project.entity.ProjectIntro.Category.DEV;
+import static org.ject.support.domain.project.entity.ProjectIntro.Category.SERVICE;
+
 @Service
 @RequiredArgsConstructor
 public class ProjectService {
 
     private final ProjectRepository projectRepository;
+    private final MemberRepository memberRepository;
 
     /**
      * 주어진 기수의 프로젝트를 모두 조회합니다.
@@ -20,5 +34,29 @@ public class ProjectService {
     @Transactional(readOnly = true)
     public Page<ProjectResponse> findProjectsBySemester(String semester, Pageable pageable) {
         return projectRepository.findProjectsBySemester(semester, pageable);
+    }
+
+    /**
+     * 프로젝트 상세 정보를 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    public ProjectDetailResponse findProjectDetails(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ProjectException(ProjectErrorCode.NOT_FOUND));
+
+        TeamMemberNames teamMemberNames = memberRepository.findMemberNamesByTeamId(project.getTeam().getId());
+
+        List<ProjectIntro> projectIntros = project.getProjectIntros();
+        List<ProjectIntroResponse> serviceIntros = mapToResponsesByCategory(projectIntros, SERVICE);
+        List<ProjectIntroResponse> devIntros = mapToResponsesByCategory(projectIntros, DEV);
+
+        return ProjectDetailResponse.toResponse(project, teamMemberNames, serviceIntros, devIntros);
+    }
+
+    private List<ProjectIntroResponse> mapToResponsesByCategory(List<ProjectIntro> projectIntros, Category category) {
+        return projectIntros.stream()
+                .filter(projectIntro -> projectIntro.isCategory(category))
+                .map(ProjectIntroResponse::toResponse)
+                .toList();
     }
 }

--- a/src/main/java/org/ject/support/domain/project/service/ProjectService.java
+++ b/src/main/java/org/ject/support/domain/project/service/ProjectService.java
@@ -2,21 +2,23 @@ package org.ject.support.domain.project.service;
 
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.project.dto.ProjectResponse;
-import org.ject.support.domain.project.repository.ProjectQueryRepository;
+import org.ject.support.domain.project.repository.ProjectRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ProjectService {
 
-    private final ProjectQueryRepository projectQueryRepository;
+    private final ProjectRepository projectRepository;
 
     /**
      * 주어진 기수의 프로젝트를 모두 조회합니다.
      */
+    @Transactional(readOnly = true)
     public Page<ProjectResponse> findProjectsBySemester(String semester, Pageable pageable) {
-        return projectQueryRepository.findProjectsBySemester(semester, pageable);
+        return projectRepository.findProjectsBySemester(semester, pageable);
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/domain/ApplicationForm.java
+++ b/src/main/java/org/ject/support/domain/recruit/domain/ApplicationForm.java
@@ -1,10 +1,17 @@
 package org.ject.support.domain.recruit.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;
-import org.ject.support.domain.member.Member;
+import org.ject.support.domain.member.entity.Member;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
       ddl-auto: create
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
+        dialect: org.hibernate.dialect.H2Dialect
   datasource:
     url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
     driver-class-name: org.h2.Driver
@@ -50,4 +50,4 @@ logging:
   level:
     org:
       springframework:
-        jdbc: debug
+        jdbc: trace

--- a/src/test/java/org/ject/support/common/security/CustomUserDetailServiceTest.java
+++ b/src/test/java/org/ject/support/common/security/CustomUserDetailServiceTest.java
@@ -1,16 +1,11 @@
 package org.ject.support.common.security;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-
 import java.util.Optional;
 import org.ject.support.domain.member.JobFamily;
-import org.ject.support.domain.member.Member;
-import org.ject.support.domain.member.MemberException;
-import org.ject.support.domain.member.MemberRepository;
 import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.exception.MemberException;
+import org.ject.support.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +13,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CustomUserDetailServiceTest {

--- a/src/test/java/org/ject/support/common/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/ject/support/common/security/jwt/JwtTokenProviderTest.java
@@ -1,16 +1,13 @@
 package org.ject.support.common.security.jwt;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-import static org.ject.support.common.exception.GlobalErrorCode.AUTHENTICATION_REQUIRED;
-
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import org.ject.support.common.exception.GlobalException;
 import org.ject.support.common.security.CustomUserDetailService;
 import org.ject.support.common.security.CustomUserDetails;
 import org.ject.support.domain.member.JobFamily;
-import org.ject.support.domain.member.Member;
 import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,8 +18,10 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ject.support.common.exception.GlobalErrorCode.AUTHENTICATION_REQUIRED;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class JwtTokenProviderTest {

--- a/src/test/java/org/ject/support/domain/member/MemberTest.java
+++ b/src/test/java/org/ject/support/domain/member/MemberTest.java
@@ -1,9 +1,10 @@
 package org.ject.support.domain.member;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import org.ject.support.domain.member.entity.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class MemberTest {
 
@@ -20,13 +21,13 @@ class MemberTest {
 
         // when
         Member member = Member.builder()
-            .name(name)
-            .phoneNumber(phoneNumber)
-            .email(email)
-            .semester(semester)
-            .jobFamily(jobFamily)
-            .role(role)
-            .build();
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .email(email)
+                .semester(semester)
+                .jobFamily(jobFamily)
+                .role(role)
+                .build();
 
         // then
         assertThat(member.getName()).isEqualTo(name);
@@ -48,11 +49,11 @@ class MemberTest {
 
         // when
         Member member = Member.builder()
-            .name(name)
-            .phoneNumber(phoneNumber)
-            .email(email)
-            .role(role)
-            .build();
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .email(email)
+                .role(role)
+                .build();
 
         // then
         assertThat(member.getName()).isEqualTo(name);

--- a/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
@@ -22,7 +22,7 @@ import static org.ject.support.domain.member.JobFamily.PD;
 
 @Import(QueryDslTestConfig.class)
 @DataJpaTest
-class MemberRepositoryTest {
+class MemberQueryRepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;

--- a/src/test/java/org/ject/support/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,94 @@
+package org.ject.support.domain.member.repository;
+
+import java.util.List;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.dto.TeamMemberNames;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.entity.Team;
+import org.ject.support.domain.member.entity.TeamMember;
+import org.ject.support.testconfig.QueryDslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.member.JobFamily.BE;
+import static org.ject.support.domain.member.JobFamily.FE;
+import static org.ject.support.domain.member.JobFamily.PD;
+
+@Import(QueryDslTestConfig.class)
+@DataJpaTest
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private TeamMemberRepository teamMemberRepository;
+
+    private Team teamA;
+    private Member pd1, fe1, be1, be2;
+    private TeamMember teamApd1, teamAfe1, teamAbe1, teamAbe2;
+
+    @BeforeEach
+    void setUp() {
+        teamA = createTeam("teamA");
+        teamRepository.save(teamA);
+
+        pd1 = createMember("pd1", "01011112223", "pd1Email", "1기", PD);
+        fe1 = createMember("fe1", "01011112224", "fe1Email", "1기", FE);
+        be1 = createMember("be1", "01011112225", "be1Email", "1기", BE);
+        be2 = createMember("be2", "01011112226", "be2Email", "1기", BE);
+        memberRepository.saveAll(List.of(pd1, fe1, be1, be2));
+
+        teamApd1 = createTeamMember(teamA, pd1);
+        teamAfe1 = createTeamMember(teamA, fe1);
+        teamAbe1 = createTeamMember(teamA, be1);
+        teamAbe2 = createTeamMember(teamA, be2);
+        teamMemberRepository.saveAll(List.of(teamApd1, teamAfe1, teamAbe1, teamAbe2));
+    }
+
+    @Test
+    @DisplayName("직군별 팀원 이름 조회")
+    void find_member_names_by_team_id() {
+        // when
+        TeamMemberNames teamMemberNames = memberRepository.findMemberNamesByTeamId(1L);
+
+        // then
+        assertThat(teamMemberNames.projectManagers()).hasSize(0);
+        assertThat(teamMemberNames.productDesigners()).hasSize(1);
+        assertThat(teamMemberNames.frontendDevelopers()).hasSize(1);
+        assertThat(teamMemberNames.backendDevelopers()).hasSize(2);
+    }
+
+    private Team createTeam(String name) {
+        return Team.builder()
+                .name(name)
+                .build();
+    }
+
+    private Member createMember(String name, String phoneNumber, String email, String semester, JobFamily jobFamily) {
+        return Member.builder()
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .email(email)
+                .semester(semester)
+                .jobFamily(jobFamily)
+                .role(Role.USER)
+                .build();
+    }
+
+    private TeamMember createTeamMember(Team team, Member member) {
+        return TeamMember.builder()
+                .team(team)
+                .member(member)
+                .build();
+    }
+}

--- a/src/test/java/org/ject/support/domain/project/entity/ProjectIntroTest.java
+++ b/src/test/java/org/ject/support/domain/project/entity/ProjectIntroTest.java
@@ -1,0 +1,34 @@
+package org.ject.support.domain.project.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.project.entity.ProjectIntro.Category.DEV;
+import static org.ject.support.domain.project.entity.ProjectIntro.Category.SERVICE;
+
+class ProjectIntroTest {
+
+    @Test
+    @DisplayName("프로젝트 소개서의 카테고리가 일치하는지 확인")
+    void is_category() {
+        // given
+        ProjectIntro serviceIntro = createProjectIntro(1L, SERVICE, "image1.png");
+        ProjectIntro devIntro = createProjectIntro(2L, DEV, "image2.png");
+
+        // when, then
+        assertThat(serviceIntro.isCategory(SERVICE)).isTrue();
+        assertThat(serviceIntro.isCategory(DEV)).isFalse();
+        assertThat(devIntro.isCategory(DEV)).isTrue();
+        assertThat(devIntro.isCategory(SERVICE)).isFalse();
+    }
+
+    private ProjectIntro createProjectIntro(long id, ProjectIntro.Category dev, String image) {
+        return ProjectIntro.builder()
+                .id(id)
+                .category(dev)
+                .imageUrl(image)
+                .sequence(1)
+                .build();
+    }
+}

--- a/src/test/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryTest.java
@@ -1,29 +1,25 @@
 package org.ject.support.domain.project.repository;
 
-import org.ject.support.domain.member.Team;
-import org.ject.support.domain.member.TeamRepository;
+import java.time.LocalDate;
+import java.util.List;
+import org.ject.support.domain.member.entity.Team;
+import org.ject.support.domain.member.repository.TeamRepository;
 import org.ject.support.domain.project.dto.ProjectResponse;
 import org.ject.support.domain.project.entity.Project;
+import org.ject.support.testconfig.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.ject.support.testconfig.IntegrationTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
 @Transactional
 class ProjectQueryRepositoryTest {
-
-    @Autowired
-    private ProjectQueryRepository projectQueryRepository;
 
     @Autowired
     private ProjectRepository projectRepository;
@@ -51,7 +47,7 @@ class ProjectQueryRepositoryTest {
         projectRepository.saveAll(List.of(project1, project2, project3));
 
         // when
-        Page<ProjectResponse> result = projectQueryRepository.findProjectsBySemester("1기", PageRequest.of(0, 20));
+        Page<ProjectResponse> result = projectRepository.findProjectsBySemester("1기", PageRequest.of(0, 20));
 
         // then
         assertThat(result).isNotNull();

--- a/src/test/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryTest.java
@@ -47,7 +47,7 @@ class ProjectQueryRepositoryTest {
         projectRepository.saveAll(List.of(project1, project2, project3));
 
         // when
-        Page<ProjectResponse> result = projectRepository.findProjectsBySemester("1기", PageRequest.of(0, 20));
+        Page<ProjectResponse> result = projectRepository.findProjectsBySemester("1기", PageRequest.of(0, 30));
 
         // then
         assertThat(result).isNotNull();

--- a/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
@@ -1,0 +1,136 @@
+package org.ject.support.domain.project.service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.ject.support.domain.member.dto.TeamMemberNames;
+import org.ject.support.domain.member.entity.Team;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.project.dto.ProjectDetailResponse;
+import org.ject.support.domain.project.dto.ProjectIntroResponse;
+import org.ject.support.domain.project.entity.Project;
+import org.ject.support.domain.project.entity.ProjectIntro;
+import org.ject.support.domain.project.exception.ProjectException;
+import org.ject.support.domain.project.repository.ProjectRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ject.support.domain.project.entity.ProjectIntro.Category;
+import static org.ject.support.domain.project.entity.ProjectIntro.builder;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @InjectMocks
+    private ProjectService projectService;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private Project project;
+    private List<String> projectManagers;
+    private List<String> productDesigners;
+    private List<String> frontendDevelopers;
+    private List<String> backendDevelopers;
+
+    @BeforeEach
+    void setUp() {
+        projectManagers = List.of();
+        productDesigners = List.of("designer1");
+        frontendDevelopers = List.of("front1", "front2");
+        backendDevelopers = List.of("back1", "back2", "back3");
+        ProjectIntro serviceIntro1 = createProjectIntro(1L, "serviceImage1.png", Category.SERVICE, 1);
+        ProjectIntro serviceIntro2 = createProjectIntro(2L, "serviceImage2.png", Category.SERVICE, 2);
+        ProjectIntro serviceIntro3 = createProjectIntro(3L, "serviceImage3.png", Category.SERVICE, 3);
+        ProjectIntro devIntro1 = createProjectIntro(4L, "devImage1.png", Category.DEV, 1);
+        project = Project.builder()
+                .id(1L)
+                .semester("1기")
+                .summary("summary")
+                .techStack("tech stack")
+                .startDate(LocalDate.of(2025, 3, 2))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .description("description")
+                .thumbnailUrl("thumbnail.png")
+                .serviceUrl("service.com")
+                .team(Team.builder().id(1L).name("team").build())
+                .projectIntros(List.of(serviceIntro1, serviceIntro2, serviceIntro3, devIntro1))
+                .build();
+    }
+
+    @Test
+    @DisplayName("프로젝트 상세 조회")
+    void find_project_details() {
+        // given
+        when(projectRepository.findById(1L)).thenReturn(Optional.ofNullable(project));
+        when(memberRepository.findMemberNamesByTeamId(1L)).thenReturn(
+                new TeamMemberNames(projectManagers, productDesigners, frontendDevelopers, backendDevelopers));
+
+        // when
+        ProjectDetailResponse result = projectService.findProjectDetails(1L);
+
+        // then
+        assertThat(result.thumbnailUrl()).isEqualTo(project.getThumbnailUrl());
+        assertThat(result.name()).isEqualTo(project.getName());
+        assertThat(result.startDate()).isEqualTo(project.getStartDate());
+        assertThat(result.endDate()).isEqualTo(project.getEndDate());
+        assertThat(result.teamMemberNames().projectManagers()).hasSize(0);
+        assertThat(result.teamMemberNames().productDesigners()).hasSize(1);
+        assertThat(result.teamMemberNames().frontendDevelopers()).hasSize(2);
+        assertThat(result.teamMemberNames().backendDevelopers()).hasSize(3);
+        assertThat(result.techStack()).isEqualTo(project.getTechStack());
+        assertThat(result.description()).isEqualTo(project.getDescription());
+        assertThat(result.serviceUrl()).isEqualTo(project.getServiceUrl());
+        assertThat(result.serviceIntros()).hasSize(3);
+        assertThat(result.devIntros()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("프로젝트 상세 조회 시 서비스 소개서는 sequence 기준 오름차순 정렬되어야 함")
+    void find_project_details_sort_project_intro_by_sequence_ascending() {
+        // given
+        when(projectRepository.findById(1L)).thenReturn(Optional.ofNullable(project));
+        when(memberRepository.findMemberNamesByTeamId(1L)).thenReturn(
+                new TeamMemberNames(projectManagers, productDesigners, frontendDevelopers, backendDevelopers));
+
+        // when
+        ProjectDetailResponse result = projectService.findProjectDetails(1L);
+
+        // then
+        assertThat(result.serviceIntros())
+                .extracting(ProjectIntroResponse::sequence)
+                .containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 프로젝트 상세 조회 시 예외 발생")
+    void find_project_details_fail_by_not_found() {
+        // given
+        when(projectRepository.findById(Mockito.any())).thenReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> projectService.findProjectDetails(1L))
+                .isInstanceOf(ProjectException.class);
+    }
+
+    private ProjectIntro createProjectIntro(Long id, String imageUrl, Category category, int sequence) {
+        return builder()
+                .id(id)
+                .imageUrl(imageUrl)
+                .category(category)
+                .sequence(sequence)
+                .build();
+    }
+}

--- a/src/test/java/org/ject/support/testconfig/QueryDslTestConfig.java
+++ b/src/test/java/org/ject/support/testconfig/QueryDslTestConfig.java
@@ -1,0 +1,22 @@
+package org.ject.support.testconfig;
+
+import com.querydsl.jpa.JPQLTemplates;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+
+@Profile("test")
+@TestConfiguration
+public class QueryDslTestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #44 

## 📝작업 내용
- 프로젝트 목록 조회 API의 page size 기본값을 20에서 30으로 변경
- ProjectService가 ProjectRepository를 주입 받도록 변경
- member 도메인 패키지 세분화
- 디자이너를 의미하는 JobFamily name을 니에서 PD로 변경
- 프로젝트 상세 조회 기능 구현
- 테스트 환경 hibernate dialect를 H2로 변경
- 테스트 코드 작성

## ✅테스트 결과
<img width="595" alt="image" src="https://github.com/user-attachments/assets/b2a94460-6b99-4baf-870c-e6e0fe7eeb79" />
<img width="599" alt="스크린샷 2025-02-21 오후 5 48 35" src="https://github.com/user-attachments/assets/4b07eee4-215d-4a77-af6c-a50822cbf3cf" />

