### PR TITLE
JWT 시크릿 키에 salt 사용

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -35,6 +35,7 @@ spring:
     token:
       access-expiration-time: 1800000  # 30분 (밀리초)
       refresh-expiration-time: 604800000  # 7일 (밀리초)
+      secret: secretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkey
 
 aws:
   access-key: accesskey

--- a/src/test/java/org/ject/support/common/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/ject/support/common/security/jwt/JwtTokenProviderTest.java
@@ -3,7 +3,6 @@ package org.ject.support.common.security.jwt;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.ject.support.common.exception.GlobalException;
-import org.ject.support.common.security.CustomUserDetailService;
 import org.ject.support.common.security.CustomUserDetails;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.Role;
@@ -31,9 +30,6 @@ class JwtTokenProviderTest {
     private JwtCookieProvider jwtCookieProvider;
 
     @Mock
-    private CustomUserDetailService customUserDetailService;
-
-    @Mock
     private HttpServletRequest request;
 
     private Member testMember;
@@ -45,6 +41,11 @@ class JwtTokenProviderTest {
         jwtCookieProvider = new JwtCookieProvider();
         ReflectionTestUtils.setField(jwtTokenProvider, "accessExpirationTime", 3600000L); // 1시간
         ReflectionTestUtils.setField(jwtTokenProvider, "refreshExpirationTime", 1209600000L); // 2주
+        
+        // secretKey 초기화 추가
+        String salt = "secretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkey";
+        ReflectionTestUtils.setField(jwtTokenProvider, "salt", salt);
+        jwtTokenProvider.init(); // PostConstruct 메서드 직접 호출
 
         testMember = Member.builder()
                 .id(1L)


### PR DESCRIPTION
## #️⃣연관된 이슈

close #143 

## 📝작업 내용

- `SecretKeyFor(SignatureAlgorithm.HS512)`을 사용해 내부적으로 랜덤한 키를 생성하던 기존 방식에서 yml파일에 저장된 secret키를 가져오는 방법으로 수정했습니다.
- 확실히 의존성 주입이 완료된 후 시크릿 키를 초기화 하기 위해 `JwtTokenProvider`에서 `@PostConstruct`를 사용했습니다.
- `@PostConstruct`는 단위 테스트에서는 자동으로 호출되지 않으므로, 직접 호출하도록 기존 테스트 코드를 수정했습니다.

## ✅테스트 결과

![스크린샷 2025-03-25 오후 8 46 27](https://github.com/user-attachments/assets/a83f9182-8602-4dd5-a561-d4fad7c3100b)