### PR TITLE
프로젝트 상세 조회 API 응답 필드명 변경(projectManagers -> productManagers)

### DIFF
--- a/src/main/java/org/ject/support/domain/member/dto/TeamMemberNames.java
+++ b/src/main/java/org/ject/support/domain/member/dto/TeamMemberNames.java
@@ -3,7 +3,7 @@ package org.ject.support.domain.member.dto;
 import com.querydsl.core.annotations.QueryProjection;
 import java.util.List;
 
-public record TeamMemberNames(List<String> projectManagers,
+public record TeamMemberNames(List<String> productManagers,
                               List<String> productDesigners,
                               List<String> frontendDevelopers,
                               List<String> backendDevelopers) {

--- a/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
@@ -62,7 +62,7 @@ class MemberQueryRepositoryTest {
         TeamMemberNames teamMemberNames = memberRepository.findMemberNamesByTeamId(1L);
 
         // then
-        assertThat(teamMemberNames.projectManagers()).hasSize(0);
+        assertThat(teamMemberNames.productManagers()).hasSize(0);
         assertThat(teamMemberNames.productDesigners()).hasSize(1);
         assertThat(teamMemberNames.frontendDevelopers()).hasSize(1);
         assertThat(teamMemberNames.backendDevelopers()).hasSize(2);

--- a/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
@@ -86,7 +86,7 @@ class ProjectServiceTest {
         assertThat(result.name()).isEqualTo(project.getName());
         assertThat(result.startDate()).isEqualTo(project.getStartDate());
         assertThat(result.endDate()).isEqualTo(project.getEndDate());
-        assertThat(result.teamMemberNames().projectManagers()).hasSize(0);
+        assertThat(result.teamMemberNames().productManagers()).hasSize(0);
         assertThat(result.teamMemberNames().productDesigners()).hasSize(1);
         assertThat(result.teamMemberNames().frontendDevelopers()).hasSize(2);
         assertThat(result.teamMemberNames().backendDevelopers()).hasSize(3);


### PR DESCRIPTION
## #️⃣연관된 이슈

close #98 

## 📝작업 내용
- 프로젝트 상세 조회 API 응답 필드명 변경(projectManagers -> productManagers)
