### PR TITLE
Redis 사용 관련 설정 변경

### DIFF
--- a/src/main/java/org/ject/support/common/data/redis/RedisConfig.java
+++ b/src/main/java/org/ject/support/common/data/redis/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -33,7 +34,11 @@ public class RedisConfig {
             redisConfig.setPassword(RedisPassword.of(redisPassword));
         }
 
-        return new LettuceConnectionFactory(redisConfig);
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .useSsl()
+                .build();
+
+        return new LettuceConnectionFactory(redisConfig, clientConfig);
     }
 
     @Bean


### PR DESCRIPTION
## #️⃣연관된 이슈

close #88

## 📝작업 내용

- application-prod.yml 에 redis ssl 설정 추가
- RedisConfig에 `useSsl()` 옵션 추가

---
Elasticache Redis 는 현재 TLS 옵션을 사용하기에 이에 알맞게 SSL 설정을 활성화시켜줘야 해당 Redis 서버에 연결이 가능합니다.
따라서 해당 옵션을 추가했습니다.
