### PR TITLE
권한에 따라 pre-signed url api 분리 및 인가 처리

### DIFF
--- a/src/main/java/org/ject/support/domain/file/controller/FileController.java
+++ b/src/main/java/org/ject/support/domain/file/controller/FileController.java
@@ -1,14 +1,15 @@
 package org.ject.support.domain.file.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.ject.support.domain.file.dto.CreatePresignedUrlResponse;
+import org.ject.support.common.security.AuthPrincipal;
+import org.ject.support.domain.file.dto.UploadFileResponse;
 import org.ject.support.external.s3.S3Service;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/upload")
@@ -17,17 +18,17 @@ public class FileController {
 
     private final S3Service s3Service;
 
-    // TODO 인증 어노테이션 추가
-    @PostMapping("/presigned-url")
-    public CreatePresignedUrlResponse createPresignedUrl(final Long memberId,
-                                                         @RequestBody final String fileName) {
-        return s3Service.createPresignedUrl(memberId, fileName);
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/contents")
+    public List<UploadFileResponse> uploadContents(@AuthPrincipal final Long memberId,
+                                                   @RequestBody final List<String> fileNames) {
+        return s3Service.uploadContents(memberId, fileNames);
     }
 
-    // TODO 인증 어노테이션 추가
-    @PostMapping("/presigned-urls")
-    public List<CreatePresignedUrlResponse> createPresignedUrls(final Long memberId,
-                                                                @RequestBody final List<String> fileNames) {
-        return s3Service.createPresignedUrls(memberId, fileNames);
+    @PreAuthorize("hasRole('ROLE_TEMP')")
+    @PostMapping("/portfolios")
+    public List<UploadFileResponse> uploadPortfolios(@AuthPrincipal final Long memberId,
+                                                     @RequestBody final List<String> fileNames) {
+        return s3Service.uploadPortfolios(memberId, fileNames);
     }
 }

--- a/src/main/java/org/ject/support/domain/file/controller/FileController.java
+++ b/src/main/java/org/ject/support/domain/file/controller/FileController.java
@@ -3,6 +3,7 @@ package org.ject.support.domain.file.controller;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.security.AuthPrincipal;
+import org.ject.support.domain.file.dto.UploadFileRequest;
 import org.ject.support.domain.file.dto.UploadFileResponse;
 import org.ject.support.external.s3.S3Service;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -21,14 +22,14 @@ public class FileController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/contents")
     public List<UploadFileResponse> uploadContents(@AuthPrincipal final Long memberId,
-                                                   @RequestBody final List<String> fileNames) {
-        return s3Service.uploadContents(memberId, fileNames);
+                                                   @RequestBody final List<UploadFileRequest> requests) {
+        return s3Service.uploadContents(memberId, requests);
     }
 
     @PreAuthorize("hasRole('ROLE_TEMP')")
     @PostMapping("/portfolios")
     public List<UploadFileResponse> uploadPortfolios(@AuthPrincipal final Long memberId,
-                                                     @RequestBody final List<String> fileNames) {
-        return s3Service.uploadPortfolios(memberId, fileNames);
+                                                     @RequestBody final List<UploadFileRequest> requests) {
+        return s3Service.uploadPortfolios(memberId, requests);
     }
 }

--- a/src/main/java/org/ject/support/domain/file/dto/CreatePresignedUrlResponse.java
+++ b/src/main/java/org/ject/support/domain/file/dto/CreatePresignedUrlResponse.java
@@ -1,6 +1,0 @@
-package org.ject.support.domain.file.dto;
-
-import java.time.LocalDateTime;
-
-public record CreatePresignedUrlResponse(String keyName, String presignedUrl, LocalDateTime expiration) {
-}

--- a/src/main/java/org/ject/support/domain/file/dto/UploadFileRequest.java
+++ b/src/main/java/org/ject/support/domain/file/dto/UploadFileRequest.java
@@ -1,0 +1,4 @@
+package org.ject.support.domain.file.dto;
+
+public record UploadFileRequest(String name, String contentType, long contentLength) {
+}

--- a/src/main/java/org/ject/support/domain/file/dto/UploadFileResponse.java
+++ b/src/main/java/org/ject/support/domain/file/dto/UploadFileResponse.java
@@ -1,0 +1,8 @@
+package org.ject.support.domain.file.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record UploadFileResponse(String keyName, String presignedUrl, LocalDateTime expiration) {
+}

--- a/src/main/java/org/ject/support/domain/file/exception/FileErrorCode.java
+++ b/src/main/java/org/ject/support/domain/file/exception/FileErrorCode.java
@@ -1,0 +1,15 @@
+package org.ject.support.domain.file.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.ject.support.common.exception.ErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum FileErrorCode implements ErrorCode {
+    INVALID_EXTENSION("INVALID_EXTENSION", "유효하지 않은 확장자입니다."),
+    ;
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/ject/support/domain/file/exception/FileException.java
+++ b/src/main/java/org/ject/support/domain/file/exception/FileException.java
@@ -1,0 +1,10 @@
+package org.ject.support.domain.file.exception;
+
+import org.ject.support.common.exception.BusinessException;
+import org.ject.support.common.exception.ErrorCode;
+
+public class FileException extends BusinessException {
+    public FileException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/ject/support/external/s3/S3Service.java
+++ b/src/main/java/org/ject/support/external/s3/S3Service.java
@@ -1,5 +1,6 @@
 package org.ject.support.external.s3;
 
+import com.google.common.net.MediaType;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -46,9 +47,13 @@ public class S3Service {
     }
 
     private void validatePortfolioExtension(List<UploadFileRequest> requests) {
-        if (requests.stream().anyMatch(request -> !request.contentType().equals("application/pdf"))) {
+        if (requests.stream().anyMatch(request -> !isTypePdf(request.contentType()))) {
             throw new FileException(FileErrorCode.INVALID_EXTENSION);
         }
+    }
+
+    private boolean isTypePdf(String contentType) {
+        return MediaType.parse(contentType).is(MediaType.PDF);
     }
 
     private List<UploadFileResponse> createPresignedUrls(Long memberId, List<UploadFileRequest> requests) {

--- a/src/main/java/org/ject/support/external/s3/S3Service.java
+++ b/src/main/java/org/ject/support/external/s3/S3Service.java
@@ -1,20 +1,21 @@
 package org.ject.support.external.s3;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.util.PeriodAccessible;
-import org.ject.support.domain.file.dto.CreatePresignedUrlResponse;
+import org.ject.support.domain.file.dto.UploadFileResponse;
+import org.ject.support.domain.file.exception.FileErrorCode;
+import org.ject.support.domain.file.exception.FileException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
-
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -28,27 +29,34 @@ public class S3Service {
     private String bucket;
 
     /**
-     * 사용자가 첨부한 파일 이름과 해당 사용자의 식별자를 토대로 Pre-signed URL 생성
+     * 지원자가 첨부한 포트폴리오 파일 이름과 해당 지원자의 식별자를 토대로 Pre-signed URL 생성
      */
     @PeriodAccessible
-    public CreatePresignedUrlResponse createPresignedUrl(Long memberId, String fileName) {
-        String keyName = getKeyName(memberId, fileName);
-        PutObjectPresignRequest presignRequest = getPutObjectPresignRequest(keyName);
-        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
-        return getCreatePresignedUrlResponse(keyName, presignedRequest);
+    public List<UploadFileResponse> uploadPortfolios(Long memberId, List<String> fileNames) { // TODO 순서 보장
+        validatePortfolioExtension(fileNames);
+        return createPresignedUrls(memberId, fileNames);
     }
 
     /**
-     * 여러 개의 Pre-signed URL 생성
+     * USER 이상의 권한을 가진 사용자가 첨부한 파일 이름과 해당 사용자의 식별자를 토대로 Pre-signed URL 생성
      */
-    @PeriodAccessible
-    public List<CreatePresignedUrlResponse> createPresignedUrls(Long memberId, List<String> fileNames) {
+    public List<UploadFileResponse> uploadContents(Long memberId, List<String> fileNames) { // TODO 순서 보장
+        return createPresignedUrls(memberId, fileNames);
+    }
+
+    private void validatePortfolioExtension(List<String> fileNames) {
+        if (fileNames.stream().anyMatch(fileName -> !fileName.endsWith("pdf"))) {
+            throw new FileException(FileErrorCode.INVALID_EXTENSION);
+        }
+    }
+
+    private List<UploadFileResponse> createPresignedUrls(Long memberId, List<String> fileNames) {
         return fileNames.stream()
                 .map(fileName -> {
                     String keyName = getKeyName(memberId, fileName);
                     PutObjectPresignRequest presignRequest = getPutObjectPresignRequest(keyName);
                     PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
-                    return getCreatePresignedUrlResponse(keyName, presignedRequest);
+                    return getUploadFileResponse(keyName, presignedRequest);
                 })
                 .toList();
     }
@@ -72,10 +80,11 @@ public class S3Service {
                 .build();
     }
 
-    private CreatePresignedUrlResponse getCreatePresignedUrlResponse(String keyName, PresignedPutObjectRequest presignedRequest) {
-        return new CreatePresignedUrlResponse(
-                keyName,
-                presignedRequest.url().toExternalForm(),
-                LocalDateTime.ofInstant(presignedRequest.expiration(), ZoneId.systemDefault()));
+    private UploadFileResponse getUploadFileResponse(String keyName, PresignedPutObjectRequest presignedRequest) {
+        return UploadFileResponse.builder()
+                .keyName(keyName)
+                .presignedUrl(presignedRequest.url().toExternalForm())
+                .expiration(LocalDateTime.ofInstant(presignedRequest.expiration(), ZoneId.systemDefault()))
+                .build();
     }
 }

--- a/src/main/java/org/ject/support/external/s3/S3Service.java
+++ b/src/main/java/org/ject/support/external/s3/S3Service.java
@@ -32,7 +32,7 @@ public class S3Service {
      * 지원자가 첨부한 포트폴리오 파일 이름과 해당 지원자의 식별자를 토대로 Pre-signed URL 생성
      */
     @PeriodAccessible
-    public List<UploadFileResponse> uploadPortfolios(Long memberId, List<String> fileNames) { // TODO 순서 보장
+    public List<UploadFileResponse> uploadPortfolios(Long memberId, List<String> fileNames) {
         validatePortfolioExtension(fileNames);
         return createPresignedUrls(memberId, fileNames);
     }
@@ -40,7 +40,7 @@ public class S3Service {
     /**
      * USER 이상의 권한을 가진 사용자가 첨부한 파일 이름과 해당 사용자의 식별자를 토대로 Pre-signed URL 생성
      */
-    public List<UploadFileResponse> uploadContents(Long memberId, List<String> fileNames) { // TODO 순서 보장
+    public List<UploadFileResponse> uploadContents(Long memberId, List<String> fileNames) {
         return createPresignedUrls(memberId, fileNames);
     }
 

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.file.controller;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.ject.support.domain.member.Role.USER;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -8,17 +9,22 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.LocalDate;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.repository.MemberRepository;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.dto.Constants;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.ject.support.testconfig.ApplicationPeriodTest;
+import org.ject.support.testconfig.AuthenticatedUser;
 import org.ject.support.testconfig.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.test.context.TestPropertySource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 @IntegrationTest
 @AutoConfigureMockMvc
@@ -30,8 +36,28 @@ class FileControllerTest extends ApplicationPeriodTest {
     @Autowired
     MockMvc mockMvc;
 
+    @Autowired
+    MemberRepository memberRepository;
+
+    Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .email("test32@gmail.com")
+                .jobFamily(JobFamily.BE)
+                .name("test32")
+                .role(USER)
+                .phoneNumber("01012345678")
+                .semester("2025-1")
+                .build();
+        memberRepository.save(member);
+    }
+
     @Test
     @DisplayName("test period access endpoint")
+    @AuthenticatedUser
+    @Transactional
     void test_access_period() throws Exception {
         recruitRepository.save(Recruit.builder()
                 .jobFamily(JobFamily.BE)
@@ -40,15 +66,18 @@ class FileControllerTest extends ApplicationPeriodTest {
                 .endDate(LocalDate.now().plusDays(1))
                 .build());
 
-        mockMvc.perform(post("/upload/presigned-url")
+        mockMvc.perform(post("/upload/portfolios")
                         .contentType("application/json")
-                        .content("{\"fileName\":\"test.txt\"}"))
+                        .param("memberId", member.getId().toString())
+                        .content("[\"test1.pdf\", \"test2.pdf\"]"))
                 .andExpect(content().string(containsString("SUCCESS")))
                 .andDo(print());
     }
 
     @Test
     @DisplayName("not in period")
+    @AuthenticatedUser
+    @Transactional
     void not_in_period() throws Exception {
         // given
         recruitRepository.save(Recruit.builder()
@@ -60,9 +89,10 @@ class FileControllerTest extends ApplicationPeriodTest {
 
         when(redisTemplate.opsForValue().get(Constants.PERIOD_FLAG)).thenReturn(Boolean.toString(false));
         // then
-        mockMvc.perform(post("/upload/presigned-url")
+        mockMvc.perform(post("/upload/portfolios")
                         .contentType("application/json")
-                        .content("{\"fileName\":\"test.txt\"}"))
+                        .param("memberId", member.getId().toString())
+                        .content("[\"test1.pdf\", \"test2.pdf\"]"))
                 .andExpect(content().string(containsString("G-06")))
                 .andDo(print());
     }

--- a/src/test/java/org/ject/support/external/s3/S3ServiceTest.java
+++ b/src/test/java/org/ject/support/external/s3/S3ServiceTest.java
@@ -1,6 +1,13 @@
 package org.ject.support.external.s3;
 
-import org.ject.support.domain.file.dto.CreatePresignedUrlResponse;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.ject.support.domain.file.dto.UploadFileResponse;
+import org.ject.support.domain.file.exception.FileException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,81 +19,104 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class S3ServiceTest {
 
+    private static final String CDN_DOMAIN = "https://test-ject-cdn.net";
+    private static final int EXPIRE_MINUTES = 10;
+
     @Mock
     private S3Presigner s3Presigner;
+
+    @Mock
+    PresignedPutObjectRequest presignedPutObjectRequest;
 
     @InjectMocks
     private S3Service s3Service;
 
-    private TestParameter testParameter;
+    Instant expirationTime;
+    Long memberId;
+    List<String> portfolioFileNames;
+    List<String> expectedPortfolioUploadUrls;
 
     @BeforeEach
-    void setUp() throws MalformedURLException {
-        testParameter = new TestParameter(123L, "test.pdf", Instant.now().plusSeconds(600));
-        PresignedPutObjectRequest mockRequest = mock(PresignedPutObjectRequest.class);
-        when(mockRequest.url()).thenReturn(URI.create(testParameter.expectedUrl).toURL());
-        when(mockRequest.expiration()).thenReturn(testParameter.expirationTime);
-        when(s3Presigner.presignPutObject((PutObjectPresignRequest) any())).thenReturn(mockRequest);
+    void setUp() {
+        expirationTime = Instant.now().plusSeconds(60 * EXPIRE_MINUTES);
+        memberId = 1L;
+        portfolioFileNames = List.of("portfolio1.pdf", "portfolio1.pdf");
+        expectedPortfolioUploadUrls =
+                List.of(createExpectedUrl(memberId, "portfolio1.pdf"), createExpectedUrl(memberId, "portfolio2.pdf"));
     }
 
     @Test
-    @DisplayName("create pre-signed url")
-    void create_presigned_url() {
+    @DisplayName("포트폴리오 업로드를 위한 pre-signed url 생성")
+    void upload_portfolio() throws MalformedURLException {
+        // given
+        when(presignedPutObjectRequest.url()).thenReturn(URI.create(expectedPortfolioUploadUrls.get(0)).toURL());
+        when(presignedPutObjectRequest.expiration()).thenReturn(expirationTime);
+        when(s3Presigner.presignPutObject((PutObjectPresignRequest) any())).thenReturn(presignedPutObjectRequest);
+
         // when
-        CreatePresignedUrlResponse response =
-                s3Service.createPresignedUrl(testParameter.memberId, testParameter.fileName);
+        List<UploadFileResponse> result = s3Service.uploadPortfolios(1L, portfolioFileNames);
 
         // then
-        assertThat(response.keyName()).contains(testParameter.fileName);
-        assertThat(response.presignedUrl()).contains(testParameter.expectedUrl);
-        assertThat(response.presignedUrl()).isEqualTo(testParameter.expectedUrl);
-        assertThat(response.expiration())
-                .isEqualTo(LocalDateTime.ofInstant(testParameter.expirationTime, ZoneId.systemDefault()));
+        assertThat(result).hasSize(2);
+
+        UploadFileResponse firstResponse = result.get(0);
+        assertThat(firstResponse.keyName()).contains(portfolioFileNames.get(0));
+        assertThat(firstResponse.presignedUrl()).isEqualTo(expectedPortfolioUploadUrls.get(0));
+        assertThat(firstResponse.expiration())
+                .isEqualTo(LocalDateTime.ofInstant(expirationTime, ZoneId.systemDefault()));
+
+        UploadFileResponse secondResponse = result.get(1);
+        assertThat(secondResponse.keyName()).contains(portfolioFileNames.get(1));
     }
 
     @Test
-    @DisplayName("create key name")
-    void create_key_name() {
+    @DisplayName("객체 키 생성")
+    void create_key_name() throws MalformedURLException {
+        // given
+        when(presignedPutObjectRequest.url()).thenReturn(URI.create(expectedPortfolioUploadUrls.get(0)).toURL());
+        when(presignedPutObjectRequest.expiration()).thenReturn(expirationTime);
+        when(s3Presigner.presignPutObject((PutObjectPresignRequest) any())).thenReturn(presignedPutObjectRequest);
+
         // when
-        CreatePresignedUrlResponse response =
-                s3Service.createPresignedUrl(testParameter.memberId, testParameter.fileName);
+        List<UploadFileResponse> result =
+                s3Service.uploadPortfolios(memberId, portfolioFileNames);
 
         // then
-        assertThat(response.keyName()).contains(testParameter.memberId.toString());
-        assertThat(removePrefix(response.keyName())).startsWith(testParameter.fileName);
-        assertThat(response.keyName()).contains("_");
+        assertThat(result).hasSize(2);
+
+        for (int i = 0; i < 2; i++) {
+            UploadFileResponse firstResponse = result.get(0);
+            assertThat(firstResponse.keyName()).contains(memberId.toString());
+            assertThat(removePrefix(firstResponse.keyName())).startsWith(portfolioFileNames.get(i));
+            assertThat(firstResponse.keyName()).contains("_");
+        }
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 확장자로 인한 포트폴리오 업로드 실패")
+    void upload_portfolio_fail() {
+        // given
+        List<String> invalidExtensionFileNames = List.of("test1.png", "test2.pdf");
+
+        // when, then
+        assertThatThrownBy(() -> s3Service.uploadPortfolios(memberId, invalidExtensionFileNames))
+                .isInstanceOf(FileException.class);
+    }
+
+    private String createExpectedUrl(Long memberId, String fileName) {
+        return String.format("%s/%d/%s", CDN_DOMAIN, memberId, fileName);
     }
 
     private String removePrefix(String keyName) {
-        String prefix = String.format("%s/", testParameter.memberId);
+        String prefix = String.format("%s/", memberId);
         return keyName.replace(prefix, "");
-    }
-
-    static class TestParameter {
-        Long memberId;
-        String fileName;
-        Instant expirationTime;
-        String expectedKeyName;
-        String expectedUrl;
-
-        public TestParameter(Long memberId, String fileName, Instant expirationTime) {
-            this.memberId = memberId;
-            this.fileName = fileName;
-            this.expectedKeyName = String.format("%s/%s", memberId, "test.pdf_uuid");
-            this.expectedUrl = String.format("%s%s", "https://s3.test.com/", expectedKeyName);
-            this.expirationTime = expirationTime;
-        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #40 

## 📝작업 내용
- 이미지 업로드 API path 분리
- 구현된 API 모두 인가 처리
- 하나의 파일 업로드 API에서 포폴 전용 API 분리
- url 생성 시 content-type과 content-length 지정하는 코드 추가

## ✅테스트 결과
<img width="546" alt="스크린샷 2025-03-05 오전 2 39 14" src="https://github.com/user-attachments/assets/3b010490-3a19-4063-9fee-4f60c59cd6ab" />
<img width="542" alt="image" src="https://github.com/user-attachments/assets/4475aabb-9755-408e-9c39-b2f835ab2eac" />

### SignatureDoesNotMatch 에러
<img width="1397" alt="image" src="https://github.com/user-attachments/assets/0c12b259-f8b8-42c5-9afc-a56657b53d9a" />
url 생성 시 지정한 contentType이나 contentLength가 업로드한 파일의 메타데이터와 다를 경우 위 error가 발생하는 것까지 확인했습니다.

