### PR TITLE
미니스터디 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/domain/ministudy/controller/MiniStudyController.java
+++ b/src/main/java/org/ject/support/domain/ministudy/controller/MiniStudyController.java
@@ -1,0 +1,24 @@
+package org.ject.support.domain.ministudy.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.ministudy.dto.MiniStudyResponse;
+import org.ject.support.domain.ministudy.service.MiniStudyService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ministudies")
+@RequiredArgsConstructor
+public class MiniStudyController {
+
+    private final MiniStudyService miniStudyService;
+
+    @GetMapping
+    public Page<MiniStudyResponse> findMiniStudies(@PageableDefault(size = 30) Pageable pageable) {
+        return miniStudyService.findMiniStudies(pageable);
+    }
+}

--- a/src/main/java/org/ject/support/domain/ministudy/dto/MiniStudyResponse.java
+++ b/src/main/java/org/ject/support/domain/ministudy/dto/MiniStudyResponse.java
@@ -1,0 +1,15 @@
+package org.ject.support.domain.ministudy.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+
+@Builder
+public record MiniStudyResponse(Long id,
+                              String name,
+                              String linkUrl,
+                              String imageUrl) {
+
+    @QueryProjection
+    public MiniStudyResponse {
+    }
+}

--- a/src/main/java/org/ject/support/domain/ministudy/entity/MiniStudy.java
+++ b/src/main/java/org/ject/support/domain/ministudy/entity/MiniStudy.java
@@ -1,4 +1,4 @@
-package org.ject.support.domain.ministudy;
+package org.ject.support.domain.ministudy.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/org/ject/support/domain/ministudy/entity/MiniStudy.java
+++ b/src/main/java/org/ject/support/domain/ministudy/entity/MiniStudy.java
@@ -2,10 +2,14 @@ package org.ject.support.domain.ministudy.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;
 
 @Entity
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MiniStudy extends BaseTimeEntity {
 

--- a/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepository.java
@@ -1,0 +1,9 @@
+package org.ject.support.domain.ministudy.repository;
+
+import org.ject.support.domain.ministudy.dto.MiniStudyResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MiniStudyQueryRepository {
+    Page<MiniStudyResponse> findMiniStudies(Pageable pageable);
+}

--- a/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryImpl.java
@@ -1,0 +1,44 @@
+package org.ject.support.domain.ministudy.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.ministudy.dto.MiniStudyResponse;
+import org.ject.support.domain.ministudy.dto.QMiniStudyResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static org.ject.support.domain.ministudy.QMiniStudy.miniStudy;
+
+@Repository
+@RequiredArgsConstructor
+public class MiniStudyQueryRepositoryImpl implements MiniStudyQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<MiniStudyResponse> findMiniStudies(Pageable pageable) {
+        List<MiniStudyResponse> content = queryFactory
+                .select(new QMiniStudyResponse(
+                        miniStudy.id,
+                        miniStudy.name,
+                        miniStudy.linkUrl,
+                        miniStudy.imageUrl
+                ))
+                .from(miniStudy)
+                .orderBy(miniStudy.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(miniStudy.count())
+                .from(miniStudy);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryImpl.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-import static org.ject.support.domain.ministudy.QMiniStudy.miniStudy;
+import static org.ject.support.domain.ministudy.entity.QMiniStudy.miniStudy;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyRepository.java
+++ b/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyRepository.java
@@ -1,0 +1,7 @@
+package org.ject.support.domain.ministudy.repository;
+
+import org.ject.support.domain.ministudy.entity.MiniStudy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MiniStudyRepository extends JpaRepository<MiniStudy, Long>, MiniStudyQueryRepository {
+}

--- a/src/main/java/org/ject/support/domain/ministudy/service/MiniStudyService.java
+++ b/src/main/java/org/ject/support/domain/ministudy/service/MiniStudyService.java
@@ -1,0 +1,21 @@
+package org.ject.support.domain.ministudy.service;
+
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.ministudy.dto.MiniStudyResponse;
+import org.ject.support.domain.ministudy.repository.MiniStudyRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MiniStudyService {
+
+    private final MiniStudyRepository miniStudyRepository;
+
+    @Transactional
+    public Page<MiniStudyResponse> findMiniStudies(Pageable pageable) {
+        return miniStudyRepository.findMiniStudies(pageable);
+    }
+}

--- a/src/test/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryTest.java
@@ -1,0 +1,65 @@
+package org.ject.support.domain.ministudy.repository;
+
+import org.ject.support.domain.ministudy.dto.MiniStudyResponse;
+import org.ject.support.domain.ministudy.entity.MiniStudy;
+import org.ject.support.testconfig.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+@Transactional
+class MiniStudyQueryRepositoryTest {
+
+    @Autowired
+    private MiniStudyRepository miniStudyRepository;
+
+    @Test
+    @DisplayName("미니 스터디 목록 조회 - 페이징")
+    void findMiniStudies() {
+        // given
+        MiniStudy miniStudy1 = createMiniStudy("미니 스터디 1");
+        MiniStudy miniStudy2 = createMiniStudy("미니 스터디 2");
+        MiniStudy miniStudy3 = createMiniStudy("미니 스터디 3");
+        miniStudyRepository.saveAll(List.of(miniStudy1, miniStudy2, miniStudy3));
+
+        // when
+        Page<MiniStudyResponse> result = miniStudyRepository.findMiniStudies(PageRequest.of(0, 2));
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(3); // 전체 데이터 개수
+        assertThat(result.getTotalPages()).isEqualTo(2); // 전체 페이지 수
+        assertThat(result.getNumber()).isEqualTo(0); // 현재 페이지 번호
+        assertThat(result.getSize()).isEqualTo(2); // 페이지 크기
+
+        List<MiniStudyResponse> responses = result.getContent();
+        assertThat(responses).hasSize(2); // 현재 페이지의 데이터 개수
+
+        MiniStudyResponse firstResponse = responses.get(0);
+        assertThat(firstResponse.id()).isNotNull();
+        assertThat(firstResponse.name()).isEqualTo("미니 스터디 3"); // ID 내림차순이므로 마지막에 생성된 데이터가 첫 번째
+        assertThat(firstResponse.linkUrl()).isEqualTo("https://test.net/ministudy3");
+        assertThat(firstResponse.imageUrl()).isEqualTo("https://test.net/image3.png");
+
+        // 두 번째 페이지 조회
+        Page<MiniStudyResponse> secondPage = miniStudyRepository.findMiniStudies(PageRequest.of(1, 2));
+        assertThat(secondPage.getContent()).hasSize(1); // 마지막 페이지는 1개의 데이터만 존재
+    }
+
+    private MiniStudy createMiniStudy(String name) {
+        String urlSafeName = name.replaceAll("[미니 스터디]", "");
+        return MiniStudy.builder()
+                .name(name)
+                .linkUrl("https://test.net/ministudy" + urlSafeName)
+                .imageUrl("https://test.net/image" + urlSafeName + ".png")
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #58 

## 📝작업 내용

- 미니스터디 목록 조회 기능 구현
- 미니스터디 응답 dto 클래스 구현
- 테스트 코드 작성

## ✅테스트 결과
<img width="431" alt="스크린샷 2025-02-26 오후 12 52 43" src="https://github.com/user-attachments/assets/344e7475-5542-4a4b-9186-d28667c6f81b" />

## 🙏리뷰 요구사항(선택)

처음으로 QueryDsl을 사용해 본 거라, 해당 부분을 중점적으로 리뷰해주셨으면 합니다.
