### PR TITLE
모니터링 툴 사용을 위한 actuator, prometheus 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,10 @@ dependencies {
     // jackon
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.0'
 
+    // monitoring
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
 }
 
 configurations {


### PR DESCRIPTION
## #️⃣연관된 이슈

close #113 

## 📝작업 내용

- 모니터링 툴(Grafana, Loki, Prometheus, Promtail) 사용을 위한 의존성 추가
  - `spring-boot-starter-actuator`
  - `micrometer-registry-prometheus` 

- 승인 후 s3에 존재하는 prod.yml 에 아래 내용이 추가될 예정입니다.
```yml
management:
  endpoints:
    web:
      exposure:
        include: prometheus, health, info
  prometheus:
    metrics:
      export:
        enabled: true
```