### PR TITLE
Role Hierarchy를 사용한 인가 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/common/security/CustomUserDetails.java
+++ b/src/main/java/org/ject/support/common/security/CustomUserDetails.java
@@ -30,7 +30,7 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> collection = new ArrayList<>();
-        collection.add((GrantedAuthority) () -> String.valueOf(role));
+        collection.add((GrantedAuthority)() -> "ROLE_" + role);
         return collection;
     }
 

--- a/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
@@ -78,7 +78,14 @@ public class JwtTokenProvider {
         Claims claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
         String email = claims.getSubject();
         Long memberId = claims.get("memberId", Long.class);
-        Role role = Role.valueOf(claims.get("role", String.class).toUpperCase());
+        String roleStr = claims.get("role", String.class).toUpperCase();
+        
+        // "ROLE_" 접두사가 있으면 제거
+        if (roleStr.startsWith("ROLE_")) {
+            roleStr = roleStr.substring(5);
+        }
+        
+        Role role = Role.valueOf(roleStr);
 
         CustomUserDetails userDetails = new CustomUserDetails(email, memberId, role);
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());

--- a/src/main/java/org/ject/support/domain/auth/AuthController.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthController.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.ject.support.common.security.jwt.JwtCookieProvider;
 import org.ject.support.domain.auth.AuthDto.AuthCodeResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeRequest;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +21,7 @@ public class AuthController {
     private final JwtCookieProvider jwtCookieProvider;
 
     @PostMapping("/code")
+    @PreAuthorize("permitAll()")
     public AuthCodeResponse verifyAuthCode(HttpServletResponse response,
                                            @RequestBody VerifyAuthCodeRequest request) {
         AuthCodeResponse authResponse = authService.verifyEmailByAuthCode(request.name(), request.email(),

--- a/src/main/java/org/ject/support/external/email/EmailController.java
+++ b/src/main/java/org/ject/support/external/email/EmailController.java
@@ -1,5 +1,6 @@
 package org.ject.support.external.email;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,6 +16,7 @@ public class EmailController {
     private final EmailAuthService authEmailService;
 
     @PostMapping("/send/auth")
+    @PreAuthorize("permitAll()") // TODO: PostAuthorize 설정 추가
     public void sendAuthEmail(@RequestParam String email) {
         authEmailService.sendAuthCode(email);
     }

--- a/src/test/java/org/ject/support/common/security/CustomUserDetailsTest.java
+++ b/src/test/java/org/ject/support/common/security/CustomUserDetailsTest.java
@@ -1,0 +1,71 @@
+package org.ject.support.common.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+
+class CustomUserDetailsTest {
+
+    private final String TEST_EMAIL = "test@example.com";
+    private final Long TEST_MEMBER_ID = 1L;
+
+    @Test
+    @DisplayName("Member 객체로 CustomUserDetails 생성 시 권한에 ROLE_ 접두사가 추가되는지 확인")
+    void getAuthorities_FromMember_ShouldAddRolePrefix() {
+        // given
+        Member member = Member.builder()
+                .id(TEST_MEMBER_ID)
+                .email(TEST_EMAIL)
+                .name("Test User")
+                .phoneNumber("01012345678")
+                .role(Role.TEMP)
+                .build();
+
+        // when
+        CustomUserDetails userDetails = new CustomUserDetails(member);
+        Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
+
+        // then
+        assertThat(authorities).isNotEmpty();
+        assertThat(authorities).hasSize(1);
+        assertThat(authorities.iterator().next().getAuthority()).isEqualTo("ROLE_TEMP");
+    }
+
+    @Test
+    @DisplayName("파라미터로 CustomUserDetails 생성 시 권한에 ROLE_ 접두사가 추가되는지 확인")
+    void getAuthorities_FromParameters_ShouldAddRolePrefix() {
+        // given
+        Role role = Role.USER;
+
+        // when
+        CustomUserDetails userDetails = new CustomUserDetails(TEST_EMAIL, TEST_MEMBER_ID, role);
+        Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
+
+        // then
+        assertThat(authorities).isNotEmpty();
+        assertThat(authorities).hasSize(1);
+        assertThat(authorities.iterator().next().getAuthority()).isEqualTo("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("ADMIN 역할로 CustomUserDetails 생성 시 권한에 ROLE_ 접두사가 추가되는지 확인")
+    void getAuthorities_AdminRole_ShouldAddRolePrefix() {
+        // given
+        Role role = Role.ADMIN;
+
+        // when
+        CustomUserDetails userDetails = new CustomUserDetails(TEST_EMAIL, TEST_MEMBER_ID, role);
+        Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
+
+        // then
+        assertThat(authorities).isNotEmpty();
+        assertThat(authorities).hasSize(1);
+        assertThat(authorities.iterator().next().getAuthority()).isEqualTo("ROLE_ADMIN");
+    }
+}

--- a/src/test/java/org/ject/support/common/security/config/SecurityConfigTest.java
+++ b/src/test/java/org/ject/support/common/security/config/SecurityConfigTest.java
@@ -1,0 +1,81 @@
+package org.ject.support.common.security.config;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import org.ject.support.testconfig.ApplicationPeriodTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
+class SecurityConfigTest extends ApplicationPeriodTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RoleHierarchy roleHierarchy;
+
+    @Test
+    @DisplayName("RoleHierarchy가 올바르게 설정되었는지 확인")
+    void roleHierarchy_ShouldBeConfiguredCorrectly() {
+        // given
+        SimpleGrantedAuthority tempAuthority = new SimpleGrantedAuthority("ROLE_TEMP");
+        SimpleGrantedAuthority userAuthority = new SimpleGrantedAuthority("ROLE_USER");
+        SimpleGrantedAuthority adminAuthority = new SimpleGrantedAuthority("ROLE_ADMIN");
+
+        // when & then
+        // ADMIN > USER > TEMP 계층 구조 확인
+        List<String> adminAuthorities = roleHierarchy.getReachableGrantedAuthorities(
+                java.util.Collections.singleton(adminAuthority))
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+        
+        assertThat(adminAuthorities).contains(
+                adminAuthority.getAuthority(), 
+                userAuthority.getAuthority(), 
+                tempAuthority.getAuthority());
+
+        // USER > TEMP 계층 구조 확인
+        List<String> userAuthorities = roleHierarchy.getReachableGrantedAuthorities(
+                java.util.Collections.singleton(userAuthority))
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+                
+        assertThat(userAuthorities)
+                .contains(userAuthority.getAuthority(), tempAuthority.getAuthority())
+                .doesNotContain(adminAuthority.getAuthority());
+
+        // TEMP는 다른 권한을 포함하지 않음
+        List<String> tempAuthorities = roleHierarchy.getReachableGrantedAuthorities(
+                java.util.Collections.singleton(tempAuthority))
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+                
+        assertThat(tempAuthorities)
+                .containsOnly(tempAuthority.getAuthority());
+    }
+
+    @Test
+    @DisplayName("permitAll 설정이 적용된 경로는 인증 없이 접근 가능해야 함")
+    void permitAll_ShouldAllowAccessWithoutAuthentication() throws Exception {
+        // 인증 없이 접근 가능한지 확인 (SecurityConfig에서 .anyRequest().permitAll() 설정)
+        mockMvc.perform(get("/any-path"))
+                .andExpect(status().isNotFound()); // 404는 경로가 없어서이지, 인증 실패(401, 403)가 아님
+    }
+}

--- a/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
@@ -2,21 +2,34 @@ package org.ject.support.domain.auth;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.ject.support.common.security.jwt.JwtCookieProvider;
 import org.ject.support.domain.auth.AuthDto.AuthCodeResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeRequest;
+import org.ject.support.testconfig.ApplicationPeriodTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.HttpServletResponse;
 
 @ExtendWith(MockitoExtension.class)
 class AuthControllerTest {
+    // 기존 단위 테스트 유지
 
     @InjectMocks
     private AuthController authController;
@@ -60,5 +73,48 @@ class AuthControllerTest {
         verify(jwtCookieProvider).createAccessCookie(TEST_ACCESS_TOKEN);
         verify(jwtCookieProvider).createRefreshCookie(TEST_REFRESH_TOKEN);
         verify(response, times(2)).addCookie(any()); // access token과 refresh token 쿠키 각각 설정
+    }
+}
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
+class AuthControllerIntegrationTest extends ApplicationPeriodTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @MockBean
+    private AuthService authService;
+    
+    private final String TEST_NAME = "test";
+    private final String TEST_EMAIL = "test@example.com";
+    private final String TEST_PHONE_NUMBER = "01012345678";
+    private final String TEST_AUTH_CODE = "123456";
+    private final String TEST_ACCESS_TOKEN = "test.access.token";
+    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
+    
+    @Test
+    @DisplayName("@PreAuthorize(\"permitAll()\") 설정으로 인증 없이 접근 가능한지 확인")
+    void verifyAuthCode_WithPermitAll_ShouldAllowAccessWithoutAuthentication() throws Exception {
+        // given
+        VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(
+                TEST_NAME, TEST_EMAIL, TEST_PHONE_NUMBER, TEST_AUTH_CODE);
+        
+        AuthCodeResponse authResponse = new AuthCodeResponse(TEST_ACCESS_TOKEN, TEST_REFRESH_TOKEN);
+        
+        given(authService.verifyEmailByAuthCode(
+                anyString(), anyString(), anyString(), anyString())
+        ).willReturn(authResponse);
+        
+        // when & then
+        // 인증 없이 접근 가능한지 확인 (permitAll 설정)
+        mockMvc.perform(post("/auth/code")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
@@ -9,16 +9,17 @@ import org.ject.support.common.security.jwt.JwtCookieProvider;
 import org.ject.support.domain.auth.AuthDto.AuthCodeResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeRequest;
 import org.ject.support.testconfig.ApplicationPeriodTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -78,7 +79,8 @@ class AuthControllerTest {
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
+@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false", "server.port=0"})
+@ExtendWith(MockitoExtension.class)
 class AuthControllerIntegrationTest extends ApplicationPeriodTest {
 
     @Autowired
@@ -87,8 +89,13 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
     @Autowired
     private ObjectMapper objectMapper;
     
-    @MockBean
+    @Mock
     private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
     
     private final String TEST_NAME = "test";
     private final String TEST_EMAIL = "test@example.com";


### PR DESCRIPTION
## #️⃣연관된 이슈

close #51 

## 📝작업 내용

- `RoleHierarchy` 설정
- 토큰에 `Role` 정상적으로 담기도록 기능 개선
- 테스트 코드 작성

## ✅테스트 결과

<img width="269" alt="스크린샷 2025-03-03 오후 11 40 10" src="https://github.com/user-attachments/assets/8e61208a-9482-410e-a851-cd3bab5bf05c" />

## 각 API별 어노테이션 설정

https://oth3410.tistory.com/356

자세한 내용은 위 게시글을 참고해주세요. 각자 맡으신 API에 어노테이션을 달아주시면 됩니다.
아래는 예시입니다.

`@PreAuthorize("permitAll()")` - (비회원 포함) 모든 권한 접근 가능
`@PreAuthorize("hasRole('ROLE_TEMP')")` - 메서드 실행 전에 검증됨. TEMP 권한 이상만 통과됨
`@PostAuthorize("returnObject.email == authentication.email") // 리턴 객체의 이메일과 인증정보의 이메일 등을 비교가 가능함` - 메서드 실행 이후 검증됨. 추가 권한 확인이 필요할 때 사용

