### PR TITLE
엑세스 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/common/exception/GlobalErrorCode.java
+++ b/src/main/java/org/ject/support/common/exception/GlobalErrorCode.java
@@ -16,7 +16,7 @@ public enum GlobalErrorCode implements ErrorCode {
     INVALID_PERMISSION("G-08", "Invalid permission"),
     AUTHENTICATION_REQUIRED("G-09", "Authentication is required"),
     INTERNAL_SERVER_ERROR("G-10", "Internal server error"),
-    OVER_PERIOD("G-06", "모집 기간이 아닙니다.");
+    OVER_PERIOD("G-11", "모집 기간이 아닙니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/org/ject/support/domain/auth/AuthController.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthController.java
@@ -42,7 +42,8 @@ public class AuthController {
     @PreAuthorize("hasRole('ROLE_TEMP')")
     public TokenRefreshResponse refreshToken(@AuthPrincipal Long memberId, @RequestBody TokenRefreshRequest request) {
         return authService.refreshAccessToken(memberId, request.refreshToken());
-      
+    }
+
     /**
      * PIN 로그인 API
      * 이메일과 PIN 번호로 로그인하고 액세스 토큰과 리프레시 토큰을 발급합니다.

--- a/src/main/java/org/ject/support/domain/auth/AuthController.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthController.java
@@ -1,6 +1,9 @@
 package org.ject.support.domain.auth;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.security.AuthPrincipal;
+import org.ject.support.domain.auth.AuthDto.TokenRefreshRequest;
+import org.ject.support.domain.auth.AuthDto.TokenRefreshResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeRequest;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -24,5 +27,15 @@ public class AuthController {
     @PreAuthorize("permitAll()")
     public VerifyAuthCodeOnlyResponse verifyAuthCode(@RequestBody VerifyAuthCodeRequest request) {
         return authService.verifyEmailByAuthCodeOnly(request.email(), request.authCode());
+    }
+    
+    /**
+     * 리프레시 토큰을 이용한 액세스 토큰 재발급 API
+     * 리프레시 토큰이 유효한 경우 새로운 액세스 토큰을 발급합니다.
+     */
+    @PostMapping("/refresh")
+    @PreAuthorize("hasRole('ROLE_TEMP')")
+    public TokenRefreshResponse refreshToken(@AuthPrincipal Long memberId, @RequestBody TokenRefreshRequest request) {
+        return authService.refreshAccessToken(memberId, request.refreshToken());
     }
 }

--- a/src/main/java/org/ject/support/domain/auth/AuthDto.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthDto.java
@@ -9,4 +9,12 @@ public class AuthDto {
     public record VerifyAuthCodeOnlyResponse(String verificationToken) {
         // 인증번호 검증 성공 시 발급되는 임시 토큰
     }
+    
+    public record TokenRefreshRequest(String refreshToken) {
+        // 토큰 재발급 요청 DTO
+    }
+    
+    public record TokenRefreshResponse(String accessToken) {
+        // 토큰 재발급 응답 DTO
+    }
 }

--- a/src/main/java/org/ject/support/domain/auth/AuthErrorCode.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthErrorCode.java
@@ -8,7 +8,9 @@ import org.ject.support.common.exception.ErrorCode;
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
     INVALID_AUTH_CODE("INVALID_AUTH_CODE", "인증 번호가 유효하지 않습니다."),
-    NOT_FOUND_AUTH_CODE("NOT_FOUND_AUTH_CODE", "인증 번호를 찾을 수 없습니다.");
+    NOT_FOUND_AUTH_CODE("NOT_FOUND_AUTH_CODE", "인증 번호를 찾을 수 없습니다."),
+    INVALID_REFRESH_TOKEN("INVALID_REFRESH_TOKEN", "유효하지 않은 리프레시 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN("EXPIRED_REFRESH_TOKEN", "만료된 리프레시 토큰입니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/org/ject/support/domain/auth/AuthErrorCode.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthErrorCode.java
@@ -10,7 +10,7 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_AUTH_CODE("INVALID_AUTH_CODE", "인증 번호가 유효하지 않습니다."),
     NOT_FOUND_AUTH_CODE("NOT_FOUND_AUTH_CODE", "인증 번호를 찾을 수 없습니다."),
     INVALID_REFRESH_TOKEN("INVALID_REFRESH_TOKEN", "유효하지 않은 리프레시 토큰입니다."),
-    EXPIRED_REFRESH_TOKEN("EXPIRED_REFRESH_TOKEN", "만료된 리프레시 토큰입니다.");
+    EXPIRED_REFRESH_TOKEN("EXPIRED_REFRESH_TOKEN", "만료된 리프레시 토큰입니다."),
     INVALID_CREDENTIALS("INVALID_CREDENTIALS", "PIN 번호가 올바르지 않습니다.");
 
     private final String code;

--- a/src/main/java/org/ject/support/domain/auth/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthService.java
@@ -1,14 +1,20 @@
 package org.ject.support.domain.auth;
 
 
+import static org.ject.support.domain.auth.AuthErrorCode.EXPIRED_REFRESH_TOKEN;
 import static org.ject.support.domain.auth.AuthErrorCode.INVALID_AUTH_CODE;
+import static org.ject.support.domain.auth.AuthErrorCode.INVALID_REFRESH_TOKEN;
 import static org.ject.support.domain.auth.AuthErrorCode.NOT_FOUND_AUTH_CODE;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
+import org.ject.support.domain.auth.AuthDto.TokenRefreshResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,23 +23,25 @@ public class AuthService {
     private final RedisTemplate<String, String> redisTemplate;
     private final JwtTokenProvider jwtTokenProvider;
 
+
     /**
      * 인증번호 검증만 수행하고 임시 토큰을 발급합니다.
      * 이메일 인증 -> 인증번호 입력 단계에서 호출됩니다.
      * 인증번호 검증이 성공하면 임시 토큰을 발급하여 반환합니다.
      * 이 토큰은 사용자 정보를 포함하지 않고, 인증번호 검증이 완료되었음을 증명하는 용도로만 사용됩니다.
-     * 
+     *
      * @param email 인증할 이메일 주소
      * @param userInputCode 사용자가 입력한 인증번호
      * @return 임시 인증 토큰이 포함된 응답 객체
      */
+    @Transactional
     public VerifyAuthCodeOnlyResponse verifyEmailByAuthCodeOnly(String email, String userInputCode) {
         // 인증번호 검증
         verifyAuthCode(email, userInputCode);
-        
+
         // 임시 토큰 발급 - 인증번호 검증이 완료되었음을 증명하는 토큰
         String verificationToken = jwtTokenProvider.createVerificationToken(email);
-        
+
         // 임시 토큰 반환
         return new VerifyAuthCodeOnlyResponse(verificationToken);
     }
@@ -54,5 +62,31 @@ public class AuthService {
 
         // 인증 성공
         redisTemplate.delete(email);
+    }
+
+    /**
+     * 리프레시 토큰을 검증하고 새로운 액세스 토큰을 발급합니다.
+     *
+     * @param refreshToken 리프레시 토큰
+     * @return 새로 발급된 액세스 토큰이 포함된 응답 객체
+     * @throws AuthException 리프레시 토큰이 유효하지 않거나 만료된 경우
+     */
+    @Transactional
+    public TokenRefreshResponse refreshAccessToken(Long memberId, String refreshToken) {
+        try {
+            // 리프레시 토큰 유효성 검증
+            if (!jwtTokenProvider.validateToken(refreshToken)) {
+                throw new AuthException(INVALID_REFRESH_TOKEN);
+            }
+            
+            // 새 액세스 토큰 발급
+            String newAccessToken = jwtTokenProvider.reissueAccessToken(refreshToken, memberId);
+            
+            return new TokenRefreshResponse(newAccessToken);
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(EXPIRED_REFRESH_TOKEN);
+        } catch (JwtException e) {
+            throw new AuthException(INVALID_REFRESH_TOKEN);
+        }
     }
 }

--- a/src/main/java/org/ject/support/domain/auth/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthService.java
@@ -112,17 +112,18 @@ public class AuthService {
             if (!jwtTokenProvider.validateToken(refreshToken)) {
                 throw new AuthException(INVALID_REFRESH_TOKEN);
             }
-            
+
             // 새 액세스 토큰 발급
             String newAccessToken = jwtTokenProvider.reissueAccessToken(refreshToken, memberId);
-            
+
             return new TokenRefreshResponse(newAccessToken);
         } catch (ExpiredJwtException e) {
             throw new AuthException(EXPIRED_REFRESH_TOKEN);
         } catch (JwtException e) {
             throw new AuthException(INVALID_REFRESH_TOKEN);
         }
-      
+    }
+
     public boolean isExistMember(String email) {
         return memberRepository.existsByEmail(email);
     }

--- a/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
@@ -1,21 +1,21 @@
 package org.ject.support.domain.auth;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.ject.support.domain.auth.AuthDto.TokenRefreshRequest;
+import org.ject.support.domain.auth.AuthDto.TokenRefreshResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeRequest;
 import org.ject.support.testconfig.ApplicationPeriodTest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -37,6 +37,9 @@ class AuthControllerTest {
     private final String TEST_EMAIL = "test@example.com";
     private final String TEST_AUTH_CODE = "123456";
     private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
+    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
+    private final String TEST_ACCESS_TOKEN = "test.access.token";
+    private final Long TEST_MEMBER_ID = 1L;
 
     @Test
     @DisplayName("인증 코드 검증 및 인증 토큰 발급 성공")
@@ -53,14 +56,31 @@ class AuthControllerTest {
 
         // then
         verify(authService).verifyEmailByAuthCodeOnly(TEST_EMAIL, TEST_AUTH_CODE);
-        org.assertj.core.api.Assertions.assertThat(result.verificationToken()).isEqualTo(TEST_VERIFICATION_TOKEN);
+        assertThat(result.verificationToken()).isEqualTo(TEST_VERIFICATION_TOKEN);
+    }
+    
+    @Test
+    @DisplayName("리프레시 토큰을 사용한 액세스 토큰 재발급 성공")
+    void refreshToken_Success() {
+        // given
+        TokenRefreshRequest request = new TokenRefreshRequest(TEST_REFRESH_TOKEN);
+        TokenRefreshResponse response = new TokenRefreshResponse(TEST_ACCESS_TOKEN);
+        
+        given(authService.refreshAccessToken(TEST_MEMBER_ID, request.refreshToken()))
+            .willReturn(response);
+
+        // when
+        TokenRefreshResponse result = authController.refreshToken(TEST_MEMBER_ID, request);
+
+        // then
+        verify(authService).refreshAccessToken(TEST_MEMBER_ID, TEST_REFRESH_TOKEN);
+        assertThat(result.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
     }
 }
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = true)
 @TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false", "server.port=0"})
-@ExtendWith(MockitoExtension.class)
 class AuthControllerIntegrationTest extends ApplicationPeriodTest {
 
     @Autowired
@@ -68,18 +88,10 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
     
     @Autowired
     private ObjectMapper objectMapper;
-    
-    @Mock
-    private AuthService authService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     private final String TEST_EMAIL = "test@example.com";
     private final String TEST_AUTH_CODE = "123456";
-    private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
+    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
     
     @Test
     @DisplayName("@PreAuthorize(\"permitAll()\") 설정으로 인증 없이 접근 가능한지 확인")
@@ -87,14 +99,23 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
         // given
         VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE);
         
-        VerifyAuthCodeOnlyResponse response = new VerifyAuthCodeOnlyResponse(TEST_VERIFICATION_TOKEN);
-        
-        given(authService.verifyEmailByAuthCodeOnly(anyString(), anyString()))
-            .willReturn(response);
-        
         // when & then
         // 인증 없이 접근 가능한지 확인 (permitAll 설정)
         mockMvc.perform(post("/auth/code")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+    
+    @Test
+    @DisplayName("@PreAuthorize(\"hasRole('ROLE_TEMP')\") 설정으로 인증이 필요한지 확인")
+    void refreshToken_WithRoleTemp_ShouldRequireAuthentication() throws Exception {
+        // given
+        TokenRefreshRequest request = new TokenRefreshRequest(TEST_REFRESH_TOKEN);
+        
+        // when & then
+        // 인증 없이 접근 시 403 에러 발생 (hasRole('ROLE_TEMP') 설정)
+        mockMvc.perform(post("/auth/refresh")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());

--- a/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
@@ -151,8 +151,11 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
         TokenRefreshRequest request = new TokenRefreshRequest(TEST_REFRESH_TOKEN);
         
         // when & then
-        // 인증 없이 접근 시 403 에러 발생 (hasRole('ROLE_TEMP') 설정)
-        mockMvc.perform(post("/auth/refresh")
+        mockMvc.perform(post("/auth/login/pin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
                         
     @DisplayName("PIN 로그인 API 인증 없이 접근 가능한지 확인")
     void loginWithPin_WithPermitAll_ShouldAllowAccessWithoutAuthentication() throws Exception {

--- a/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
@@ -2,13 +2,17 @@ package org.ject.support.domain.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ject.support.domain.auth.AuthErrorCode.EXPIRED_REFRESH_TOKEN;
 import static org.ject.support.domain.auth.AuthErrorCode.INVALID_AUTH_CODE;
+import static org.ject.support.domain.auth.AuthErrorCode.INVALID_REFRESH_TOKEN;
 import static org.ject.support.domain.auth.AuthErrorCode.NOT_FOUND_AUTH_CODE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.when;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
+import org.ject.support.domain.auth.AuthDto.TokenRefreshResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,11 +20,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AuthServiceTest {
 
     @InjectMocks
@@ -38,10 +45,14 @@ class AuthServiceTest {
     private final String TEST_EMAIL = "test@example.com";
     private final String TEST_AUTH_CODE = "123456";
     private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
+    private final String TEST_REFRESH_TOKEN = "test.refresh.token";
+    private final String TEST_ACCESS_TOKEN = "test.access.token";
+    private final Long TEST_MEMBER_ID = 1L;
 
     @BeforeEach
     void setUp() {
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        // Mockito 설정 - 불필요한 스터빙 경고 무시
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
     }
 
     @Test
@@ -84,5 +95,58 @@ class AuthServiceTest {
             .isInstanceOf(AuthException.class)
             .extracting(e -> ((AuthException) e).getErrorCode())
             .isEqualTo(NOT_FOUND_AUTH_CODE);
+    }
+    
+    @Test
+    @DisplayName("리프레시 토큰 검증 성공 - 새 액세스 토큰 발급")
+    void refreshAccessToken_Success() {
+        // given
+        given(jwtTokenProvider.validateToken(TEST_REFRESH_TOKEN)).willReturn(true);
+        given(jwtTokenProvider.reissueAccessToken(TEST_REFRESH_TOKEN, TEST_MEMBER_ID)).willReturn(TEST_ACCESS_TOKEN);
+
+        // when
+        TokenRefreshResponse result = authService.refreshAccessToken(TEST_MEMBER_ID, TEST_REFRESH_TOKEN);
+
+        // then
+        assertThat(result.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+    }
+    
+    @Test
+    @DisplayName("리프레시 토큰 검증 실패 - 유효하지 않은 토큰")
+    void refreshAccessToken_InvalidToken_ThrowsException() {
+        // given
+        given(jwtTokenProvider.validateToken(TEST_REFRESH_TOKEN)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshAccessToken(TEST_MEMBER_ID, TEST_REFRESH_TOKEN))
+            .isInstanceOf(AuthException.class)
+            .extracting(e -> ((AuthException) e).getErrorCode())
+            .isEqualTo(INVALID_REFRESH_TOKEN);
+    }
+    
+    @Test
+    @DisplayName("리프레시 토큰 검증 실패 - 만료된 토큰")
+    void refreshAccessToken_ExpiredToken_ThrowsException() {
+        // given
+        given(jwtTokenProvider.validateToken(TEST_REFRESH_TOKEN)).willThrow(new ExpiredJwtException(null, null, "만료된 토큰"));
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshAccessToken(TEST_MEMBER_ID, TEST_REFRESH_TOKEN))
+            .isInstanceOf(AuthException.class)
+            .extracting(e -> ((AuthException) e).getErrorCode())
+            .isEqualTo(EXPIRED_REFRESH_TOKEN);
+    }
+    
+    @Test
+    @DisplayName("리프레시 토큰 검증 실패 - JWT 예외 발생")
+    void refreshAccessToken_JwtException_ThrowsException() {
+        // given
+        given(jwtTokenProvider.validateToken(TEST_REFRESH_TOKEN)).willThrow(JwtException.class);
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshAccessToken(TEST_MEMBER_ID, TEST_REFRESH_TOKEN))
+            .isInstanceOf(AuthException.class)
+            .extracting(e -> ((AuthException) e).getErrorCode())
+            .isEqualTo(INVALID_REFRESH_TOKEN);
     }
 }

--- a/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
@@ -169,9 +169,11 @@ class AuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> authService.refreshAccessToken(TEST_MEMBER_ID, TEST_REFRESH_TOKEN))
-            .isInstanceOf(AuthException.class)
-            .extracting(e -> ((AuthException) e).getErrorCode())
-            .isEqualTo(INVALID_REFRESH_TOKEN);
+                .isInstanceOf(AuthException.class)
+                .extracting(e -> ((AuthException) e).getErrorCode())
+                .isEqualTo(INVALID_REFRESH_TOKEN);
+    }
+
     @DisplayName("PIN 로그인 성공")
     void loginWithPin_Success() {
         // given

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -95,7 +95,7 @@ class FileControllerTest extends ApplicationPeriodTest {
                         .contentType("application/json")
                         .param("memberId", member.getId().toString())
                         .content(getContent()))
-                .andExpect(content().string(containsString("G-06")))
+                .andExpect(content().string(containsString("G-11")))
                 .andDo(print());
     }
 
@@ -127,7 +127,7 @@ class FileControllerTest extends ApplicationPeriodTest {
                                     }
                                 ]
                                 """))
-                .andExpect(content().string(containsString("G-06")))
+                .andExpect(content().string(containsString("G-11")))
                 .andDo(print());
     }
 

--- a/src/test/java/org/ject/support/testconfig/TestSecurityConfig.java
+++ b/src/test/java/org/ject/support/testconfig/TestSecurityConfig.java
@@ -1,0 +1,34 @@
+package org.ject.support.testconfig;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * 테스트 환경에서 사용할 Spring Security 설정
+ * 메서드 수준의 보안 설정(@PreAuthorize 등)이 적용되도록 설정
+ */
+@TestConfiguration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true, jsr250Enabled = true, prePostEnabled = true)
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers("/auth/code").permitAll()
+                        .requestMatchers("/auth/refresh").authenticated()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #95 

## 📝작업 내용

- 리프레시 토큰 재발급 기능 구현
- `GlobalErrorCode` 에서 잘못된 에러코드 번호 수정

## ✅테스트 결과

![스크린샷 2025-03-14 오전 3 57 11](https://github.com/user-attachments/assets/4c7333fe-c780-4861-9bbb-5b4a8f2aac8d)


## 🙏리뷰 요구사항(선택)

리프레시 토큰 재발급 시 발생하는 예외처리에 대한 에러코드를 Global에 둘지, Auth에 둘지를 조금 고민했습니다.
결론은, '리프레시 토큰'은 엑세스 토큰을 재발급 할 때만 쓰이므로, 전역적으로 사용되지 않는다 판단, Auth 도메인에 속하는게 맞다고 생각했습니다.
