### PR TITLE
pre-signed url 발급 완료 시 cdn url 전달하도록 변경

### DIFF
--- a/src/main/java/org/ject/support/domain/file/dto/UploadFileResponse.java
+++ b/src/main/java/org/ject/support/domain/file/dto/UploadFileResponse.java
@@ -4,5 +4,5 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
-public record UploadFileResponse(String keyName, String presignedUrl, LocalDateTime expiration) {
+public record UploadFileResponse(String cdnUrl, String presignedUrl, LocalDateTime expiration) {
 }

--- a/src/main/java/org/ject/support/external/s3/S3Service.java
+++ b/src/main/java/org/ject/support/external/s3/S3Service.java
@@ -30,6 +30,9 @@ public class S3Service {
     @Value("${aws.s3.bucket}")
     private String bucket;
 
+    @Value("aws.cloudfront.domain")
+    private String cloudfrontDomain;
+
     /**
      * 지원자가 첨부한 포트폴리오 파일 이름과 해당 지원자의 식별자를 토대로 Pre-signed URL 생성
      */
@@ -63,7 +66,7 @@ public class S3Service {
                     PutObjectPresignRequest presignRequest =
                             getPutObjectPresignRequest(keyName, request.contentType(), request.contentLength());
                     PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
-                    return getUploadFileResponse(keyName, presignedRequest);
+                    return getUploadFileResponse(cloudfrontDomain + keyName, presignedRequest);
                 })
                 .toList();
     }
@@ -85,9 +88,9 @@ public class S3Service {
                 .build();
     }
 
-    private UploadFileResponse getUploadFileResponse(String keyName, PresignedPutObjectRequest presignedRequest) {
+    private UploadFileResponse getUploadFileResponse(String cdnUrl, PresignedPutObjectRequest presignedRequest) {
         return UploadFileResponse.builder()
-                .keyName(keyName)
+                .cdnUrl(cdnUrl)
                 .presignedUrl(presignedRequest.url().toExternalForm())
                 .expiration(LocalDateTime.ofInstant(presignedRequest.expiration(), ZoneId.systemDefault()))
                 .build();

--- a/src/test/java/org/ject/support/external/s3/S3ServiceTest.java
+++ b/src/test/java/org/ject/support/external/s3/S3ServiceTest.java
@@ -71,13 +71,13 @@ class S3ServiceTest {
         assertThat(result).hasSize(2);
 
         UploadFileResponse firstResponse = result.get(0);
-        assertThat(firstResponse.keyName()).contains(requests.get(0).name());
+        assertThat(firstResponse.cdnUrl()).contains(requests.get(0).name());
         assertThat(firstResponse.presignedUrl()).isEqualTo(expectedPortfolioUploadUrls.get(0));
         assertThat(firstResponse.expiration())
                 .isEqualTo(LocalDateTime.ofInstant(expirationTime, ZoneId.systemDefault()));
 
         UploadFileResponse secondResponse = result.get(1);
-        assertThat(secondResponse.keyName()).contains(requests.get(1).name());
+        assertThat(secondResponse.cdnUrl()).contains(requests.get(1).name());
     }
 
     @Test
@@ -97,9 +97,8 @@ class S3ServiceTest {
 
         for (int i = 0; i < 2; i++) {
             UploadFileResponse firstResponse = result.get(i);
-            assertThat(firstResponse.keyName()).contains(memberId.toString());
-            assertThat(removePrefix(firstResponse.keyName())).startsWith(requests.get(i).name());
-            assertThat(firstResponse.keyName()).contains("_");
+            assertThat(firstResponse.cdnUrl()).contains(memberId.toString());
+            assertThat(firstResponse.cdnUrl()).contains("_");
         }
     }
 
@@ -116,10 +115,5 @@ class S3ServiceTest {
 
     private String createExpectedUrl(Long memberId, String fileName) {
         return String.format("%s/%d/%s", CDN_DOMAIN, memberId, fileName);
-    }
-
-    private String removePrefix(String keyName) {
-        String prefix = String.format("%s/", memberId);
-        return keyName.replace(prefix, "");
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #128 

## 📝작업 내용
- UploadFileResponse의 fileName 필드를 cdnUrl로 변경
- 테스트코드 수정

## ✅테스트 결과
<img width="578" alt="스크린샷 2025-03-21 오전 1 52 09" src="https://github.com/user-attachments/assets/9c4c2984-7988-4fdd-b112-834bfe63cc91" />


