### PR TITLE
이메일 인증-임시 회원 생성-PIN 설정 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
@@ -1,17 +1,22 @@
 package org.ject.support.common.security.jwt;
 
-import static org.ject.support.common.exception.GlobalErrorCode.INVALID_ACCESS_TOKEN;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.ject.support.common.exception.GlobalException;
 
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -37,11 +42,62 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = jwtTokenProvider.resolveToken(request);
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
-            Authentication auth = jwtTokenProvider.getAuthenticationByToken(token);
-            SecurityContextHolder.getContext().setAuthentication(auth);
+            try {
+                // 토큰 타입 확인
+                if (isVerificationToken(token)) {
+                    // verification 토큰인 경우 별도 처리
+                    // 이메일만 추출하여 간단한 인증 정보 생성
+                    String email = jwtTokenProvider.extractEmailFromVerificationToken(token);
+                    Authentication auth = createVerificationAuthentication(email);
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                } else {
+                    // 일반 인증 토큰인 경우 기존 방식으로 처리
+                    Authentication auth = jwtTokenProvider.getAuthenticationByToken(token);
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                }
+            } catch (Exception e) {
+                log.error("토큰 처리 중 오류 발생: {}", e.getMessage());
+                // 토큰 처리 중 오류가 발생해도 요청은 계속 진행
+            }
         }
 
         chain.doFilter(request, response);
+    }
+    
+    /**
+     * 주어진 토큰이 verification 토큰인지 확인
+     */
+    private boolean isVerificationToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(jwtTokenProvider.getSecretKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            
+            // type 필드가 있는지 확인
+            if (claims.containsKey("type")) {
+                String type = claims.get("type", String.class);
+                return "verification".equals(type);
+            }
+            return false;
+        } catch (Exception e) {
+            log.debug("토큰 타입 확인 중 예외 발생: {}", e.getMessage());
+            return false;
+        }
+    }
+    
+    /**
+     * 이메일 기반으로 verification 인증 정보 생성
+     * 이 인증은 회원 등록 API에만 접근 가능하도록 제한된 권한을 가짐
+     */
+    private Authentication createVerificationAuthentication(String email) {
+        // 임시 인증 정보 생성 (이메일만 포함, 권한은 VERIFICATION 으로 제한)
+        List<GrantedAuthority> authorities = Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_VERIFICATION"));
+        
+        return new UsernamePasswordAuthenticationToken(
+                email, "", authorities);
     }
 }
 

--- a/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
@@ -10,6 +10,7 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.util.Date;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.exception.GlobalException;
 import org.ject.support.common.security.CustomUserDetails;
@@ -26,6 +27,12 @@ import static org.ject.support.common.exception.GlobalErrorCode.AUTHENTICATION_R
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
+    /**
+     * -- GETTER --
+     *  JWT 서명에 사용되는 비밀키 반환
+     */
+
+    @Getter
     private final Key secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS512);
     @Value("${spring.jwt.token.access-expiration-time}")
     private long accessExpirationTime;

--- a/src/main/java/org/ject/support/domain/auth/AuthController.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthController.java
@@ -1,11 +1,8 @@
 package org.ject.support.domain.auth;
 
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.ject.support.common.security.jwt.JwtCookieProvider;
-import org.ject.support.domain.auth.AuthDto.AuthCodeResponse;
+import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeRequest;
-import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,18 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
-    private final JwtCookieProvider jwtCookieProvider;
 
+    /**
+     * 인증번호 검증 API
+     * 인증번호 검증만 수행하고 임시 토큰을 발급합니다.
+     */
     @PostMapping("/code")
     @PreAuthorize("permitAll()")
-    public AuthCodeResponse verifyAuthCode(HttpServletResponse response,
-                                           @RequestBody VerifyAuthCodeRequest request) {
-        AuthCodeResponse authResponse = authService.verifyEmailByAuthCode(request.name(), request.email(),
-                request.phoneNumber(), request.authCode());
-
-        response.addCookie(jwtCookieProvider.createAccessCookie(authResponse.accessToken()));
-        response.addCookie(jwtCookieProvider.createRefreshCookie(authResponse.refreshToken()));
-
-        return authResponse;
+    public VerifyAuthCodeOnlyResponse verifyAuthCode(@RequestBody VerifyAuthCodeRequest request) {
+        return authService.verifyEmailByAuthCodeOnly(request.email(), request.authCode());
     }
 }

--- a/src/main/java/org/ject/support/domain/auth/AuthDto.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthDto.java
@@ -2,9 +2,11 @@ package org.ject.support.domain.auth;
 
 public class AuthDto {
 
-    public record VerifyAuthCodeRequest(String name, String email, String phoneNumber, String authCode) {
+    public record VerifyAuthCodeRequest(String email, String authCode) {
+        // 이메일 인증 코드 검증 요청 DTO
     }
 
-    public record AuthCodeResponse(String accessToken, String refreshToken) {
+    public record VerifyAuthCodeOnlyResponse(String verificationToken) {
+        // 인증번호 검증 성공 시 발급되는 임시 토큰
     }
 }

--- a/src/main/java/org/ject/support/domain/auth/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthService.java
@@ -6,12 +6,8 @@ import static org.ject.support.domain.auth.AuthErrorCode.NOT_FOUND_AUTH_CODE;
 
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
-import org.ject.support.domain.auth.AuthDto.AuthCodeResponse;
-import org.ject.support.domain.member.dto.MemberDto.TempMemberJoinRequest;
-import org.ject.support.domain.member.entity.Member;
-import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,31 +15,30 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final RedisTemplate<String, String> redisTemplate;
-    private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthCodeResponse verifyEmailByAuthCode(String name, String email,
-                                                  String phoneNumber, String userInputCode) {
+    /**
+     * 인증번호 검증만 수행하고 임시 토큰을 발급합니다.
+     * 이메일 인증 -> 인증번호 입력 단계에서 호출됩니다.
+     * 인증번호 검증이 성공하면 임시 토큰을 발급하여 반환합니다.
+     * 이 토큰은 사용자 정보를 포함하지 않고, 인증번호 검증이 완료되었음을 증명하는 용도로만 사용됩니다.
+     * 
+     * @param email 인증할 이메일 주소
+     * @param userInputCode 사용자가 입력한 인증번호
+     * @return 임시 인증 토큰이 포함된 응답 객체
+     */
+    public VerifyAuthCodeOnlyResponse verifyEmailByAuthCodeOnly(String email, String userInputCode) {
+        // 인증번호 검증
         verifyAuthCode(email, userInputCode);
-
-        Member member = memberRepository.findByEmail(email).orElse(null);
-        if (member == null) {
-            member = createTempMember(name, email, phoneNumber);
-        }
-
-        Authentication authentication = jwtTokenProvider.createAuthenticationByMember(member);
-        String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
-        String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
-
-        return new AuthCodeResponse(accessToken, refreshToken);
+        
+        // 임시 토큰 발급 - 인증번호 검증이 완료되었음을 증명하는 토큰
+        String verificationToken = jwtTokenProvider.createVerificationToken(email);
+        
+        // 임시 토큰 반환
+        return new VerifyAuthCodeOnlyResponse(verificationToken);
     }
 
-    private Member createTempMember(String name,  String email, String phoneNumber) {
-        Member member = TempMemberJoinRequest.toEntity(name, email, phoneNumber);
-        return memberRepository.save(member);
-    }
-
-    public void verifyAuthCode(String email, String userInputCode) {
+    private void verifyAuthCode(String email, String userInputCode) {
         // redis에서 키 값으로 인증 번호 조회
         String redisCode = redisTemplate.opsForValue().get(email);
 

--- a/src/main/java/org/ject/support/domain/member/controller/MemberController.java
+++ b/src/main/java/org/ject/support/domain/member/controller/MemberController.java
@@ -2,17 +2,14 @@ package org.ject.support.domain.member.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.ject.support.common.security.jwt.JwtCookieProvider;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
 import org.ject.support.domain.member.dto.MemberDto;
 import org.ject.support.domain.member.dto.MemberDto.RegisterResponse;
 import org.ject.support.domain.member.service.MemberService;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,7 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
-    private final JwtCookieProvider jwtCookieProvider;
     private final JwtTokenProvider jwtTokenProvider;
 
     /**
@@ -29,8 +25,7 @@ public class MemberController {
      * 인증번호 검증 후 발급받은 토큰을 통해 인증된 사용자만 접근 가능합니다.
      * PIN 번호를 암호화하여 임시 회원을 생성합니다.
      */
-    @PostMapping("/register")
-    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping()
     public RegisterResponse registerMember(@RequestHeader("Authorization") String authorizationHeader,
                                            @Valid @RequestBody MemberDto.RegisterRequest request) {
 

--- a/src/main/java/org/ject/support/domain/member/controller/MemberController.java
+++ b/src/main/java/org/ject/support/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import org.ject.support.common.security.jwt.JwtTokenProvider;
 import org.ject.support.domain.member.dto.MemberDto;
 import org.ject.support.domain.member.dto.MemberDto.RegisterResponse;
 import org.ject.support.domain.member.service.MemberService;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -25,7 +26,8 @@ public class MemberController {
      * 인증번호 검증 후 발급받은 토큰을 통해 인증된 사용자만 접근 가능합니다.
      * PIN 번호를 암호화하여 임시 회원을 생성합니다.
      */
-    @PostMapping()
+    @PostMapping
+    @PreAuthorize("hasRole('ROLE_VERIFICATION')")
     public RegisterResponse registerMember(@RequestHeader("Authorization") String authorizationHeader,
                                            @Valid @RequestBody MemberDto.RegisterRequest request) {
 

--- a/src/main/java/org/ject/support/domain/member/controller/MemberController.java
+++ b/src/main/java/org/ject/support/domain/member/controller/MemberController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/member")
+@RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController {
 

--- a/src/main/java/org/ject/support/domain/member/controller/MemberController.java
+++ b/src/main/java/org/ject/support/domain/member/controller/MemberController.java
@@ -1,0 +1,44 @@
+package org.ject.support.domain.member.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.common.security.jwt.JwtCookieProvider;
+import org.ject.support.common.security.jwt.JwtTokenProvider;
+import org.ject.support.domain.member.dto.MemberDto;
+import org.ject.support.domain.member.dto.MemberDto.RegisterResponse;
+import org.ject.support.domain.member.service.MemberService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+    private final JwtCookieProvider jwtCookieProvider;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 회원 등록 API
+     * 인증번호 검증 후 발급받은 토큰을 통해 인증된 사용자만 접근 가능합니다.
+     * PIN 번호를 암호화하여 임시 회원을 생성합니다.
+     */
+    @PostMapping("/register")
+    @ResponseStatus(HttpStatus.CREATED)
+    public RegisterResponse registerMember(@RequestHeader("Authorization") String authorizationHeader,
+                                           @Valid @RequestBody MemberDto.RegisterRequest request) {
+
+        // 인증 토큰에서 이메일 추출
+        String token = authorizationHeader.substring(7); // "Bearer " 제거
+        String email = jwtTokenProvider.extractEmailFromVerificationToken(token);
+
+        // 임시 회원 생성 및 토큰 발급
+        return memberService.registerTempMember(request, email);
+    }
+}

--- a/src/main/java/org/ject/support/domain/member/dto/MemberDto.java
+++ b/src/main/java/org/ject/support/domain/member/dto/MemberDto.java
@@ -1,43 +1,32 @@
 package org.ject.support.domain.member.dto;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 
 public class MemberDto {
 
-    @Data
-    @Builder
-    @AllArgsConstructor
-    public static class TempMemberJoinRequest {
+    public record RegisterRequest (
 
-        @NotBlank
-        @Pattern(regexp = "^[가-힣]{1,5}$", message = "한글 1~5글자만 입력 가능합니다.")
-        private String name;
+            @NotBlank @Pattern(regexp = "^[가-힣]{1,5}$", message = "한글 1~5글자만 입력 가능합니다.")
+            String name,
 
-        @NotBlank
-        @Pattern(regexp = "^010\\d{8}$", message = "010으로 시작하는 11자리 숫자를 입력하세요.")
-        private String phoneNumber;
+            @NotBlank @Pattern(regexp = "^010\\d{8}$", message = "010으로 시작하는 11자리 숫자를 입력하세요.")
+            String phoneNumber,
+            @NotBlank @Pattern(regexp = "^\\d{6}$", message = "PIN 번호는 6자리 숫자여야 합니다.") String pin) {
 
-        @NotNull
-        @Size(max = 30)
-        @Email(regexp = "^[a-zA-Z0-9._%+-]{1,20}@[a-zA-Z0-9.-]{1,10}\\.[a-zA-Z]{2,}$")
-        private String email;
-
-        public static Member toEntity(String name, String email, String phoneNumber) {
+        public Member toEntity(String email, String encodedPin) {
             return Member.builder()
                     .name(name)
                     .phoneNumber(phoneNumber)
                     .email(email)
+                    .pin(encodedPin)
                     .role(Role.TEMP)
                     .build();
         }
+    }
+
+    public record RegisterResponse(String accessToken, String refreshToken) {
     }
 }

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -51,6 +51,9 @@ public class Member extends BaseTimeEntity {
     @Column(columnDefinition = "varchar(10)", nullable = false)
     private Role role;
 
+    @Column(length = 255)
+    private String pin;
+
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     @Builder.Default
     private List<TeamMember> teamMembers = new ArrayList<>();

--- a/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
@@ -7,7 +7,8 @@ import org.ject.support.common.exception.ErrorCode;
 @Getter
 @AllArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
-    NOT_FOUND_MEMBER("NOT_FOUND_MEMBER", "멤버를 찾을 수 없습니다.");
+    NOT_FOUND_MEMBER("NOT_FOUND_MEMBER", "멤버를 찾을 수 없습니다."),
+    ALREADY_EXIST_MEMBER("ALREADY_EXIST_MEMBER", "이미 가입되어 있는 회원입니다.");
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/domain/member/service/MemberService.java
+++ b/src/main/java/org/ject/support/domain/member/service/MemberService.java
@@ -55,7 +55,7 @@ public class MemberService {
      */
     private Member createTempMemberWithPin(RegisterRequest registerRequest, String email) {
         String encodedPin = passwordEncoder.encode(registerRequest.pin());
-        Member member = registerRequest.toEntity(encodedPin, email);
+        Member member = registerRequest.toEntity(email, encodedPin);
         return memberRepository.save(member);
     }
 }

--- a/src/main/java/org/ject/support/domain/member/service/MemberService.java
+++ b/src/main/java/org/ject/support/domain/member/service/MemberService.java
@@ -1,0 +1,61 @@
+package org.ject.support.domain.member.service;
+
+import static org.ject.support.domain.member.exception.MemberErrorCode.ALREADY_EXIST_MEMBER;
+
+import lombok.RequiredArgsConstructor;
+import org.ject.support.common.security.jwt.JwtTokenProvider;
+import org.ject.support.domain.member.dto.MemberDto.RegisterRequest;
+import org.ject.support.domain.member.dto.MemberDto.RegisterResponse;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.exception.MemberException;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 인증된 사용자의 PIN 번호를 설정하고 임시 회원을 생성합니다.
+     * 인증번호 검증 -> PIN 번호 설정 -> 임시 회원 생성 단계에서 호출됩니다.
+     * 인증 토큰을 통해 검증된 이메일로 회원을 조회하고, PIN 번호를 암호화하여 저장합니다.
+     */
+    @Transactional
+    public RegisterResponse registerTempMember(RegisterRequest registerRequest, String email) {
+        // 이메일로 회원 조회
+        Member member = memberRepository.findByEmail(email)
+                .orElse(null);
+
+        if (member == null) {
+            // 새로운 회원 생성
+            member = createTempMemberWithPin(registerRequest, email);
+        } else {
+            // 기존 회원이 있는 경우 PIN 번호만 업데이트
+            throw new MemberException(ALREADY_EXIST_MEMBER);
+        }
+
+        // 인증 및 토큰 발급
+        Authentication authentication = jwtTokenProvider.createAuthenticationByMember(member);
+        String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
+
+        return new RegisterResponse(accessToken, refreshToken);
+    }
+
+    /**
+     * PIN 번호가 설정된 임시 회원을 생성합니다.
+     * PIN 번호는 암호화하여 저장합니다.
+     */
+    private Member createTempMemberWithPin(RegisterRequest registerRequest, String email) {
+        String encodedPin = passwordEncoder.encode(registerRequest.pin());
+        Member member = registerRequest.toEntity(encodedPin, email);
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/org/ject/support/external/email/EmailController.java
+++ b/src/main/java/org/ject/support/external/email/EmailController.java
@@ -16,7 +16,7 @@ public class EmailController {
     private final EmailAuthService authEmailService;
 
     @PostMapping("/send/auth")
-    @PreAuthorize("permitAll()") // TODO: PostAuthorize 설정 추가
+    @PreAuthorize("permitAll()")
     public void sendAuthEmail(@RequestParam String email) {
         authEmailService.sendAuthCode(email);
     }

--- a/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
@@ -4,18 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.ject.support.domain.auth.AuthErrorCode.INVALID_AUTH_CODE;
 import static org.ject.support.domain.auth.AuthErrorCode.NOT_FOUND_AUTH_CODE;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
-import org.ject.support.domain.auth.AuthDto.AuthCodeResponse;
-import org.ject.support.domain.member.entity.Member;
-import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +19,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.security.core.Authentication;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -37,19 +30,14 @@ class AuthServiceTest {
     private RedisTemplate<String, String> redisTemplate;
 
     @Mock
-    private MemberRepository memberRepository;
-
-    @Mock
     private JwtTokenProvider jwtTokenProvider;
+    
     @Mock
     private ValueOperations<String, String> valueOperations;
 
-    private final String TEST_NAME = "test";
     private final String TEST_EMAIL = "test@example.com";
-    private final String TEST_PHONE_NUMBER = "01012345678";
     private final String TEST_AUTH_CODE = "123456";
-    private final String TEST_ACCESS_TOKEN = "test.access.token";
-    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
+    private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
 
     @BeforeEach
     void setUp() {
@@ -57,66 +45,29 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("이메일 인증 코드 검증 성공 - 신규 회원")
-    void verifyEmailByAuthCode_NewMember_Success() {
+    @DisplayName("이메일 인증 코드 검증 성공 - 인증 토큰 발급")
+    void verifyEmailByAuthCodeOnly_Success() {
         // given
-        Authentication authentication = mock(Authentication.class);
-        Member newMember = Member.builder()
-                .name(TEST_NAME)
-                .email(TEST_EMAIL)
-                .phoneNumber(TEST_PHONE_NUMBER)
-                .build();
-
         given(valueOperations.get(TEST_EMAIL)).willReturn(TEST_AUTH_CODE);
-        given(memberRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.empty());
-        given(memberRepository.save(any(Member.class))).willReturn(newMember);
-        given(jwtTokenProvider.createAuthenticationByMember(any(Member.class))).willReturn(authentication);
-        given(jwtTokenProvider.createAccessToken(any(), any())).willReturn(TEST_ACCESS_TOKEN);
-        given(jwtTokenProvider.createRefreshToken(any())).willReturn(TEST_REFRESH_TOKEN);
+        given(jwtTokenProvider.createVerificationToken(TEST_EMAIL)).willReturn(TEST_VERIFICATION_TOKEN);
 
         // when
-        AuthCodeResponse result = authService.verifyEmailByAuthCode(TEST_NAME, TEST_EMAIL,
-                TEST_PHONE_NUMBER, TEST_AUTH_CODE);
+        VerifyAuthCodeOnlyResponse result = authService.verifyEmailByAuthCodeOnly(TEST_EMAIL, TEST_AUTH_CODE);
 
         // then
-        assertThat(result.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
-        assertThat(result.refreshToken()).isEqualTo(TEST_REFRESH_TOKEN);
-        verify(redisTemplate).delete(TEST_EMAIL);
-    }
-
-    @Test
-    @DisplayName("이메일 인증 코드 검증 성공 - 기존 회원")
-    void verifyEmailByAuthCode_ExistingMember_Success() {
-        // given
-        Authentication authentication = mock(Authentication.class);
-        Member existingMember = Member.builder()
-            .email(TEST_EMAIL)
-            .build();
-
-        given(valueOperations.get(TEST_EMAIL)).willReturn(TEST_AUTH_CODE);
-        given(memberRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(existingMember));
-        given(jwtTokenProvider.createAuthenticationByMember(any(Member.class))).willReturn(authentication);
-        given(jwtTokenProvider.createAccessToken(any(), any())).willReturn(TEST_ACCESS_TOKEN);
-        given(jwtTokenProvider.createRefreshToken(any())).willReturn(TEST_REFRESH_TOKEN);
-
-        // when
-        AuthCodeResponse result = authService.verifyEmailByAuthCode(TEST_NAME, TEST_EMAIL,
-                TEST_PHONE_NUMBER, TEST_AUTH_CODE);
-        // then
-        assertThat(result.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
-        assertThat(result.refreshToken()).isEqualTo(TEST_REFRESH_TOKEN);
-        verify(redisTemplate).delete(TEST_EMAIL);
+        assertThat(result.verificationToken()).isEqualTo(TEST_VERIFICATION_TOKEN);
+        // 인증 코드 검증 후에는 Redis에서 코드를 삭제하지 않음 (이전과 다른 점)
     }
 
     @Test
     @DisplayName("인증 코드 검증 실패 - 잘못된 코드")
-    void verifyAuthCode_InvalidCode_ThrowsException() {
+    void verifyEmailByAuthCodeOnly_InvalidCode_ThrowsException() {
         // given
         String wrongCode = "wrong_code";
         given(valueOperations.get(anyString())).willReturn(TEST_AUTH_CODE);
 
         // when & then
-        assertThatThrownBy(() -> authService.verifyAuthCode(TEST_EMAIL, wrongCode))
+        assertThatThrownBy(() -> authService.verifyEmailByAuthCodeOnly(TEST_EMAIL, wrongCode))
             .isInstanceOf(AuthException.class)
             .extracting(e -> ((AuthException) e).getErrorCode())
             .isEqualTo(INVALID_AUTH_CODE);
@@ -124,12 +75,12 @@ class AuthServiceTest {
 
     @Test
     @DisplayName("인증 코드 검증 실패 - 만료된 코드")
-    void verifyAuthCode_ExpiredCode_ThrowsException() {
+    void verifyEmailByAuthCodeOnly_ExpiredCode_ThrowsException() {
         // given
         given(valueOperations.get(anyString())).willReturn(null);
 
         // when & then
-        assertThatThrownBy(() -> authService.verifyAuthCode(TEST_EMAIL, TEST_AUTH_CODE))
+        assertThatThrownBy(() -> authService.verifyEmailByAuthCodeOnly(TEST_EMAIL, TEST_AUTH_CODE))
             .isInstanceOf(AuthException.class)
             .extracting(e -> ((AuthException) e).getErrorCode())
             .isEqualTo(NOT_FOUND_AUTH_CODE);

--- a/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
@@ -70,7 +70,7 @@ class MemberControllerTest {
         given(memberService.registerTempMember(any(RegisterRequest.class), anyString())).willReturn(response);
 
         // when & then
-        mockMvc.perform(post("/member/register")
+        mockMvc.perform(post("/member")
                 .header("Authorization", "Bearer " + TEST_VERIFICATION_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
@@ -94,23 +94,14 @@ class MemberControllerIntegrationTest extends ApplicationPeriodTest {
     @Autowired
     private ObjectMapper objectMapper;
     
-    @Autowired
-    private MemberService memberService;
-    
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
-    
     @BeforeEach
     void setUp() {
         // 실제 서비스를 사용하는 통합 테스트
     }
     
     private final String TEST_NAME = "홍길동";
-    private final String TEST_EMAIL = "test@example.com";
     private final String TEST_PHONE_NUMBER = "01012345678";
     private final String TEST_PIN = "123456";
-    private final String TEST_ACCESS_TOKEN = "test.access.token";
-    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
     private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
     
     @Test
@@ -123,7 +114,7 @@ class MemberControllerIntegrationTest extends ApplicationPeriodTest {
         // 대신 응답 구조만 확인
         
         // when & then
-        mockMvc.perform(post("/member/register")
+        mockMvc.perform(post("/member")
                 .header("Authorization", "Bearer " + TEST_VERIFICATION_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
@@ -70,13 +70,13 @@ class MemberControllerTest {
         given(memberService.registerTempMember(any(RegisterRequest.class), anyString())).willReturn(response);
 
         // when & then
-        mockMvc.perform(post("/member")
+        mockMvc.perform(post("/members")
                 .header("Authorization", "Bearer " + TEST_VERIFICATION_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.accessToken").value(TEST_ACCESS_TOKEN))
-                .andExpect(jsonPath("$.refreshToken").value(TEST_REFRESH_TOKEN));
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.refreshToken").exists());
         
         verify(jwtTokenProvider).extractEmailFromVerificationToken(TEST_VERIFICATION_TOKEN);
         verify(memberService).registerTempMember(any(RegisterRequest.class), anyString());
@@ -114,7 +114,7 @@ class MemberControllerIntegrationTest extends ApplicationPeriodTest {
         // 대신 응답 구조만 확인
         
         // when & then
-        mockMvc.perform(post("/member")
+        mockMvc.perform(post("/members")
                 .header("Authorization", "Bearer " + TEST_VERIFICATION_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,134 @@
+package org.ject.support.domain.member.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.ject.support.common.security.jwt.JwtTokenProvider;
+import org.ject.support.domain.member.dto.MemberDto.RegisterRequest;
+import org.ject.support.domain.member.dto.MemberDto.RegisterResponse;
+import org.ject.support.domain.member.service.MemberService;
+import org.ject.support.testconfig.ApplicationPeriodTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class MemberControllerTest {
+
+    @InjectMocks
+    private MemberController memberController;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    private final String TEST_NAME = "홍길동";
+    private final String TEST_EMAIL = "test@example.com";
+    private final String TEST_PHONE_NUMBER = "01012345678";
+    private final String TEST_PIN = "123456";
+    private final String TEST_ACCESS_TOKEN = "test.access.token";
+    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
+    private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        mockMvc = MockMvcBuilders.standaloneSetup(memberController).build();
+    }
+
+    @Test
+    @DisplayName("회원 등록 성공")
+    void registerMember_Success() throws Exception {
+        // given
+        RegisterRequest request = new RegisterRequest(TEST_NAME, TEST_PHONE_NUMBER, TEST_PIN);
+        RegisterResponse response = new RegisterResponse(TEST_ACCESS_TOKEN, TEST_REFRESH_TOKEN);
+        
+        given(jwtTokenProvider.extractEmailFromVerificationToken(TEST_VERIFICATION_TOKEN)).willReturn(TEST_EMAIL);
+        given(memberService.registerTempMember(any(RegisterRequest.class), anyString())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/member/register")
+                .header("Authorization", "Bearer " + TEST_VERIFICATION_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value(TEST_ACCESS_TOKEN))
+                .andExpect(jsonPath("$.refreshToken").value(TEST_REFRESH_TOKEN));
+        
+        verify(jwtTokenProvider).extractEmailFromVerificationToken(TEST_VERIFICATION_TOKEN);
+        verify(memberService).registerTempMember(any(RegisterRequest.class), anyString());
+    }
+}
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false", "server.port=0"})
+class MemberControllerIntegrationTest extends ApplicationPeriodTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @Autowired
+    private MemberService memberService;
+    
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+    
+    @BeforeEach
+    void setUp() {
+        // 실제 서비스를 사용하는 통합 테스트
+    }
+    
+    private final String TEST_NAME = "홍길동";
+    private final String TEST_EMAIL = "test@example.com";
+    private final String TEST_PHONE_NUMBER = "01012345678";
+    private final String TEST_PIN = "123456";
+    private final String TEST_ACCESS_TOKEN = "test.access.token";
+    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
+    private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
+    
+    @Test
+    @DisplayName("회원 등록 API 통합 테스트")
+    void registerMember_Integration() throws Exception {
+        // given
+        RegisterRequest request = new RegisterRequest(TEST_NAME, TEST_PHONE_NUMBER, TEST_PIN);
+        
+        // 실제 서비스를 사용하므로 모킹하지 않음
+        // 대신 응답 구조만 확인
+        
+        // when & then
+        mockMvc.perform(post("/member/register")
+                .header("Authorization", "Bearer " + TEST_VERIFICATION_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").exists());
+        // 실제 응답 값은 테스트마다 다를 수 있으므로 구조만 확인
+    }
+}

--- a/src/test/java/org/ject/support/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/ject/support/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,108 @@
+package org.ject.support.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+
+import org.ject.support.common.security.jwt.JwtTokenProvider;
+import org.ject.support.domain.member.dto.MemberDto.RegisterRequest;
+import org.ject.support.domain.member.dto.MemberDto.RegisterResponse;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.exception.MemberErrorCode;
+import org.ject.support.domain.member.exception.MemberException;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private Authentication authentication;
+
+    private final String TEST_NAME = "홍길동";
+    private final String TEST_EMAIL = "test@example.com";
+    private final String TEST_PHONE_NUMBER = "01012345678";
+    private final String TEST_PIN = "123456";
+    private final String TEST_ENCODED_PIN = "encoded_pin";
+    private final String TEST_ACCESS_TOKEN = "test.access.token";
+    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
+
+    @BeforeEach
+    void setUp() {
+        // 기본 설정
+    }
+
+    @Test
+    @DisplayName("임시 회원 등록 성공")
+    void registerTempMember_Success() {
+        // given
+        RegisterRequest request = new RegisterRequest(TEST_NAME, TEST_PHONE_NUMBER, TEST_PIN);
+        Member member = Member.builder()
+                .name(TEST_NAME)
+                .phoneNumber(TEST_PHONE_NUMBER)
+                .email(TEST_EMAIL)
+                .pin(TEST_ENCODED_PIN)
+                .build();
+
+        given(memberRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.empty());
+        given(passwordEncoder.encode(TEST_PIN)).willReturn(TEST_ENCODED_PIN);
+        given(memberRepository.save(any(Member.class))).willReturn(member);
+        given(jwtTokenProvider.createAuthenticationByMember(any(Member.class))).willReturn(authentication);
+        given(jwtTokenProvider.createAccessToken(any(Authentication.class), any())).willReturn(TEST_ACCESS_TOKEN);
+        given(jwtTokenProvider.createRefreshToken(any(Authentication.class))).willReturn(TEST_REFRESH_TOKEN);
+
+        // when
+        RegisterResponse response = memberService.registerTempMember(request, TEST_EMAIL);
+
+        // then
+        assertThat(response.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+        assertThat(response.refreshToken()).isEqualTo(TEST_REFRESH_TOKEN);
+        verify(memberRepository).save(any(Member.class));
+        verify(passwordEncoder).encode(TEST_PIN);
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 회원인 경우 예외 발생")
+    void registerTempMember_AlreadyExistMember_ThrowsException() {
+        // given
+        RegisterRequest request = new RegisterRequest(TEST_NAME, TEST_PHONE_NUMBER, TEST_PIN);
+        Member existingMember = Member.builder()
+                .name(TEST_NAME)
+                .phoneNumber(TEST_PHONE_NUMBER)
+                .email(TEST_EMAIL)
+                .pin(TEST_ENCODED_PIN)
+                .build();
+
+        given(memberRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(existingMember));
+
+        // when & then
+        assertThatThrownBy(() -> memberService.registerTempMember(request, TEST_EMAIL))
+                .isInstanceOf(MemberException.class)
+                .extracting(e -> ((MemberException) e).getErrorCode())
+                .isEqualTo(MemberErrorCode.ALREADY_EXIST_MEMBER);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #66 
close #67

## 📝작업 내용

- 임시 회원 생성 로직을 MemberService로 분리
- 이메일 인증 성공 시 제한된 접근 권한을 가진 토큰 발급
- PIN 설정 기능 구현
- 임시 회원 생성 API 구현 

## ✅테스트 결과
<img width="339" alt="스크린샷 2025-03-10 오전 3 33 25" src="https://github.com/user-attachments/assets/c6bf4d5b-382d-4bfb-a40e-fd17588ed31c" />

