### PR TITLE
Feat/110 add portfolio to temp apply

### DIFF
--- a/src/main/java/org/ject/support/domain/recruit/Portfolio.java
+++ b/src/main/java/org/ject/support/domain/recruit/Portfolio.java
@@ -30,6 +30,9 @@ public class Portfolio extends BaseTimeEntity {
     @Column(nullable = false)
     private Long fileSize;
 
+    @Column(nullable = false)
+    private int sequence;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "application_form_id", nullable = false)
     private ApplicationForm applicationForm;

--- a/src/main/java/org/ject/support/domain/recruit/controller/ApplyController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/ApplyController.java
@@ -1,9 +1,10 @@
 package org.ject.support.domain.recruit.controller;
 
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.security.AuthPrincipal;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.dto.ApplyTemporaryRequest;
+import org.ject.support.domain.recruit.dto.ApplyTemporaryResponse;
 import org.ject.support.domain.recruit.service.ApplyUsecase;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,15 +21,15 @@ public class ApplyController {
     private final ApplyUsecase applyUsecase;
 
     @GetMapping("/temp")
-    public Map<String, String> getTemporaryApplication(@AuthPrincipal Long memberId) {
+    public ApplyTemporaryResponse getTemporaryApplication(@AuthPrincipal Long memberId) {
         return applyUsecase.getTemporaryApplication(memberId);
     }
 
     @PostMapping("/temp")
     public void applyTemporary(@AuthPrincipal Long memberId,
                                @RequestParam JobFamily jobFamily,
-                               @RequestBody Map<String, String> answers) {
-        applyUsecase.applyTemporary(jobFamily, memberId, answers);
+                               @RequestBody ApplyTemporaryRequest request) {
+        applyUsecase.applyTemporary(jobFamily, memberId, request.answers(), request.portfolios());
     }
 
     @PutMapping("/job")

--- a/src/main/java/org/ject/support/domain/recruit/dto/ApplyTemporaryRequest.java
+++ b/src/main/java/org/ject/support/domain/recruit/dto/ApplyTemporaryRequest.java
@@ -1,0 +1,7 @@
+package org.ject.support.domain.recruit.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record ApplyTemporaryRequest(Map<String, String> answers, List<Map<String, String>> portfolios) {
+}

--- a/src/main/java/org/ject/support/domain/recruit/dto/ApplyTemporaryResponse.java
+++ b/src/main/java/org/ject/support/domain/recruit/dto/ApplyTemporaryResponse.java
@@ -1,0 +1,11 @@
+package org.ject.support.domain.recruit.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record ApplyTemporaryResponse(Map<String, String> answers, List<Map<String, String>> portfolios) {
+
+    public static ApplyTemporaryResponse of(Map<String, String> answers, List<Map<String, String>> portfolios) {
+        return new ApplyTemporaryResponse(answers, portfolios);
+    }
+}

--- a/src/main/java/org/ject/support/domain/recruit/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/ApplyService.java
@@ -1,11 +1,13 @@
 package org.ject.support.domain.recruit.service;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.util.PeriodAccessible;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.dto.ApplyTemporaryResponse;
 import org.ject.support.domain.recruit.exception.ApplyErrorCode;
 import org.ject.support.domain.recruit.exception.ApplyException;
 import org.ject.support.domain.recruit.exception.QuestionErrorCode;
@@ -26,21 +28,26 @@ public class ApplyService implements ApplyUsecase {
 
     @Override
     @PeriodAccessible
-    public Map<String, String> getTemporaryApplication(final Long memberId) {
+    public ApplyTemporaryResponse getTemporaryApplication(final Long memberId) {
         return temporaryApplyService.findMembersRecentTemporaryApplication(memberId);
     }
 
     @Override
     @PeriodAccessible
-    public void applyTemporary(JobFamily jobFamily, Long memberId, Map<String, String> answers) {
+    public void applyTemporary(JobFamily jobFamily,
+                               Long memberId,
+                               Map<String, String> answers,
+                               List<Map<String, String>> portfolios) {
         //1. jobFamily를 통해 현재 기수 지원양식 id를 가져옴
         Recruit recruit = getPeriodRecruit(jobFamily);
 
         //2. 지원양식과 answers의 key를 비교해 올바른 질문 양식인지 점검
         validateQuestions(answers, recruit);
 
+        // TODO 파일 크기 검증
+
         //3. 지원서 저장
-        temporaryApplyService.saveTemporaryApplication(memberId, answers, jobFamily);
+        temporaryApplyService.saveTemporaryApplication(memberId, answers, jobFamily, portfolios);
     }
 
     @Override

--- a/src/main/java/org/ject/support/domain/recruit/service/ApplyUsecase.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/ApplyUsecase.java
@@ -1,12 +1,17 @@
 package org.ject.support.domain.recruit.service;
 
+import java.util.List;
 import java.util.Map;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.dto.ApplyTemporaryResponse;
 
 public interface ApplyUsecase {
-    Map<String, String> getTemporaryApplication(Long memberId);
+    ApplyTemporaryResponse getTemporaryApplication(Long memberId);
 
-    void applyTemporary(JobFamily jobFamily, Long memberId, Map<String, String> answers);
+    void applyTemporary(JobFamily jobFamily,
+                        Long memberId,
+                        Map<String, String> answers,
+                        List<Map<String, String>> portfolios);
 
 
     void changeJobFamily(Long memberId, JobFamily newJobFamily);

--- a/src/main/java/org/ject/support/domain/tempapply/domain/TemporaryApplication.java
+++ b/src/main/java/org/ject/support/domain/tempapply/domain/TemporaryApplication.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.tempapply.domain;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.Setter;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.external.dynamodb.domain.CompositeKey;
 import org.ject.support.external.dynamodb.domain.EntityWithPrimaryKey;
+import org.ject.support.external.dynamodb.util.ListMapConverter;
 import org.ject.support.external.dynamodb.util.LocalDateTimeConverter;
 import org.ject.support.external.dynamodb.util.MapConverter;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
@@ -28,6 +30,20 @@ public class TemporaryApplication extends EntityWithPrimaryKey {
     private LocalDateTime timestamp;
     private String jobFamily;
     private Map<String, String> answers;
+    private List<Map<String, String>> portfolios;
+
+    public TemporaryApplication(final String memberId,
+                                final Map<String, String> answers,
+                                final String jobFamily,
+                                final List<Map<String, String>> portfolios) {
+        this.memberId = memberId;
+        this.timestamp = LocalDateTime.now();
+        this.answers = answers;
+        this.jobFamily = jobFamily;
+        this.portfolios = portfolios;
+        this.pk = new CompositeKey(PK_PREFIX, this.memberId);
+        this.sk = new CompositeKey(SK_PREFIX, this.timestamp.toString());
+    }
 
     @DynamoDbAttribute(value = "member_id")
     public String getMemberId() {
@@ -40,13 +56,9 @@ public class TemporaryApplication extends EntityWithPrimaryKey {
         return timestamp;
     }
 
-    public TemporaryApplication(final String memberId, final Map<String, String> answers, final String jobFamily) {
-        this.memberId = memberId;
-        this.timestamp = LocalDateTime.now();
-        this.answers = answers;
-        this.jobFamily = jobFamily;
-        this.pk = new CompositeKey(PK_PREFIX, this.memberId);
-        this.sk = new CompositeKey(SK_PREFIX, this.timestamp.toString());
+    @DynamoDbAttribute(value = "job_family")
+    public String getJobFamily() {
+        return jobFamily;
     }
 
     @DynamoDbAttribute(value = "answers")
@@ -55,9 +67,10 @@ public class TemporaryApplication extends EntityWithPrimaryKey {
         return answers;
     }
 
-    @DynamoDbAttribute(value = "job_family")
-    public String getJobFamily() {
-        return jobFamily;
+    @DynamoDbAttribute(value = "portfolios")
+    @DynamoDbConvertedBy(value = ListMapConverter.class)
+    public List<Map<String, String>> getPortfolios() {
+        return portfolios;
     }
 
     public boolean isSameJobFamily(JobFamily jobFamily) {

--- a/src/main/java/org/ject/support/domain/tempapply/service/TemporaryApplyService.java
+++ b/src/main/java/org/ject/support/domain/tempapply/service/TemporaryApplyService.java
@@ -1,18 +1,23 @@
 package org.ject.support.domain.tempapply.service;
 
+import java.util.List;
 import java.util.Map;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.dto.ApplyTemporaryResponse;
 
 public interface TemporaryApplyService {
     /**
      * 사용자의 임시 지원서를 조회<br/>
      */
-    Map<String, String> findMembersRecentTemporaryApplication(Long memberId);
+    ApplyTemporaryResponse findMembersRecentTemporaryApplication(Long memberId);
 
     /**
      * 사용자의 임시 지원서를 저장<br/> 임시지원서의 양식이 지원 파트(직군)에 적절한지 판별 후 저장<br/> 임시 지원서는 덮어써지는 형태가 아닌 새로운 임시저장본이 추가로 저장되는 형태<br/>
      */
-    void saveTemporaryApplication(Long memberId, Map<String, String> answers, JobFamily jobFamily);
+    void saveTemporaryApplication(Long memberId,
+                                  Map<String, String> answers,
+                                  JobFamily jobFamily,
+                                  List<Map<String, String>> portfolios);
 
     /**
      * 변경 요청한 직군이 사용자의 최근 임시 지원서의 직군과 동일한지 판별

--- a/src/main/java/org/ject/support/domain/tempapply/service/TemporaryApplyServiceImpl.java
+++ b/src/main/java/org/ject/support/domain/tempapply/service/TemporaryApplyServiceImpl.java
@@ -1,8 +1,10 @@
 package org.ject.support.domain.tempapply.service;
 
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.dto.ApplyTemporaryResponse;
 import org.ject.support.domain.tempapply.domain.TemporaryApplication;
 import org.ject.support.domain.tempapply.exception.TemporaryApplicationErrorCode;
 import org.ject.support.domain.tempapply.exception.TemporaryApplicationException;
@@ -15,20 +17,21 @@ public class TemporaryApplyServiceImpl implements TemporaryApplyService {
     private final TemporaryApplicationRepository temporaryApplicationRepository;
 
     @Override
-    public Map<String, String> findMembersRecentTemporaryApplication(final Long memberId) {
+    public ApplyTemporaryResponse findMembersRecentTemporaryApplication(final Long memberId) {
         TemporaryApplication latestApplication =
                 temporaryApplicationRepository.findLatestByMemberId(memberId.toString())
                         .orElseThrow(() -> new TemporaryApplicationException(TemporaryApplicationErrorCode.NOT_FOUND));
 
-        return latestApplication.getAnswers();
+        return ApplyTemporaryResponse.of(latestApplication.getAnswers(), latestApplication.getPortfolios());
     }
 
     @Override
     public void saveTemporaryApplication(final Long memberId,
                                          final Map<String, String> answers,
-                                         final JobFamily jobFamily) {
+                                         final JobFamily jobFamily,
+                                         final List<Map<String, String>> portfolios) {
         TemporaryApplication temporaryApplication =
-                new TemporaryApplication(memberId.toString(), answers, jobFamily.name());
+                new TemporaryApplication(memberId.toString(), answers, jobFamily.name(), portfolios);
         temporaryApplicationRepository.save(temporaryApplication);
     }
 

--- a/src/main/java/org/ject/support/external/dynamodb/util/ListMapConverter.java
+++ b/src/main/java/org/ject/support/external/dynamodb/util/ListMapConverter.java
@@ -1,0 +1,47 @@
+package org.ject.support.external.dynamodb.util;
+
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ListMapConverter implements AttributeConverter<List<Map<String, String>>> {
+
+    @Override
+    public AttributeValue transformFrom(List<Map<String, String>> list) {
+        return AttributeValue.builder()
+                .l(list.stream()
+                        .map(map -> AttributeValue.builder()
+                                .m(map.entrySet().stream()
+                                        .collect(Collectors.toMap(
+                                                Map.Entry::getKey,
+                                                e -> AttributeValue.builder().s(e.getValue()).build())))
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    @Override
+    public List<Map<String, String>> transformTo(AttributeValue attributeValue) {
+        return attributeValue.l().stream()
+                .map(map -> map.m().entrySet().stream()
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey, e -> e.getValue().s()
+                        )))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public EnhancedType<List<Map<String, String>>> type() {
+        return EnhancedType.listOf(EnhancedType.mapOf(String.class, String.class));
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.L;
+    }
+}

--- a/src/test/java/org/ject/support/domain/recruit/controller/ApplyControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/ApplyControllerTest.java
@@ -5,7 +5,6 @@ import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.ject.support.domain.recruit.domain.Question;
 import org.ject.support.domain.recruit.domain.Recruit;
-import org.ject.support.domain.recruit.dto.ApplyTemporaryRequest;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.ject.support.domain.tempapply.domain.TemporaryApplication;
 import org.ject.support.domain.tempapply.repository.TemporaryApplicationRepository;
@@ -191,7 +190,8 @@ class ApplyControllerTest extends ApplicationPeriodTest {
                 "1",
                 Map.of("3", "답변3", "4", "답변4", "5", "답변5"),
                 "BE",
-                List.of(Map.of("key", "value"))));
+                List.of(Map.of("fileName", "nameNameA", "fileUrl", "https://~~A"),
+                        Map.of("fileName", "nameNameB", "fileUrl", "https://~~B"))));
 
         // when & then
         ResultActions resultActions = mockMvc.perform(get("/apply/temp"))
@@ -200,7 +200,9 @@ class ApplyControllerTest extends ApplicationPeriodTest {
                 .andExpectAll(
                         content().string(containsString("답변3")),
                         content().string(containsString("답변4")),
-                        content().string(containsString("답변5"))
+                        content().string(containsString("답변5")),
+                        content().string(containsString("fileName")),
+                        content().string(containsString("fileUrl"))
                 );
 
         resultActions.andDo(print());

--- a/src/test/java/org/ject/support/domain/recruit/controller/ApplyControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/ApplyControllerTest.java
@@ -5,6 +5,7 @@ import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.ject.support.domain.recruit.domain.Question;
 import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.dto.ApplyTemporaryRequest;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.ject.support.domain.tempapply.domain.TemporaryApplication;
 import org.ject.support.domain.tempapply.repository.TemporaryApplicationRepository;
@@ -30,7 +31,9 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.ject.support.domain.member.Role.USER;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -104,12 +107,30 @@ class ApplyControllerTest extends ApplicationPeriodTest {
                         .param("jobFamily", "BE")
                         .content("""
                                 {
-                                  "1": "answer1",
-                                  "2": "answer2",
-                                  "3": "answer3",
-                                  "4": "answer4",
-                                  "5": "answer5"
-                                }""")
+                                    "answers": {
+                                        "8": "8번 답변임",
+                                        "9": "9번 답변임~",
+                                        "10": "10번 답변임~~",
+                                        "11": "11번.",
+                                        "12": "12번 답변~",
+                                        "13": "13이이이임"
+                                    },
+                                    "portfolios": [
+                                        {
+                                            "fileUrl": "filrUrlA",
+                                            "fileName": "fileNameA",
+                                            "fileSize": "105021",
+                                            "sequence": "1"
+                                        },
+                                        {
+                                            "fileUrl": "filrUrlB",
+                                            "fileName": "fileNameB",
+                                            "fileSize": "105021",
+                                            "sequence": "2"
+                                        }
+                                    ]
+                                }
+                                """)
                 )
                 .andExpect(status().isOk())
                 .andDo(print())
@@ -126,13 +147,30 @@ class ApplyControllerTest extends ApplicationPeriodTest {
                         .param("jobFamily", "BE")
                         .content("""
                                 {
-                                  "1": "answer1",
-                                  "2": "answer2",
-                                  "3": "answer3",
-                                  "4": "answer4",
-                                  "5": "answer5",
-                                  "6": "answer6"
-                                }""")
+                                    "answers": {
+                                        "8": "8번 답변임",
+                                        "9": "9번 답변임~",
+                                        "10": "10번 답변임~~",
+                                        "11": "11번.",
+                                        "12": "12번 답변~",
+                                        "14": "???"
+                                    },
+                                    "portfolios": [
+                                        {
+                                            "fileUrl": "filrUrlA",
+                                            "fileName": "fileNameA",
+                                            "fileSize": "105021",
+                                            "sequence": "1"
+                                        },
+                                        {
+                                            "fileUrl": "filrUrlB",
+                                            "fileName": "fileNameB",
+                                            "fileSize": "105021",
+                                            "sequence": "2"
+                                        }
+                                    ]
+                                }
+                                """)
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("QUESTION_NOT_FOUND")))
@@ -144,9 +182,16 @@ class ApplyControllerTest extends ApplicationPeriodTest {
     @AuthenticatedUser
     void inquire_temporal_application() throws Exception {
         // given: 테스트 데이터 저장
-        temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of("1", "답변1", "2", "답변2"), "PM"));
-        temporaryApplicationRepository.save(
-                new TemporaryApplication("1", Map.of("3", "답변3", "4", "답변4", "5", "답변5"), "BE"));
+        temporaryApplicationRepository.save(createTemporaryApplication(
+                "1",
+                Map.of("1", "답변1", "2", "답변2"),
+                "PM",
+                List.of(Map.of("key", "value"))));
+        temporaryApplicationRepository.save(createTemporaryApplication(
+                "1",
+                Map.of("3", "답변3", "4", "답변4", "5", "답변5"),
+                "BE",
+                List.of(Map.of("key", "value"))));
 
         // when & then
         ResultActions resultActions = mockMvc.perform(get("/apply/temp"))
@@ -169,23 +214,23 @@ class ApplyControllerTest extends ApplicationPeriodTest {
         temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of(
                 "8", "answer 1-1 for 8",
                 "9", "answer 1-1 for 9",
-                "10", "answer 1-1 for 10"), "BE"));
+                "10", "answer 1-1 for 10"), "BE", List.of(Map.of("key", "value"))));
         temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of(
                 "8", "answer 1-2 for 8",
                 "9", "answer 1-2 for 9",
-                "10", "answer 1-2 for 10"), "BE"));
+                "10", "answer 1-2 for 10"), "BE", List.of(Map.of("key", "value"))));
         temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of(
                 "8", "answer 1-3 for 8",
                 "9", "answer 1-3 for 9",
-                "10", "answer 1-3 for 10"), "BE"));
+                "10", "answer 1-3 for 10"), "BE", List.of(Map.of("key", "value"))));
         temporaryApplicationRepository.save(new TemporaryApplication("2", Map.of(
                 "8", "answer 2-1 for 8",
                 "9", "answer 2-1 for 9",
-                "10", "answer 2-1 for 10"), "BE"));
+                "10", "answer 2-1 for 10"), "BE", List.of(Map.of("key", "value"))));
         temporaryApplicationRepository.save(new TemporaryApplication("2", Map.of(
                 "8", "answer 2-2 for 8",
                 "9", "answer 2-2 for 9",
-                "10", "answer 2-2 for 10"), "BE"));
+                "10", "answer 2-2 for 10"), "BE", List.of(Map.of("key", "value"))));
 
         // when, then
         mockMvc.perform(put("/apply/job")
@@ -199,5 +244,12 @@ class ApplyControllerTest extends ApplicationPeriodTest {
 
         assertThat(temporaryApplicationRepository.findByPartitionKey(new CompositeKey("MEMBER", "1"))).isEmpty();
         assertThat(temporaryApplicationRepository.findByPartitionKey(new CompositeKey("MEMBER", "2"))).hasSize(2);
+    }
+
+    private TemporaryApplication createTemporaryApplication(String memberId,
+                                                            Map<String, String> answers,
+                                                            String jobFamily,
+                                                            List<Map<String, String>> portfolios) {
+        return new TemporaryApplication(memberId, answers, jobFamily, portfolios);
     }
 }

--- a/src/test/java/org/ject/support/external/dynamodb/repository/TemporaryApplicationRepositoryTest.java
+++ b/src/test/java/org/ject/support/external/dynamodb/repository/TemporaryApplicationRepositoryTest.java
@@ -1,23 +1,21 @@
 package org.ject.support.external.dynamodb.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.ject.support.domain.tempapply.domain.TemporaryApplication;
+import org.ject.support.domain.tempapply.repository.TemporaryApplicationRepository;
+import org.ject.support.external.dynamodb.domain.CompositeKey;
+import org.ject.support.testconfig.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.ject.support.domain.member.JobFamily;
-import org.ject.support.domain.tempapply.domain.TemporaryApplication;
-import org.ject.support.domain.tempapply.repository.TemporaryApplicationRepository;
-import org.ject.support.external.dynamodb.domain.CompositeKey;
-import org.ject.support.testconfig.IntegrationTest;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
 class TemporaryApplicationRepositoryTest {

--- a/src/test/java/org/ject/support/external/dynamodb/repository/TemporaryApplicationRepositoryTest.java
+++ b/src/test/java/org/ject/support/external/dynamodb/repository/TemporaryApplicationRepositoryTest.java
@@ -6,10 +6,13 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.tempapply.domain.TemporaryApplication;
 import org.ject.support.domain.tempapply.repository.TemporaryApplicationRepository;
 import org.ject.support.external.dynamodb.domain.CompositeKey;
 import org.ject.support.testconfig.IntegrationTest;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
@@ -32,7 +35,8 @@ class TemporaryApplicationRepositoryTest {
     @DisplayName("dynamodb repository save test")
     void dynamodb_save() {
         // given
-        TemporaryApplication temporaryApplication = new TemporaryApplication("1", Map.of("key", "value"), "BE");
+        TemporaryApplication temporaryApplication =
+                createTemporaryApplication("1", Map.of("key", "value"), "BE", List.of(Map.of("key", "value")));
 
         // when
         temporaryApplicationRepository.save(temporaryApplication);
@@ -50,13 +54,20 @@ class TemporaryApplicationRepositoryTest {
     @DisplayName("dynamodb repository find by partition key test")
     void find_by_partition_key() {
         // given
-        temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of("key", "value"), "BE"));
-        temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of("key", "value"), "BE"));
-        temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of("key", "value"), "BE"));
-        temporaryApplicationRepository.save(new TemporaryApplication("2", Map.of("key", "value"), "BE"));
-        temporaryApplicationRepository.save(new TemporaryApplication("2", Map.of("key", "value"), "BE"));
-        temporaryApplicationRepository.save(new TemporaryApplication("3", Map.of("key", "value"), "BE"));
-        temporaryApplicationRepository.save(new TemporaryApplication("4", Map.of("key", "value"), "BE"));
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("1", Map.of("key", "value"), "BE", List.of(Map.of("key", "value"))));
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("1", Map.of("key", "value"), "BE", List.of(Map.of("key", "value"))));
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("1", Map.of("key", "value"), "BE", List.of(Map.of("key", "value"))));
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("2", Map.of("key", "value"), "FE", List.of(Map.of("key", "value"))));
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("2", Map.of("key", "value"), "FE", List.of(Map.of("key", "value"))));
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("3", Map.of("key", "value"), "BE", List.of(Map.of("key", "value"))));
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("4", Map.of("key", "value"), "BE", List.of(Map.of("key", "value"))));
 
         // when
         String prefix = "MEMBER";
@@ -80,13 +91,27 @@ class TemporaryApplicationRepositoryTest {
     @DisplayName("dynamodb repository find by partition with sort type test")
     void find_by_partition_with_sort_type() {
         // given
-        temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of("key", "value"), "BE"));
-        temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of("key", "value"), "BE"));
-        temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of("key", "value"), "BE"));
-        temporaryApplicationRepository.save(new TemporaryApplication("2", Map.of("key", "value"), "BE"));
-        temporaryApplicationRepository.save(new TemporaryApplication("2", Map.of("key", "value"), "BE"));
-        temporaryApplicationRepository.save(new TemporaryApplication("3", Map.of("key", "value"), "BE"));
-        temporaryApplicationRepository.save(new TemporaryApplication("4", Map.of("key", "value"), "BE"));
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("1", Map.of("key", "value"), "BE", List.of(Map.of("key", "value")))
+        );
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("1", Map.of("key", "value"), "BE", List.of(Map.of("key", "value")))
+        );
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("1", Map.of("key", "value"), "BE", List.of(Map.of("key", "value")))
+        );
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("2", Map.of("key", "value"), "FE", List.of(Map.of("key", "value")))
+        );
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("2", Map.of("key", "value"), "FE", List.of(Map.of("key", "value")))
+        );
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("3", Map.of("key", "value"), "BE", List.of(Map.of("key", "value")))
+        );
+        temporaryApplicationRepository.save(
+                createTemporaryApplication("4", Map.of("key", "value"), "BE", List.of(Map.of("key", "value")))
+        );
 
         // when
         String prefix = "TIMESTAMP";
@@ -109,26 +134,26 @@ class TemporaryApplicationRepositoryTest {
     @DisplayName("dynamodb repository delete by member id test")
     void delete_by_member_id() {
         // given
-        temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of(
+        temporaryApplicationRepository.save(createTemporaryApplication("1", Map.of(
                 "8", "answer 1-1 for 8",
                 "9", "answer 1-1 for 9",
-                "10", "answer 1-1 for 10"), "BE"));
+                "10", "answer 1-1 for 10"), "BE", List.of(Map.of("key", "value"))));
         temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of(
                 "8", "answer 1-2 for 8",
                 "9", "answer 1-2 for 9",
-                "10", "answer 1-2 for 10"), "BE"));
+                "10", "answer 1-2 for 10"), "BE", List.of(Map.of("key", "value"))));
         temporaryApplicationRepository.save(new TemporaryApplication("1", Map.of(
                 "8", "answer 1-3 for 8",
                 "9", "answer 1-3 for 9",
-                "10", "answer 1-3 for 10"), "BE"));
+                "10", "answer 1-3 for 10"), "BE", List.of(Map.of("key", "value"))));
         temporaryApplicationRepository.save(new TemporaryApplication("2", Map.of(
                 "8", "answer 2-1 for 8",
                 "9", "answer 2-1 for 9",
-                "10", "answer 2-1 for 10"), "BE"));
+                "10", "answer 2-1 for 10"), "BE", List.of(Map.of("key", "value"))));
         temporaryApplicationRepository.save(new TemporaryApplication("2", Map.of(
                 "8", "answer 2-2 for 8",
                 "9", "answer 2-2 for 9",
-                "10", "answer 2-2 for 10"), "BE"));
+                "10", "answer 2-2 for 10"), "BE", List.of(Map.of("key", "value"))));
 
         // when
         temporaryApplicationRepository.deleteByPartitionKey(new CompositeKey("MEMBER", "1"));
@@ -141,5 +166,12 @@ class TemporaryApplicationRepositoryTest {
         List<TemporaryApplication> temporaryApplicationsByMemberId2 =
                 temporaryApplicationRepository.findByPartitionKey(new CompositeKey("MEMBER", "2"));
         assertThat(temporaryApplicationsByMemberId2).hasSize(2);
+    }
+
+    private TemporaryApplication createTemporaryApplication(String memberId,
+                                                            Map<String, String> answers,
+                                                            String jobFamily,
+                                                            List<Map<String, String>> portfolios) {
+        return new TemporaryApplication(memberId, answers, jobFamily, portfolios);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #110 

## 📝작업 내용
- Portfolio 엔티티에 sequence 컬럼 추가
- 임시 지원서 저장 시 포트폴리오도 함께 전달하도록 추가 구현 및 임시 지원서 조회 응답 타입 수정
- 임시 지원서 저장 및 조회 로직 변경에 따라 기존 테스트 코드 수정
- 임시 지원서 조회 시 포트폴리오 포함 여부 테스트 코드 추가

## ✅테스트 결과
<img width="567" alt="image" src="https://github.com/user-attachments/assets/bb8323ef-f167-4e00-bfb0-2871a54296b9" />

## 🙏리뷰 요구사항(선택)
ListMapConverter는 이미 구현되어 있던 attribute converter들을 참고하여 구현했습니다.
