### PR TITLE
Security 필터 예외처리 수정

### DIFF
--- a/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
@@ -13,6 +13,8 @@ import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.ject.support.common.security.CustomUserDetails;
+import org.ject.support.domain.member.Role;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -87,17 +89,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
     }
     
-    /**
-     * 이메일 기반으로 verification 인증 정보 생성
-     * 이 인증은 회원 등록 API에만 접근 가능하도록 제한된 권한을 가짐
-     */
     private Authentication createVerificationAuthentication(String email) {
         // 임시 인증 정보 생성 (이메일만 포함, 권한은 VERIFICATION 으로 제한)
         List<GrantedAuthority> authorities = Collections.singletonList(
                 new SimpleGrantedAuthority("ROLE_VERIFICATION"));
         
+        // String 대신 CustomUserDetails 객체 생성
+        CustomUserDetails userDetails = new CustomUserDetails(email, null, Role.VERIFICATION); // 또는 적절한 Role 사용
+        
         return new UsernamePasswordAuthenticationToken(
-                email, "", authorities);
+                userDetails, "", authorities);
     }
 }
 

--- a/src/main/java/org/ject/support/common/security/jwt/JwtExceptionHandlerFilter.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtExceptionHandlerFilter.java
@@ -5,6 +5,7 @@ import static org.ject.support.common.exception.GlobalErrorCode.INVALID_ACCESS_T
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -42,9 +43,14 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
         } catch (AuthenticationException e) {
             setErrorResponse(response, INVALID_ACCESS_TOKEN);
             log.error("AuthenticationException: {}", e.getMessage());
-        } catch (Exception e) {
-            setErrorResponse(response, INTERNAL_SERVER_ERROR);
-            log.error("Exception: {}", e.getMessage());
+        } catch (ServletException e) {
+            if (e.getCause() instanceof ClassCastException) {
+                setErrorResponse(response, INVALID_ACCESS_TOKEN);
+                log.error("ClassCastException: {}", e.getCause().getMessage());
+            } else {
+                setErrorResponse(response, INTERNAL_SERVER_ERROR);
+                log.error("Exception: {}", e.getMessage());
+            }
         }
     }
 

--- a/src/main/java/org/ject/support/domain/member/Role.java
+++ b/src/main/java/org/ject/support/domain/member/Role.java
@@ -1,5 +1,5 @@
 package org.ject.support.domain.member;
 
 public enum Role {
-    TEMP, USER, ADMIN
+    TEMP, USER, ADMIN, VERIFICATION
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #125 

## 📝작업 내용

- `JwtExceptionHandlerFilter` 에서 `Exception e` 로 필터 단에서 모든 예외를 잡는 부분을 `doFilter()` 사용 시 필요한 `ServletException e` 예외를 잡도록 수정 -> 토큰 사용시 시큐리티와 관계 없는 예외가 필터 단에서 잡히지 않도록 수정됨
- 임시 회원 가입을 위한 `verificationToken` 생성 시, `JwtAuthenticationFilter` 에서 `String` 대신 `CustomUserDetails` 객체를 생성하도록 수정

## ✅테스트 결과
![스크린샷 2025-03-21 오후 9 30 14](https://github.com/user-attachments/assets/5bfd2bff-3d1c-4244-950c-916979a21593)
