### PR TITLE
CommonHttpMessageConverter 에서 올바른 직렬화 처리하도록 수정

### DIFF
--- a/src/main/java/org/ject/support/common/response/CommonHttpMessageConverter.java
+++ b/src/main/java/org/ject/support/common/response/CommonHttpMessageConverter.java
@@ -40,7 +40,7 @@ public class CommonHttpMessageConverter extends AbstractHttpMessageConverter<Api
     @Override
     protected void writeInternal(final ApiResponse<Object> objectApiResponse, final HttpOutputMessage outputMessage)
             throws IOException, HttpMessageNotWritableException {
-        String responseMessage = objectMapper.writeValueAsString(outputMessage);
+        String responseMessage = objectMapper.writeValueAsString(objectApiResponse);
         StreamUtils.copy(responseMessage.getBytes(StandardCharsets.UTF_8), outputMessage.getBody());
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #71 

## 📝작업 내용
`outputMessage`는 `HttpOutputMessage` 타입으로, 응답 본문을 작성하기 위한 컨테이너이지 실제 응답 데이터가 아닙니다.
해당 부분을 수정했습니다.

## ✅테스트 결과

<img width="418" alt="스크린샷 2025-03-07 오후 3 25 52" src="https://github.com/user-attachments/assets/0d247a81-aedb-4056-b447-57b9ffbb6f12" />

<img width="430" alt="스크린샷 2025-03-07 오후 3 25 40" src="https://github.com/user-attachments/assets/46ac321e-cd2e-416c-b6c6-1451559b5a14" />
