### PR TITLE
CORS 방지를 위한 허용 출처 추가

### DIFF
--- a/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
@@ -41,6 +41,9 @@ public class SecurityConfig {
     @Value("${security.cors.allowed-origins-https}")
     private String allowedOriginsHttps;
 
+    @Value("${security.cors.allowed-origins-client}")
+    private String allowedOriginsClient;
+
     @Bean
     public static RoleHierarchy roleHierarchy() {
         return RoleHierarchyImpl.fromHierarchy("""
@@ -80,6 +83,7 @@ public class SecurityConfig {
         configuration.addAllowedOriginPattern("http://localhost:3000");
         configuration.addAllowedOriginPattern(allowedOrigins);
         configuration.addAllowedOriginPattern(allowedOriginsHttps);
+        configuration.addAllowedOriginPattern(allowedOriginsClient);
         configuration.addAllowedHeader("*");
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
@@ -81,6 +81,7 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedOriginPattern("http://localhost:8080");
         configuration.addAllowedOriginPattern("http://localhost:3000");
+        configuration.addAllowedOriginPattern("http://localhost:5174");
         configuration.addAllowedOriginPattern(allowedOrigins);
         configuration.addAllowedOriginPattern(allowedOriginsHttps);
         configuration.addAllowedOriginPattern(allowedOriginsClient);

--- a/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.ject.support.common.security.jwt.JwtAccessDeniedHandler;
 import org.ject.support.common.security.jwt.JwtAuthenticationEntryPoint;
 import org.ject.support.common.security.jwt.JwtAuthenticationFilter;
 import org.ject.support.common.security.jwt.JwtExceptionHandlerFilter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
@@ -33,6 +34,12 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionHandlerFilter jwtExceptionHandlerFilter;
+
+    @Value("${security.cors.allowed-origins}")
+    private String allowedOrigins;
+
+    @Value("${security.cors.allowed-origins-https}")
+    private String allowedOriginsHttps;
 
     @Bean
     public static RoleHierarchy roleHierarchy() {
@@ -71,6 +78,8 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedOriginPattern("http://localhost:8080");
         configuration.addAllowedOriginPattern("http://localhost:3000");
+        configuration.addAllowedOriginPattern(allowedOrigins);
+        configuration.addAllowedOriginPattern(allowedOriginsHttps);
         configuration.addAllowedHeader("*");
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE"));
         configuration.setAllowCredentials(true);

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -54,3 +54,9 @@ logging:
     org:
       springframework:
         jdbc: trace
+
+security:
+  cors:
+    allowed-origins: http://localhost:8080
+    allowed-origins-https: https://localhost:3
+    allowed-origins-client: http://localhost:3000

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -58,5 +58,5 @@ logging:
 security:
   cors:
     allowed-origins: http://localhost:8080
-    allowed-origins-https: https://localhost:3
+    allowed-origins-https: https://localhost:443
     allowed-origins-client: http://localhost:3000


### PR DESCRIPTION
## #️⃣연관된 이슈

close #71 

## 📝작업 내용

`SecurityConfig` 에 CORS 방지를 위한 백엔드 도메인을 허용했습니다.
