### PR TITLE
프로젝트 후기 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/domain/review/controller/ReviewController.java
+++ b/src/main/java/org/ject/support/domain/review/controller/ReviewController.java
@@ -1,0 +1,24 @@
+package org.ject.support.domain.review.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.review.dto.ReviewResponse;
+import org.ject.support.domain.review.service.ReviewService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @GetMapping
+    public Page<ReviewResponse> findReviews(@PageableDefault(size = 4) Pageable pageable) {
+        return reviewService.findReviews(pageable);
+    }
+}

--- a/src/main/java/org/ject/support/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/org/ject/support/domain/review/dto/ReviewResponse.java
@@ -1,0 +1,10 @@
+package org.ject.support.domain.review.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record ReviewResponse(String linkUrl, String title, String description) {
+
+    @QueryProjection
+    public ReviewResponse {
+    }
+}

--- a/src/main/java/org/ject/support/domain/review/entity/Review.java
+++ b/src/main/java/org/ject/support/domain/review/entity/Review.java
@@ -1,6 +1,10 @@
-package org.ject.support.domain.review;
+package org.ject.support.domain.review.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;
@@ -15,4 +19,10 @@ public class Review extends BaseTimeEntity {
 
     @Column(length = 2083)
     private String linkUrl;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String description;
 }

--- a/src/main/java/org/ject/support/domain/review/entity/Review.java
+++ b/src/main/java/org/ject/support/domain/review/entity/Review.java
@@ -6,10 +6,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;
 
 @Entity
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseTimeEntity {
 

--- a/src/main/java/org/ject/support/domain/review/repository/ReviewQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/review/repository/ReviewQueryRepository.java
@@ -1,0 +1,10 @@
+package org.ject.support.domain.review.repository;
+
+import org.ject.support.domain.review.dto.ReviewResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReviewQueryRepository {
+
+    Page<ReviewResponse> findReviews(Pageable pageable);
+}

--- a/src/main/java/org/ject/support/domain/review/repository/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/review/repository/ReviewQueryRepositoryImpl.java
@@ -1,0 +1,39 @@
+package org.ject.support.domain.review.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.review.dto.QReviewResponse;
+import org.ject.support.domain.review.dto.ReviewResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import static org.ject.support.domain.review.entity.QReview.review;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ReviewResponse> findReviews(Pageable pageable) {
+        List<ReviewResponse> content = queryFactory.select(new QReviewResponse(
+                        review.linkUrl,
+                        review.title,
+                        review.description))
+                .from(review)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(review.createdAt.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory.select(review.count())
+                .from(review);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/org/ject/support/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/ject/support/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package org.ject.support.domain.review.repository;
+
+import org.ject.support.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQueryRepository {
+}

--- a/src/main/java/org/ject/support/domain/review/service/ReviewService.java
+++ b/src/main/java/org/ject/support/domain/review/service/ReviewService.java
@@ -1,0 +1,21 @@
+package org.ject.support.domain.review.service;
+
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.review.dto.ReviewResponse;
+import org.ject.support.domain.review.repository.ReviewRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    @Transactional(readOnly = true)
+    public Page<ReviewResponse> findReviews(Pageable pageable) {
+        return reviewRepository.findReviews(pageable);
+    }
+}

--- a/src/test/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryTest.java
@@ -6,19 +6,20 @@ import org.ject.support.domain.member.entity.Team;
 import org.ject.support.domain.member.repository.TeamRepository;
 import org.ject.support.domain.project.dto.ProjectResponse;
 import org.ject.support.domain.project.entity.Project;
-import org.ject.support.testconfig.IntegrationTest;
+import org.ject.support.testconfig.QueryDslTestConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@IntegrationTest
-@Transactional
+@Import(QueryDslTestConfig.class)
+@DataJpaTest
 class ProjectQueryRepositoryTest {
 
     @Autowired

--- a/src/test/java/org/ject/support/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/review/repository/ReviewRepositoryTest.java
@@ -1,0 +1,49 @@
+package org.ject.support.domain.review.repository;
+
+import java.util.List;
+import org.ject.support.domain.review.dto.ReviewResponse;
+import org.ject.support.domain.review.entity.Review;
+import org.ject.support.testconfig.QueryDslTestConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(QueryDslTestConfig.class)
+@DataJpaTest
+class ReviewRepositoryTest {
+
+    @Autowired
+    ReviewRepository reviewRepository;
+
+    @Test
+    @DisplayName("리뷰 목록 조회")
+    void find_reviews() {
+        // given
+        Review review1 = createReview();
+        Review review2 = createReview();
+        Review review3 = createReview();
+        Review review4 = createReview();
+        Review review5 = createReview();
+        reviewRepository.saveAll(List.of(review1, review2, review3, review4, review5));
+
+        // when
+        Page<ReviewResponse> result = reviewRepository.findReviews(PageRequest.of(0, 4));
+
+        // then
+        assertThat(result.getContent()).hasSize(4);
+    }
+
+    private Review createReview() {
+        return Review.builder()
+                .linkUrl("https://test.com")
+                .title("title")
+                .description("description")
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #45 

## 📝작업 내용
- Review 엔티티에 title, description 컬럼 추가
- 프로젝트 후기 목록 조회 기능 구현

## ✅테스트 결과
<img width="569" alt="스크린샷 2025-02-26 오전 3 27 58" src="https://github.com/user-attachments/assets/8ae33a84-5cf3-4fe9-a577-16bf30cd914e" />


## 🙏리뷰 요구사항
후기 목록을 조회할 때 크롤링한 제목과 본문 일부를 함께 전달하는 방향으로 구현했습니다. 이를 위해 Review 엔티티에 title과 description 컬럼을 추가했어요. 
자세한 내용은 노션을 참고해 주세요. 
https://www.notion.so/URL-1a562a893ac5804997c5f3bb8e1b8206?pvs=4