### PR TITLE
프로젝트의 기술 스택을 쉼표로 구분하여 조회하도록 구현

### DIFF
--- a/src/main/java/org/ject/support/domain/project/dto/ProjectDetailResponse.java
+++ b/src/main/java/org/ject/support/domain/project/dto/ProjectDetailResponse.java
@@ -14,7 +14,7 @@ public record ProjectDetailResponse(
         LocalDate startDate,
         LocalDate endDate,
         TeamMemberNames teamMemberNames,
-        String techStack,
+        List<String> techStack,
         String description,
         String serviceUrl,
         List<ProjectIntroResponse> serviceIntros,

--- a/src/main/java/org/ject/support/domain/project/entity/Project.java
+++ b/src/main/java/org/ject/support/domain/project/entity/Project.java
@@ -14,7 +14,10 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -47,8 +50,13 @@ public class Project extends BaseTimeEntity {
     @Column(length = 100, nullable = false)
     private String summary;
 
+    @Column
     private String techStack;
+
+    @Column
     private LocalDate startDate;
+
+    @Column
     private LocalDate endDate;
 
     @Column(columnDefinition = "text")
@@ -68,6 +76,12 @@ public class Project extends BaseTimeEntity {
     @OrderBy("sequence asc")
     @Builder.Default
     private List<ProjectIntro> projectIntros = new ArrayList<>();
+
+    public List<String> getTechStack() {
+        return Arrays.stream(techStack.split(","))
+                .map(String::trim)
+                .collect(Collectors.toList());
+    }
 
     public enum Category {
         MAIN, HACKATHON

--- a/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.project.service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.ject.support.domain.member.dto.TeamMemberNames;
@@ -59,7 +60,7 @@ class ProjectServiceTest {
                 .id(1L)
                 .semester("1기")
                 .summary("summary")
-                .techStack("tech stack")
+                .techStack("java,Spring, JPA, QueryDSL,MySQL,AWS")
                 .startDate(LocalDate.of(2025, 3, 2))
                 .endDate(LocalDate.of(2025, 6, 30))
                 .description("description")
@@ -90,7 +91,6 @@ class ProjectServiceTest {
         assertThat(result.teamMemberNames().productDesigners()).hasSize(1);
         assertThat(result.teamMemberNames().frontendDevelopers()).hasSize(2);
         assertThat(result.teamMemberNames().backendDevelopers()).hasSize(3);
-        assertThat(result.techStack()).isEqualTo(project.getTechStack());
         assertThat(result.description()).isEqualTo(project.getDescription());
         assertThat(result.serviceUrl()).isEqualTo(project.getServiceUrl());
         assertThat(result.serviceIntros()).hasSize(3);
@@ -123,6 +123,22 @@ class ProjectServiceTest {
         // when, then
         assertThatThrownBy(() -> projectService.findProjectDetails(1L))
                 .isInstanceOf(ProjectException.class);
+    }
+
+    @Test
+    @DisplayName("프로젝트 상세 조회 시 기술 스택을 배열 형태로 반환")
+    void get_tech_stack_for_list() {
+        // given
+        when(projectRepository.findById(1L)).thenReturn(Optional.ofNullable(project));
+        when(memberRepository.findMemberNamesByTeamId(1L)).thenReturn(
+                new TeamMemberNames(projectManagers, productDesigners, frontendDevelopers, backendDevelopers));
+
+        // when
+        ProjectDetailResponse result = projectService.findProjectDetails(1L);
+
+        // then
+        assertThat(result.techStack()).isExactlyInstanceOf(ArrayList.class);
+        assertThat(result.techStack()).containsExactly("java", "Spring", "JPA", "QueryDSL", "MySQL", "AWS");
     }
 
     private ProjectIntro createProjectIntro(Long id, String imageUrl, Category category, int sequence) {


### PR DESCRIPTION
## #️⃣연관된 이슈

close #131 

## 📝작업 내용
- 프로젝트의 기술 스택을 쉼표로 구분하여 조회하도록 구현
- 프로젝트 상세 조회 시 기술 스택을 배열 형태로 반환하는지 검증

## ✅테스트 결과
![image](https://github.com/user-attachments/assets/5bb39fe2-cd03-4496-8aa4-818fb1c25eda)

