### PR TITLE
프로젝트 엔티티에 카테고리 컬럼 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/project/controller/ProjectController.java
+++ b/src/main/java/org/ject/support/domain/project/controller/ProjectController.java
@@ -3,6 +3,7 @@ package org.ject.support.domain.project.controller;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.project.dto.ProjectDetailResponse;
 import org.ject.support.domain.project.dto.ProjectResponse;
+import org.ject.support.domain.project.entity.Project;
 import org.ject.support.domain.project.service.ProjectService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,13 +22,14 @@ public class ProjectController {
     private final ProjectService projectService;
 
     @GetMapping
-    public Page<ProjectResponse> findProjects(@RequestParam String semester,
-                                              @PageableDefault(size = 30) Pageable pageable) {
-        return projectService.findProjectsBySemester(semester, pageable);
+    public Page<ProjectResponse> findProjects(@RequestParam final Project.Category category,
+                                              @RequestParam final String semester,
+                                              @PageableDefault(size = 30) final Pageable pageable) {
+        return projectService.findProjects(category, semester, pageable);
     }
 
     @GetMapping("/{projectId}")
-    public ProjectDetailResponse findProjectDetails(@PathVariable Long projectId) {
+    public ProjectDetailResponse findProjectDetails(@PathVariable final Long projectId) {
         return projectService.findProjectDetails(projectId);
     }
 }

--- a/src/main/java/org/ject/support/domain/project/entity/Project.java
+++ b/src/main/java/org/ject/support/domain/project/entity/Project.java
@@ -2,6 +2,8 @@ package org.ject.support.domain.project.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -35,6 +37,10 @@ public class Project extends BaseTimeEntity {
     @Column(length = 100)
     private String name;
 
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(30)", nullable = false)
+    private Project.Category category;
+
     @Column(length = 20, nullable = false)
     private String semester;
 
@@ -62,4 +68,8 @@ public class Project extends BaseTimeEntity {
     @OrderBy("sequence asc")
     @Builder.Default
     private List<ProjectIntro> projectIntros = new ArrayList<>();
+
+    public enum Category {
+        MAIN, HACKATHON
+    }
 }

--- a/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepository.java
@@ -1,10 +1,13 @@
 package org.ject.support.domain.project.repository;
 
 import org.ject.support.domain.project.dto.ProjectResponse;
+import org.ject.support.domain.project.entity.Project;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ProjectQueryRepository {
 
-    Page<ProjectResponse> findProjectsBySemester(final String semester, Pageable pageable);
+    Page<ProjectResponse> findProjectsByCategoryAndSemester(Project.Category category,
+                                                            String semester,
+                                                            Pageable pageable);
 }

--- a/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import static org.ject.support.domain.project.entity.Project.Category;
 import static org.ject.support.domain.project.entity.QProject.project;
 
 @Repository
@@ -20,7 +21,9 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<ProjectResponse> findProjectsBySemester(final String semester, Pageable pageable) {
+    public Page<ProjectResponse> findProjectsByCategoryAndSemester(final Category category,
+                                                                   final String semester,
+                                                                   final Pageable pageable) {
         List<ProjectResponse> content = queryFactory.select(new QProjectResponse(
                         project.id,
                         project.thumbnailUrl,
@@ -30,7 +33,7 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
                         project.endDate
                 ))
                 .from(project)
-                .where(project.semester.eq(semester))
+                .where(project.category.eq(category), project.semester.eq(semester))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/org/ject/support/domain/project/service/ProjectService.java
+++ b/src/main/java/org/ject/support/domain/project/service/ProjectService.java
@@ -9,7 +9,6 @@ import org.ject.support.domain.project.dto.ProjectIntroResponse;
 import org.ject.support.domain.project.dto.ProjectResponse;
 import org.ject.support.domain.project.entity.Project;
 import org.ject.support.domain.project.entity.ProjectIntro;
-import org.ject.support.domain.project.entity.ProjectIntro.Category;
 import org.ject.support.domain.project.exception.ProjectErrorCode;
 import org.ject.support.domain.project.exception.ProjectException;
 import org.ject.support.domain.project.repository.ProjectRepository;
@@ -32,15 +31,17 @@ public class ProjectService {
      * 주어진 기수의 프로젝트를 모두 조회합니다.
      */
     @Transactional(readOnly = true)
-    public Page<ProjectResponse> findProjectsBySemester(String semester, Pageable pageable) {
-        return projectRepository.findProjectsBySemester(semester, pageable);
+    public Page<ProjectResponse> findProjects(final Project.Category category,
+                                              final String semester,
+                                              final Pageable pageable) {
+        return projectRepository.findProjectsByCategoryAndSemester(category, semester, pageable);
     }
 
     /**
      * 프로젝트 상세 정보를 조회합니다.
      */
     @Transactional(readOnly = true)
-    public ProjectDetailResponse findProjectDetails(Long projectId) {
+    public ProjectDetailResponse findProjectDetails(final Long projectId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ProjectException(ProjectErrorCode.NOT_FOUND));
 
@@ -53,7 +54,8 @@ public class ProjectService {
         return ProjectDetailResponse.toResponse(project, teamMemberNames, serviceIntros, devIntros);
     }
 
-    private List<ProjectIntroResponse> mapToResponsesByCategory(List<ProjectIntro> projectIntros, Category category) {
+    private List<ProjectIntroResponse> mapToResponsesByCategory(List<ProjectIntro> projectIntros,
+                                                                final ProjectIntro.Category category) {
         return projectIntros.stream()
                 .filter(projectIntro -> projectIntro.isCategory(category))
                 .map(ProjectIntroResponse::toResponse)


### PR DESCRIPTION
## #️⃣연관된 이슈

close #55 

## 📝작업 내용
- 프로젝트 엔티티에 카테고리 컬럼 추가
- 프로젝트 목록 조회 API 파라미터에 카테고리 값 추가
- 해커톤 프로젝트 목록 조회 단위 테스트

## ✅테스트 결과
<img width="461" alt="스크린샷 2025-02-27 오전 2 07 40" src="https://github.com/user-attachments/assets/c78fa104-b7b1-4127-a3b0-f5c8dc953585" />
