### PR TITLE
캐시 적용 및 API 응답 필드 수정

### DIFF
--- a/src/main/java/org/ject/support/common/data/RestPage.java
+++ b/src/main/java/org/ject/support/common/data/RestPage.java
@@ -1,0 +1,20 @@
+package org.ject.support.common.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
+public class RestPage<T> extends PageImpl<T> {
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public RestPage(@JsonProperty("content") List<T> content,
+                    @JsonProperty("number") int page,
+                    @JsonProperty("size") int size,
+                    @JsonProperty("totalElements") long total) {
+        super(content, PageRequest.of(page, size), total);
+    }
+}

--- a/src/main/java/org/ject/support/common/data/redis/RedisConfig.java
+++ b/src/main/java/org/ject/support/common/data/redis/RedisConfig.java
@@ -1,18 +1,27 @@
 package org.ject.support.common.data.redis;
 
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-
 @Configuration
+@EnableCaching
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")
@@ -48,5 +57,27 @@ public class RedisConfig {
 
         template.afterPropertiesSet();
         return template;
+    }
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(redisCacheConfiguration())
+                .build();
+    }
+
+    private RedisCacheConfiguration redisCacheConfiguration() {
+        StringRedisSerializer redisKeySerializer = new StringRedisSerializer();
+        GenericJackson2JsonRedisSerializer redisValueSerializer = new GenericJackson2JsonRedisSerializer()
+                .configure(objectMapper -> {
+                    objectMapper.registerModule(new JavaTimeModule());
+                    objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+                });
+        return RedisCacheConfiguration
+                .defaultCacheConfig()
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofMinutes(2))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(redisKeySerializer))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(redisValueSerializer));
     }
 }

--- a/src/main/java/org/ject/support/domain/jectalk/controller/JectalkController.java
+++ b/src/main/java/org/ject/support/domain/jectalk/controller/JectalkController.java
@@ -1,9 +1,9 @@
 package org.ject.support.domain.jectalk.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.jectalk.dto.JectalkResponse;
 import org.ject.support.domain.jectalk.service.JectalkService;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +18,7 @@ public class JectalkController {
     private final JectalkService jectalkService;
 
     @GetMapping
-    public Page<JectalkResponse> findJectalks(@PageableDefault(size = 12) Pageable pageable) {
+    public RestPage<JectalkResponse> findJectalks(@PageableDefault(size = 12) Pageable pageable) {
         return jectalkService.findJectalks(pageable);
     }
 }

--- a/src/main/java/org/ject/support/domain/jectalk/dto/JectalkResponse.java
+++ b/src/main/java/org/ject/support/domain/jectalk/dto/JectalkResponse.java
@@ -4,7 +4,7 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 
 @Builder
-public record JectalkResponse(String name, String youtubeUrl, String imageUrl, String summary) {
+public record JectalkResponse(Long id, String name, String youtubeUrl, String imageUrl, String summary) {
 
     @QueryProjection
     public JectalkResponse {

--- a/src/main/java/org/ject/support/domain/jectalk/dto/JectalkResponse.java
+++ b/src/main/java/org/ject/support/domain/jectalk/dto/JectalkResponse.java
@@ -4,9 +4,7 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 
 @Builder
-public record JectalkResponse(String name,
-                            String youtubeUrl,
-                            String imageUrl) {
+public record JectalkResponse(String name, String youtubeUrl, String imageUrl, String summary) {
 
     @QueryProjection
     public JectalkResponse {

--- a/src/main/java/org/ject/support/domain/jectalk/entity/Jectalk.java
+++ b/src/main/java/org/ject/support/domain/jectalk/entity/Jectalk.java
@@ -20,6 +20,9 @@ public class Jectalk extends BaseTimeEntity {
     @Column(length = 50, nullable = false)
     private String name;
 
+    @Column(nullable = false)
+    private String summary;
+
     @Column(length = 2083)
     private String youtubeUrl;
 

--- a/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepository.java
@@ -1,9 +1,9 @@
 package org.ject.support.domain.jectalk.repository;
 
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.jectalk.dto.JectalkResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface JectalkQueryRepository {
-    Page<JectalkResponse> findJectalks(Pageable pageable);
+    RestPage<JectalkResponse> findJectalks(Pageable pageable);
 }

--- a/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryImpl.java
@@ -22,6 +22,7 @@ public class JectalkQueryRepositoryImpl implements JectalkQueryRepository {
     public RestPage<JectalkResponse> findJectalks(Pageable pageable) {
         List<JectalkResponse> content = queryFactory
                 .select(new QJectalkResponse(
+                        jectalk.id,
                         jectalk.name,
                         jectalk.youtubeUrl,
                         jectalk.imageUrl,

--- a/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryImpl.java
@@ -24,7 +24,8 @@ public class JectalkQueryRepositoryImpl implements JectalkQueryRepository {
                 .select(new QJectalkResponse(
                         jectalk.name,
                         jectalk.youtubeUrl,
-                        jectalk.imageUrl
+                        jectalk.imageUrl,
+                        jectalk.summary
                 ))
                 .from(jectalk)
                 .orderBy(jectalk.id.desc())

--- a/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryImpl.java
@@ -1,18 +1,16 @@
 package org.ject.support.domain.jectalk.repository;
 
-import static org.ject.support.domain.jectalk.entity.QJectalk.jectalk;
-
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.jectalk.dto.JectalkResponse;
 import org.ject.support.domain.jectalk.dto.QJectalkResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import static org.ject.support.domain.jectalk.entity.QJectalk.jectalk;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,7 +19,7 @@ public class JectalkQueryRepositoryImpl implements JectalkQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<JectalkResponse> findJectalks(Pageable pageable) {
+    public RestPage<JectalkResponse> findJectalks(Pageable pageable) {
         List<JectalkResponse> content = queryFactory
                 .select(new QJectalkResponse(
                         jectalk.name,
@@ -38,6 +36,6 @@ public class JectalkQueryRepositoryImpl implements JectalkQueryRepository {
                 .select(jectalk.count())
                 .from(jectalk);
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        return new RestPage<>(content, pageable.getPageNumber(), pageable.getPageSize(), countQuery.fetchFirst());
     }
 }

--- a/src/main/java/org/ject/support/domain/jectalk/service/JectalkService.java
+++ b/src/main/java/org/ject/support/domain/jectalk/service/JectalkService.java
@@ -1,9 +1,10 @@
 package org.ject.support.domain.jectalk.service;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.jectalk.dto.JectalkResponse;
 import org.ject.support.domain.jectalk.repository.JectalkRepository;
-import org.springframework.data.domain.Page;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,8 +15,9 @@ public class JectalkService {
 
     private final JectalkRepository jectalkRepository;
 
+    @Cacheable(value = "jectalk", key = "#pageable.pageNumber")
     @Transactional(readOnly = true)
-    public Page<JectalkResponse> findJectalks(Pageable pageable) {
+    public RestPage<JectalkResponse> findJectalks(Pageable pageable) {
         return jectalkRepository.findJectalks(pageable);
     }
 }

--- a/src/main/java/org/ject/support/domain/ministudy/controller/MiniStudyController.java
+++ b/src/main/java/org/ject/support/domain/ministudy/controller/MiniStudyController.java
@@ -1,9 +1,9 @@
 package org.ject.support.domain.ministudy.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.ministudy.dto.MiniStudyResponse;
 import org.ject.support.domain.ministudy.service.MiniStudyService;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +18,7 @@ public class MiniStudyController {
     private final MiniStudyService miniStudyService;
 
     @GetMapping
-    public Page<MiniStudyResponse> findMiniStudies(@PageableDefault(size = 12) Pageable pageable) {
+    public RestPage<MiniStudyResponse> findMiniStudies(@PageableDefault(size = 12) Pageable pageable) {
         return miniStudyService.findMiniStudies(pageable);
     }
 }

--- a/src/main/java/org/ject/support/domain/ministudy/dto/MiniStudyResponse.java
+++ b/src/main/java/org/ject/support/domain/ministudy/dto/MiniStudyResponse.java
@@ -4,7 +4,7 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 
 @Builder
-public record MiniStudyResponse(String name, String linkUrl, String imageUrl, String summary) {
+public record MiniStudyResponse(Long id, String name, String linkUrl, String imageUrl, String summary) {
 
     @QueryProjection
     public MiniStudyResponse {

--- a/src/main/java/org/ject/support/domain/ministudy/dto/MiniStudyResponse.java
+++ b/src/main/java/org/ject/support/domain/ministudy/dto/MiniStudyResponse.java
@@ -4,9 +4,7 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 
 @Builder
-public record MiniStudyResponse(String name,
-                              String linkUrl,
-                              String imageUrl) {
+public record MiniStudyResponse(String name, String linkUrl, String imageUrl, String summary) {
 
     @QueryProjection
     public MiniStudyResponse {

--- a/src/main/java/org/ject/support/domain/ministudy/entity/MiniStudy.java
+++ b/src/main/java/org/ject/support/domain/ministudy/entity/MiniStudy.java
@@ -20,6 +20,9 @@ public class MiniStudy extends BaseTimeEntity {
     @Column(length = 50, nullable = false)
     private String name;
 
+    @Column(nullable = false)
+    private String summary;
+
     @Column(length = 2083)
     private String linkUrl;
 

--- a/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepository.java
@@ -1,9 +1,9 @@
 package org.ject.support.domain.ministudy.repository;
 
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.ministudy.dto.MiniStudyResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MiniStudyQueryRepository {
-    Page<MiniStudyResponse> findMiniStudies(Pageable pageable);
+    RestPage<MiniStudyResponse> findMiniStudies(Pageable pageable);
 }

--- a/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryImpl.java
@@ -24,7 +24,8 @@ public class MiniStudyQueryRepositoryImpl implements MiniStudyQueryRepository {
                 .select(new QMiniStudyResponse(
                         miniStudy.name,
                         miniStudy.linkUrl,
-                        miniStudy.imageUrl
+                        miniStudy.imageUrl,
+                        miniStudy.summary
                 ))
                 .from(miniStudy)
                 .orderBy(miniStudy.id.desc())

--- a/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryImpl.java
@@ -2,15 +2,13 @@ package org.ject.support.domain.ministudy.repository;
 
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.ministudy.dto.MiniStudyResponse;
 import org.ject.support.domain.ministudy.dto.QMiniStudyResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 import static org.ject.support.domain.ministudy.entity.QMiniStudy.miniStudy;
 
@@ -21,7 +19,7 @@ public class MiniStudyQueryRepositoryImpl implements MiniStudyQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<MiniStudyResponse> findMiniStudies(Pageable pageable) {
+    public RestPage<MiniStudyResponse> findMiniStudies(Pageable pageable) {
         List<MiniStudyResponse> content = queryFactory
                 .select(new QMiniStudyResponse(
                         miniStudy.name,
@@ -38,6 +36,6 @@ public class MiniStudyQueryRepositoryImpl implements MiniStudyQueryRepository {
                 .select(miniStudy.count())
                 .from(miniStudy);
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        return new RestPage<>(content, pageable.getPageNumber(), pageable.getPageSize(), countQuery.fetchFirst());
     }
 }

--- a/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryImpl.java
@@ -22,6 +22,7 @@ public class MiniStudyQueryRepositoryImpl implements MiniStudyQueryRepository {
     public RestPage<MiniStudyResponse> findMiniStudies(Pageable pageable) {
         List<MiniStudyResponse> content = queryFactory
                 .select(new QMiniStudyResponse(
+                        miniStudy.id,
                         miniStudy.name,
                         miniStudy.linkUrl,
                         miniStudy.imageUrl,

--- a/src/main/java/org/ject/support/domain/ministudy/service/MiniStudyService.java
+++ b/src/main/java/org/ject/support/domain/ministudy/service/MiniStudyService.java
@@ -1,9 +1,10 @@
 package org.ject.support.domain.ministudy.service;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.ministudy.dto.MiniStudyResponse;
 import org.ject.support.domain.ministudy.repository.MiniStudyRepository;
-import org.springframework.data.domain.Page;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,8 +15,9 @@ public class MiniStudyService {
 
     private final MiniStudyRepository miniStudyRepository;
 
+    @Cacheable(value = "ministudy", key = "#pageable.pageNumber")
     @Transactional(readOnly = true)
-    public Page<MiniStudyResponse> findMiniStudies(Pageable pageable) {
+    public RestPage<MiniStudyResponse> findMiniStudies(Pageable pageable) {
         return miniStudyRepository.findMiniStudies(pageable);
     }
 }

--- a/src/main/java/org/ject/support/domain/project/dto/ProjectResponse.java
+++ b/src/main/java/org/ject/support/domain/project/dto/ProjectResponse.java
@@ -10,8 +10,7 @@ public record ProjectResponse(Long id,
                               String thumbnailUrl,
                               String name,
                               String summary,
-                              LocalDate startDate,
-                              LocalDate endDate) {
+                              String description) {
 
     @QueryProjection
     public ProjectResponse {

--- a/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepository.java
@@ -1,13 +1,13 @@
 package org.ject.support.domain.project.repository;
 
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.project.dto.ProjectResponse;
 import org.ject.support.domain.project.entity.Project;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ProjectQueryRepository {
 
-    Page<ProjectResponse> findProjectsByCategoryAndSemester(Project.Category category,
-                                                            String semester,
-                                                            Pageable pageable);
+    RestPage<ProjectResponse> findProjectsByCategoryAndSemester(Project.Category category,
+                                                                String semester,
+                                                                Pageable pageable);
 }

--- a/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryImpl.java
@@ -4,11 +4,10 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.project.dto.ProjectResponse;
 import org.ject.support.domain.project.dto.QProjectResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import static org.ject.support.domain.project.entity.Project.Category;
@@ -21,9 +20,9 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<ProjectResponse> findProjectsByCategoryAndSemester(final Category category,
-                                                                   final String semester,
-                                                                   final Pageable pageable) {
+    public RestPage<ProjectResponse> findProjectsByCategoryAndSemester(final Category category,
+                                                                       final String semester,
+                                                                       final Pageable pageable) {
         List<ProjectResponse> content = queryFactory.select(new QProjectResponse(
                         project.id,
                         project.thumbnailUrl,
@@ -42,6 +41,6 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
                 .select(project.count())
                 .from(project);
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        return new RestPage<>(content, pageable.getPageNumber(), pageable.getPageSize(), countQuery.fetchFirst());
     }
 }

--- a/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryImpl.java
@@ -28,8 +28,7 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
                         project.thumbnailUrl,
                         project.name,
                         project.summary,
-                        project.startDate,
-                        project.endDate
+                        project.description
                 ))
                 .from(project)
                 .where(project.category.eq(category), project.semester.eq(semester))

--- a/src/main/java/org/ject/support/domain/project/service/ProjectService.java
+++ b/src/main/java/org/ject/support/domain/project/service/ProjectService.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.project.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.member.dto.TeamMemberNames;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.ject.support.domain.project.dto.ProjectDetailResponse;
@@ -12,7 +13,7 @@ import org.ject.support.domain.project.entity.ProjectIntro;
 import org.ject.support.domain.project.exception.ProjectErrorCode;
 import org.ject.support.domain.project.exception.ProjectException;
 import org.ject.support.domain.project.repository.ProjectRepository;
-import org.springframework.data.domain.Page;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,16 +31,18 @@ public class ProjectService {
     /**
      * 주어진 기수의 프로젝트를 모두 조회합니다.
      */
+    @Cacheable(value = "project", key = "#category + ':' + #semester")
     @Transactional(readOnly = true)
-    public Page<ProjectResponse> findProjects(final Project.Category category,
-                                              final String semester,
-                                              final Pageable pageable) {
+    public RestPage<ProjectResponse> findProjects(final Project.Category category,
+                                                  final String semester,
+                                                  final Pageable pageable) {
         return projectRepository.findProjectsByCategoryAndSemester(category, semester, pageable);
     }
 
     /**
      * 프로젝트 상세 정보를 조회합니다.
      */
+    @Cacheable(value = "project", key = "#projectId")
     @Transactional(readOnly = true)
     public ProjectDetailResponse findProjectDetails(final Long projectId) {
         Project project = projectRepository.findById(projectId)

--- a/src/main/java/org/ject/support/domain/project/service/ProjectService.java
+++ b/src/main/java/org/ject/support/domain/project/service/ProjectService.java
@@ -31,7 +31,7 @@ public class ProjectService {
     /**
      * 주어진 기수의 프로젝트를 모두 조회합니다.
      */
-    @Cacheable(value = "project", key = "#category + ':' + #semester")
+    @Cacheable(value = "project", key = "#category + ':' + #semester + ':' + #pageable.pageNumber")
     @Transactional(readOnly = true)
     public RestPage<ProjectResponse> findProjects(final Project.Category category,
                                                   final String semester,

--- a/src/main/java/org/ject/support/domain/review/controller/ReviewController.java
+++ b/src/main/java/org/ject/support/domain/review/controller/ReviewController.java
@@ -1,9 +1,9 @@
 package org.ject.support.domain.review.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.review.dto.ReviewResponse;
 import org.ject.support.domain.review.service.ReviewService;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +18,7 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @GetMapping
-    public Page<ReviewResponse> findReviews(@PageableDefault(size = 4) Pageable pageable) {
+    public RestPage<ReviewResponse> findReviews(@PageableDefault(size = 4) Pageable pageable) {
         return reviewService.findReviews(pageable);
     }
 }

--- a/src/main/java/org/ject/support/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/org/ject/support/domain/review/dto/ReviewResponse.java
@@ -2,7 +2,7 @@ package org.ject.support.domain.review.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 
-public record ReviewResponse(String linkUrl, String title, String description, String summary) {
+public record ReviewResponse(Long id, String linkUrl, String title, String description, String summary) {
 
     @QueryProjection
     public ReviewResponse {

--- a/src/main/java/org/ject/support/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/org/ject/support/domain/review/dto/ReviewResponse.java
@@ -2,7 +2,7 @@ package org.ject.support.domain.review.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 
-public record ReviewResponse(String linkUrl, String title, String description) {
+public record ReviewResponse(String linkUrl, String title, String description, String summary) {
 
     @QueryProjection
     public ReviewResponse {

--- a/src/main/java/org/ject/support/domain/review/entity/Review.java
+++ b/src/main/java/org/ject/support/domain/review/entity/Review.java
@@ -29,4 +29,7 @@ public class Review extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String description;
+
+    @Column(nullable = false)
+    private String summary;
 }

--- a/src/main/java/org/ject/support/domain/review/repository/ReviewQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/review/repository/ReviewQueryRepository.java
@@ -1,10 +1,10 @@
 package org.ject.support.domain.review.repository;
 
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.review.dto.ReviewResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ReviewQueryRepository {
 
-    Page<ReviewResponse> findReviews(Pageable pageable);
+    RestPage<ReviewResponse> findReviews(Pageable pageable);
 }

--- a/src/main/java/org/ject/support/domain/review/repository/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/review/repository/ReviewQueryRepositoryImpl.java
@@ -4,11 +4,10 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.review.dto.QReviewResponse;
 import org.ject.support.domain.review.dto.ReviewResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import static org.ject.support.domain.review.entity.QReview.review;
@@ -20,7 +19,7 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<ReviewResponse> findReviews(Pageable pageable) {
+    public RestPage<ReviewResponse> findReviews(Pageable pageable) {
         List<ReviewResponse> content = queryFactory.select(new QReviewResponse(
                         review.linkUrl,
                         review.title,
@@ -34,6 +33,6 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
         JPAQuery<Long> countQuery = queryFactory.select(review.count())
                 .from(review);
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        return new RestPage<>(content, pageable.getPageNumber(), pageable.getPageSize(), countQuery.fetchFirst());
     }
 }

--- a/src/main/java/org/ject/support/domain/review/repository/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/review/repository/ReviewQueryRepositoryImpl.java
@@ -21,6 +21,7 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
     @Override
     public RestPage<ReviewResponse> findReviews(Pageable pageable) {
         List<ReviewResponse> content = queryFactory.select(new QReviewResponse(
+                        review.id,
                         review.linkUrl,
                         review.title,
                         review.description,

--- a/src/main/java/org/ject/support/domain/review/repository/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/review/repository/ReviewQueryRepositoryImpl.java
@@ -23,7 +23,8 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
         List<ReviewResponse> content = queryFactory.select(new QReviewResponse(
                         review.linkUrl,
                         review.title,
-                        review.description))
+                        review.description,
+                        review.summary))
                 .from(review)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/org/ject/support/domain/review/service/ReviewService.java
+++ b/src/main/java/org/ject/support/domain/review/service/ReviewService.java
@@ -1,9 +1,10 @@
 package org.ject.support.domain.review.service;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.RestPage;
 import org.ject.support.domain.review.dto.ReviewResponse;
 import org.ject.support.domain.review.repository.ReviewRepository;
-import org.springframework.data.domain.Page;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,8 +15,9 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
 
+    @Cacheable(value = "review", key = "#pageable.pageNumber")
     @Transactional(readOnly = true)
-    public Page<ReviewResponse> findReviews(Pageable pageable) {
+    public RestPage<ReviewResponse> findReviews(Pageable pageable) {
         return reviewRepository.findReviews(pageable);
     }
 }

--- a/src/test/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.ject.support.domain.jectalk.repository;
 
+import java.util.List;
 import org.ject.support.domain.jectalk.dto.JectalkResponse;
 import org.ject.support.domain.jectalk.entity.Jectalk;
 import org.ject.support.testconfig.IntegrationTest;
@@ -9,8 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,6 +41,13 @@ class JectalkQueryRepositoryTest {
 
         List<JectalkResponse> responses = result.getContent();
         assertThat(responses).hasSize(2); // 현재 페이지의 데이터 개수
+        responses.forEach(jectalkResponse -> {
+            assertThat(jectalkResponse.id()).isNotNull();
+            assertThat(jectalkResponse.name()).isNotNull();
+            assertThat(jectalkResponse.imageUrl()).isNotNull();
+            assertThat(jectalkResponse.youtubeUrl()).isNotNull();
+            assertThat(jectalkResponse.summary()).isNotNull();
+        });
 
         JectalkResponse firstResponse = responses.get(0);
         assertThat(firstResponse.name()).isEqualTo("젝톡 3"); // ID 내림차순이므로 마지막에 생성된 데이터가 첫 번째

--- a/src/test/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryTest.java
@@ -45,6 +45,7 @@ class JectalkQueryRepositoryTest {
 
         JectalkResponse firstResponse = responses.get(0);
         assertThat(firstResponse.name()).isEqualTo("젝톡 3"); // ID 내림차순이므로 마지막에 생성된 데이터가 첫 번째
+        assertThat(firstResponse.summary()).isEqualTo("summary");
         assertThat(firstResponse.youtubeUrl()).isEqualTo("https://youtube.com/jectalk3");
         assertThat(firstResponse.imageUrl()).isEqualTo("https://image.com/jectalk3.png");
 
@@ -57,6 +58,7 @@ class JectalkQueryRepositoryTest {
         String urlSafeName = "jectalk" + name.replaceAll("[젝톡 ]", "");
         return Jectalk.builder()
                 .name(name)
+                .summary("summary")
                 .youtubeUrl("https://youtube.com/" + urlSafeName)
                 .imageUrl("https://image.com/" + urlSafeName + ".png")
                 .build();

--- a/src/test/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryTest.java
@@ -44,6 +44,7 @@ class MiniStudyQueryRepositoryTest {
         assertThat(responses).hasSize(2); // 현재 페이지의 데이터 개수
 
         MiniStudyResponse firstResponse = responses.get(0);
+        assertThat(firstResponse.id()).isNotNull();
         assertThat(firstResponse.name()).isEqualTo("미니 스터디 3"); // ID 내림차순이므로 마지막에 생성된 데이터가 첫 번째
         assertThat(firstResponse.summary()).isEqualTo("summary");
         assertThat(firstResponse.linkUrl()).isEqualTo("https://test.net/ministudy3");

--- a/src/test/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryTest.java
@@ -45,6 +45,7 @@ class MiniStudyQueryRepositoryTest {
 
         MiniStudyResponse firstResponse = responses.get(0);
         assertThat(firstResponse.name()).isEqualTo("미니 스터디 3"); // ID 내림차순이므로 마지막에 생성된 데이터가 첫 번째
+        assertThat(firstResponse.summary()).isEqualTo("summary");
         assertThat(firstResponse.linkUrl()).isEqualTo("https://test.net/ministudy3");
         assertThat(firstResponse.imageUrl()).isEqualTo("https://test.net/image3.png");
 
@@ -57,6 +58,7 @@ class MiniStudyQueryRepositoryTest {
         String urlSafeName = name.replaceAll("[미니 스터디]", "");
         return MiniStudy.builder()
                 .name(name)
+                .summary("summary")
                 .linkUrl("https://test.net/ministudy" + urlSafeName)
                 .imageUrl("https://test.net/image" + urlSafeName + ".png")
                 .build();

--- a/src/test/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryTest.java
@@ -60,11 +60,11 @@ class ProjectQueryRepositoryTest {
         assertThat(responses).hasSize(2);
 
         ProjectResponse firstResponse = responses.get(0);
+        assertThat(firstResponse.id()).isEqualTo(1);
         assertThat(firstResponse.name()).isEqualTo("projectName");
         assertThat(firstResponse.summary()).isEqualTo("summary");
         assertThat(firstResponse.thumbnailUrl()).isEqualTo("https://test.net/thumbnail.png");
-        assertThat(firstResponse.startDate()).isEqualTo(LocalDate.of(2025, 3, 2));
-        assertThat(firstResponse.endDate()).isEqualTo(LocalDate.of(2025, 6, 30));
+        assertThat(firstResponse.description()).isEqualTo("description");
     }
 
     @Test
@@ -91,6 +91,7 @@ class ProjectQueryRepositoryTest {
                 .thumbnailUrl("https://test.net/thumbnail.png")
                 .semester(semester)
                 .summary("summary")
+                .description("description")
                 .startDate(LocalDate.of(2025, 3, 2))
                 .endDate(LocalDate.of(2025, 6, 30))
                 .category(category)

--- a/src/test/java/org/ject/support/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/review/repository/ReviewRepositoryTest.java
@@ -37,6 +37,13 @@ class ReviewRepositoryTest {
 
         // then
         assertThat(result.getContent()).hasSize(4);
+        result.getContent().forEach(reviewResponse -> {
+            assertThat(reviewResponse.id()).isNotNull();
+            assertThat(reviewResponse.title()).isNotNull();
+            assertThat(reviewResponse.linkUrl()).isNotNull();
+            assertThat(reviewResponse.description()).isNotNull();
+            assertThat(reviewResponse.summary()).isNotNull();
+        });
     }
 
     private Review createReview() {

--- a/src/test/java/org/ject/support/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/review/repository/ReviewRepositoryTest.java
@@ -44,6 +44,7 @@ class ReviewRepositoryTest {
                 .linkUrl("https://test.com")
                 .title("title")
                 .description("description")
+                .summary("summary")
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #70 

## 📝작업 내용
- RestPage 클래스 구현
- Redis 캐시매니저 세팅
- 아래 API에 캐시 적용
  - 프로젝트 목록 조회
  - 프로젝트 상세 조회
  - 프로젝트 후기 목록 조회
  - 미니스터디 목록 조회
  - 젝톡 목록 조회
- 프로젝트 목록 조회 응답 dto에 `description` 추가, `startDate`와 `endDate` 제거
- 프로젝트 후기 목록 조회 응답 dto에 `summary` 추가
- 젝톡, 미니스터디 엔티티와 응답 dto에 `summary` 추가
- 리뷰, 젝톡, 미니스터디 목록 조회 응답 dto에 `id` 추가

### RestPage 클래스
캐싱을 적용하였더니 아래와 같은 에러가 발생했습니다.
```
org.springframework.data.redis.serializer.SerializationException: Could not read JSON:Cannot construct instance of org.springframework.data.domain.PageImpl (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
at [Source: REDACTED (StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION disabled); line: 1, column: 46]
```
이는 `Page<T>`가 역직렬화되지 않아 발생한 것으로 확인했습니다.
따라서 직렬화/역직렬화가 가능하도록 RestPage 클래스를 구현했고, 이를 모든 페이징 API의 응답 dto로 변경했습니다.

## ✅테스트 결과
<img width="463" alt="스크린샷 2025-03-09 오전 3 21 41" src="https://github.com/user-attachments/assets/c7fc82e7-45c3-4f22-b5e9-104891b2938f" />

## 🙏리뷰 요구사항
FAQ와 지원서 문항 조회 API는 구현되는대로 캐싱을 적용할 예정입니다.

