### PR TITLE
핀번호 로그인 및 회원 존재 여부 확인 API 구현

### DIFF
--- a/src/main/java/org/ject/support/domain/auth/AuthController.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthController.java
@@ -1,12 +1,17 @@
 package org.ject.support.domain.auth;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.auth.AuthDto.PinLoginRequest;
+import org.ject.support.domain.auth.AuthDto.PinLoginResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeRequest;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,5 +29,21 @@ public class AuthController {
     @PreAuthorize("permitAll()")
     public VerifyAuthCodeOnlyResponse verifyAuthCode(@RequestBody VerifyAuthCodeRequest request) {
         return authService.verifyEmailByAuthCodeOnly(request.email(), request.authCode());
+    }
+    
+    /**
+     * PIN 로그인 API
+     * 이메일과 PIN 번호로 로그인하고 액세스 토큰과 리프레시 토큰을 발급합니다.
+     */
+    @PostMapping("/login/pin")
+    @PreAuthorize("permitAll()")
+    public PinLoginResponse loginWithPin(@RequestBody @Valid PinLoginRequest request) {
+        return authService.loginWithPin(request.email(), request.pin());
+    }
+
+    @GetMapping("/login/exist")
+    @PreAuthorize("permitAll()")
+    public boolean isExistMember(@RequestParam String email) {
+        return authService.isExistMember(email);
     }
 }

--- a/src/main/java/org/ject/support/domain/auth/AuthDto.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthDto.java
@@ -1,5 +1,9 @@
 package org.ject.support.domain.auth;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public class AuthDto {
 
     public record VerifyAuthCodeRequest(String email, String authCode) {
@@ -7,6 +11,16 @@ public class AuthDto {
     }
 
     public record VerifyAuthCodeOnlyResponse(String verificationToken) {
-        // 인증번호 검증 성공 시 발급되는 임시 토큰
+        // 인증번호 검증 성공 시 발급되는 임시 토큰과 기존 회원 여부
+    }
+    
+    public record PinLoginRequest(
+        @NotBlank @Email String email,
+        @NotBlank @Pattern(regexp = "^\\d{6}$", message = "PIN 번호는 6자리 숫자여야 합니다.") String pin) {
+        // PIN 로그인 요청 DTO
+    }
+    
+    public record PinLoginResponse(String accessToken, String refreshToken) {
+        // 로그인 성공 시 발급되는 토큰 응답 DTO
     }
 }

--- a/src/main/java/org/ject/support/domain/auth/AuthErrorCode.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthErrorCode.java
@@ -8,7 +8,8 @@ import org.ject.support.common.exception.ErrorCode;
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
     INVALID_AUTH_CODE("INVALID_AUTH_CODE", "인증 번호가 유효하지 않습니다."),
-    NOT_FOUND_AUTH_CODE("NOT_FOUND_AUTH_CODE", "인증 번호를 찾을 수 없습니다.");
+    NOT_FOUND_AUTH_CODE("NOT_FOUND_AUTH_CODE", "인증 번호를 찾을 수 없습니다."),
+    INVALID_CREDENTIALS("INVALID_CREDENTIALS", "PIN 번호가 올바르지 않습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/org/ject/support/domain/auth/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthService.java
@@ -2,13 +2,22 @@ package org.ject.support.domain.auth;
 
 
 import static org.ject.support.domain.auth.AuthErrorCode.INVALID_AUTH_CODE;
+import static org.ject.support.domain.auth.AuthErrorCode.INVALID_CREDENTIALS;
 import static org.ject.support.domain.auth.AuthErrorCode.NOT_FOUND_AUTH_CODE;
+import static org.ject.support.domain.member.exception.MemberErrorCode.NOT_FOUND_MEMBER;
 
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
+import org.ject.support.domain.auth.AuthDto.PinLoginResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.exception.MemberException;
+import org.ject.support.domain.member.repository.MemberRepository;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,16 +25,18 @@ public class AuthService {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     /**
      * 인증번호 검증만 수행하고 임시 토큰을 발급합니다.
      * 이메일 인증 -> 인증번호 입력 단계에서 호출됩니다.
      * 인증번호 검증이 성공하면 임시 토큰을 발급하여 반환합니다.
      * 이 토큰은 사용자 정보를 포함하지 않고, 인증번호 검증이 완료되었음을 증명하는 용도로만 사용됩니다.
+     * 또한 해당 이메일로 등록된 회원이 있는지 여부를 함께 반환합니다.
      * 
      * @param email 인증할 이메일 주소
      * @param userInputCode 사용자가 입력한 인증번호
-     * @return 임시 인증 토큰이 포함된 응답 객체
      */
     public VerifyAuthCodeOnlyResponse verifyEmailByAuthCodeOnly(String email, String userInputCode) {
         // 인증번호 검증
@@ -33,9 +44,34 @@ public class AuthService {
         
         // 임시 토큰 발급 - 인증번호 검증이 완료되었음을 증명하는 토큰
         String verificationToken = jwtTokenProvider.createVerificationToken(email);
-        
-        // 임시 토큰 반환
+
         return new VerifyAuthCodeOnlyResponse(verificationToken);
+    }
+    
+    /**
+     * PIN 번호를 사용하여 로그인합니다.
+     * 이메일과 PIN 번호를 검증하고, 성공 시 액세스 토큰과 리프레시 토큰을 발급합니다.
+     * 
+     * @param email 사용자 이메일
+     * @param pin 사용자 PIN 번호
+     */
+    @Transactional
+    public PinLoginResponse loginWithPin(String email, String pin) {
+        // 이메일로 회원 조회
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+        
+        // PIN 번호 검증
+        if (!passwordEncoder.matches(pin, member.getPin())) {
+            throw new AuthException(INVALID_CREDENTIALS);
+        }
+        
+        // 인증 및 토큰 발급
+        Authentication authentication = jwtTokenProvider.createAuthenticationByMember(member);
+        String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
+        
+        return new PinLoginResponse(accessToken, refreshToken);
     }
 
     private void verifyAuthCode(String email, String userInputCode) {
@@ -54,5 +90,9 @@ public class AuthService {
 
         // 인증 성공
         redisTemplate.delete(email);
+    }
+
+    public boolean isExistMember(String email) {
+        return memberRepository.existsByEmail(email);
     }
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberQueryRepository {
 
     Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
@@ -1,21 +1,21 @@
 package org.ject.support.domain.auth;
 
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.ject.support.domain.auth.AuthDto.PinLoginRequest;
+import org.ject.support.domain.auth.AuthDto.PinLoginResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeRequest;
 import org.ject.support.testconfig.ApplicationPeriodTest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -37,6 +37,8 @@ class AuthControllerTest {
     private final String TEST_EMAIL = "test@example.com";
     private final String TEST_AUTH_CODE = "123456";
     private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
+    private final String TEST_ACCESS_TOKEN = "test.access.token";
+    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
 
     @Test
     @DisplayName("인증 코드 검증 및 인증 토큰 발급 성공")
@@ -55,12 +57,45 @@ class AuthControllerTest {
         verify(authService).verifyEmailByAuthCodeOnly(TEST_EMAIL, TEST_AUTH_CODE);
         org.assertj.core.api.Assertions.assertThat(result.verificationToken()).isEqualTo(TEST_VERIFICATION_TOKEN);
     }
+    
+    @Test
+    @DisplayName("PIN 로그인 성공")
+    void loginWithPin_Success() {
+        // given
+        PinLoginRequest request = new PinLoginRequest(TEST_EMAIL, TEST_AUTH_CODE);
+        PinLoginResponse response = new PinLoginResponse(TEST_ACCESS_TOKEN, TEST_REFRESH_TOKEN);
+        
+        given(authService.loginWithPin(request.email(), request.pin()))
+            .willReturn(response);
+
+        // when
+        PinLoginResponse result = authController.loginWithPin(request);
+
+        // then
+        verify(authService).loginWithPin(TEST_EMAIL, TEST_AUTH_CODE);
+        org.assertj.core.api.Assertions.assertThat(result.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+        org.assertj.core.api.Assertions.assertThat(result.refreshToken()).isEqualTo(TEST_REFRESH_TOKEN);
+    }
+    
+    @Test
+    @DisplayName("회원 존재 여부 확인 성공")
+    void isExistMember_Success() {
+        // given
+        given(authService.isExistMember(TEST_EMAIL))
+            .willReturn(true);
+
+        // when
+        boolean result = authController.isExistMember(TEST_EMAIL);
+
+        // then
+        verify(authService).isExistMember(TEST_EMAIL);
+        org.assertj.core.api.Assertions.assertThat(result).isTrue();
+    }
 }
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false", "server.port=0"})
-@ExtendWith(MockitoExtension.class)
 class AuthControllerIntegrationTest extends ApplicationPeriodTest {
 
     @Autowired
@@ -68,18 +103,12 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
     
     @Autowired
     private ObjectMapper objectMapper;
-    
-    @Mock
-    private AuthService authService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     private final String TEST_EMAIL = "test@example.com";
     private final String TEST_AUTH_CODE = "123456";
     private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
+    private final String TEST_ACCESS_TOKEN = "test.access.token";
+    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
     
     @Test
     @DisplayName("@PreAuthorize(\"permitAll()\") 설정으로 인증 없이 접근 가능한지 확인")
@@ -87,16 +116,35 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
         // given
         VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE);
         
-        VerifyAuthCodeOnlyResponse response = new VerifyAuthCodeOnlyResponse(TEST_VERIFICATION_TOKEN);
-        
-        given(authService.verifyEmailByAuthCodeOnly(anyString(), anyString()))
-            .willReturn(response);
-        
         // when & then
         // 인증 없이 접근 가능한지 확인 (permitAll 설정)
         mockMvc.perform(post("/auth/code")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+    
+    @Test
+    @DisplayName("PIN 로그인 API 인증 없이 접근 가능한지 확인")
+    void loginWithPin_WithPermitAll_ShouldAllowAccessWithoutAuthentication() throws Exception {
+        // given
+        PinLoginRequest request = new PinLoginRequest(TEST_EMAIL, TEST_AUTH_CODE);
+        
+        // when & then
+        // 인증 없이 접근 가능한지 확인 (permitAll 설정)
+        mockMvc.perform(post("/auth/login/pin")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+    
+    @Test
+    @DisplayName("회원 존재 여부 확인 API 인증 없이 접근 가능한지 확인")
+    void isExistMember_WithPermitAll_ShouldAllowAccessWithoutAuthentication() throws Exception {
+        // when & then
+        // 인증 없이 접근 가능한지 확인 (permitAll 설정)
+        mockMvc.perform(get("/auth/login/exist?email=" + TEST_EMAIL)
+                .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }
 }

--- a/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
@@ -106,9 +106,6 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
 
     private final String TEST_EMAIL = "test@example.com";
     private final String TEST_AUTH_CODE = "123456";
-    private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
-    private final String TEST_ACCESS_TOKEN = "test.access.token";
-    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
     
     @Test
     @DisplayName("@PreAuthorize(\"permitAll()\") 설정으로 인증 없이 접근 가능한지 확인")

--- a/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
@@ -3,13 +3,23 @@ package org.ject.support.domain.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.ject.support.domain.auth.AuthErrorCode.INVALID_AUTH_CODE;
+import static org.ject.support.domain.auth.AuthErrorCode.INVALID_CREDENTIALS;
 import static org.ject.support.domain.auth.AuthErrorCode.NOT_FOUND_AUTH_CODE;
+import static org.ject.support.domain.member.exception.MemberErrorCode.NOT_FOUND_MEMBER;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import org.ject.support.common.security.jwt.JwtTokenProvider;
+import org.ject.support.domain.auth.AuthDto.PinLoginResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.exception.MemberException;
+import org.ject.support.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.core.Authentication;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -34,14 +45,28 @@ class AuthServiceTest {
     
     @Mock
     private ValueOperations<String, String> valueOperations;
+    
+    @Mock
+    private MemberRepository memberRepository;
+    
+    @Mock
+    private Authentication authentication;
+    
+    @Mock
+    private org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
 
     private final String TEST_EMAIL = "test@example.com";
     private final String TEST_AUTH_CODE = "123456";
     private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
+    private final String TEST_PIN = "123456";
+    private final String TEST_ENCODED_PIN = "123456";
+    private final String TEST_ACCESS_TOKEN = "test.access.token";
+    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
+    private final Long TEST_MEMBER_ID = 1L;
 
     @BeforeEach
     void setUp() {
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
     }
 
     @Test
@@ -84,5 +109,90 @@ class AuthServiceTest {
             .isInstanceOf(AuthException.class)
             .extracting(e -> ((AuthException) e).getErrorCode())
             .isEqualTo(NOT_FOUND_AUTH_CODE);
+    }
+    
+    @Test
+    @DisplayName("PIN 로그인 성공")
+    void loginWithPin_Success() {
+        // given
+        Member member = Member.builder()
+                .id(TEST_MEMBER_ID)
+                .email(TEST_EMAIL)
+                .pin(TEST_ENCODED_PIN)
+                .role(Role.USER)
+                .build();
+        
+        given(memberRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(member));
+        given(passwordEncoder.matches(TEST_PIN, TEST_ENCODED_PIN)).willReturn(true);
+        given(jwtTokenProvider.createAuthenticationByMember(member)).willReturn(authentication);
+        given(jwtTokenProvider.createAccessToken(authentication, TEST_MEMBER_ID)).willReturn(TEST_ACCESS_TOKEN);
+        given(jwtTokenProvider.createRefreshToken(authentication)).willReturn(TEST_REFRESH_TOKEN);
+        
+        // when
+        PinLoginResponse response = authService.loginWithPin(TEST_EMAIL, TEST_PIN);
+        
+        // then
+        assertThat(response.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+        assertThat(response.refreshToken()).isEqualTo(TEST_REFRESH_TOKEN);
+    }
+    
+    @Test
+    @DisplayName("PIN 로그인 실패 - 회원 없음")
+    void loginWithPin_MemberNotFound_ThrowsException() {
+        // given
+        given(memberRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.empty());
+        
+        // when & then
+        assertThatThrownBy(() -> authService.loginWithPin(TEST_EMAIL, TEST_PIN))
+            .isInstanceOf(MemberException.class)
+            .extracting(e -> ((MemberException) e).getErrorCode())
+            .isEqualTo(NOT_FOUND_MEMBER);
+    }
+    
+    @Test
+    @DisplayName("PIN 로그인 실패 - 잘못된 PIN")
+    void loginWithPin_InvalidPin_ThrowsException() {
+        // given
+        Member member = Member.builder()
+                .id(TEST_MEMBER_ID)
+                .email(TEST_EMAIL)
+                .pin(TEST_ENCODED_PIN)
+                .role(Role.USER)
+                .build();
+        
+        given(memberRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(member));
+        given(passwordEncoder.matches(TEST_PIN, TEST_ENCODED_PIN)).willReturn(false);
+        
+        // when & then
+        assertThatThrownBy(() -> authService.loginWithPin(TEST_EMAIL, TEST_PIN))
+            .isInstanceOf(AuthException.class)
+            .extracting(e -> ((AuthException) e).getErrorCode())
+            .isEqualTo(INVALID_CREDENTIALS);
+    }
+    
+    @Test
+    @DisplayName("회원 존재 여부 확인 - 회원 존재")
+    void isExistMember_MemberExists_ReturnsTrue() {
+        // given
+        given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(true);
+        
+        // when
+        boolean result = authService.isExistMember(TEST_EMAIL);
+        
+        // then
+        assertThat(result).isTrue();
+    }
+    
+    @Test
+    @DisplayName("회원 존재 여부 확인 - 회원 없음")
+    void isExistMember_MemberNotExists_ReturnsFalse() {
+        // given
+        given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
+        
+        // when
+        boolean result = authService.isExistMember(TEST_EMAIL);
+        
+        // then
+        assertThat(result).isFalse();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #97 

## 📝작업 내용

- 핀번호 로그인 API 구현
- 회원 존재 여부 확인 API 구현

## ✅테스트 결과
![스크린샷 2025-03-14 오전 1 26 59](https://github.com/user-attachments/assets/7cc4d311-489c-4c04-ab5c-19396f3efcf4)

## 🙏리뷰 요구사항(선택)

회원 존재 여부 확인 API의 도메인이 `member` 이어야 하는지 `auth` 이어야 하는지를 꽤 고민했는데,
해당 API는 로그인 과정과 직접적으로 연결되는 API이므로 `auth` 쪽에 두는 것이 더 적절하다고 생각했습니다. 프론트 입장에서도 사용성이 더 높고요.

