### PR TITLE
Recruit의 기간 필드의 타입을 LocalDateTime으로 변경

### DIFF
--- a/src/main/java/org/ject/support/domain/recruit/domain/Recruit.java
+++ b/src/main/java/org/ject/support/domain/recruit/domain/Recruit.java
@@ -11,7 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -39,11 +39,11 @@ public class Recruit extends BaseTimeEntity {
     @Column(length = 20, nullable = false)
     private String semester;
 
-    @Column
-    private LocalDate startDate;
+    @Column(nullable = false)
+    private LocalDateTime startDate;
 
-    @Column
-    private LocalDate endDate;
+    @Column(nullable = false)
+    private LocalDateTime endDate;
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(45)", nullable = false)
@@ -62,7 +62,7 @@ public class Recruit extends BaseTimeEntity {
      * @return 지원 `기한`인지
      */
     public Boolean isRecruitingPeriod() {
-        LocalDate now = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
         return startDate.isBefore(now) && endDate.isAfter(now);
     }
 

--- a/src/main/java/org/ject/support/domain/recruit/repository/QuestionQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/QuestionQueryRepository.java
@@ -3,10 +3,10 @@ package org.ject.support.domain.recruit.repository;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.dto.QuestionResponse;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface QuestionQueryRepository {
 
-    List<QuestionResponse> findByJobFamilyOfActiveRecruit(LocalDate currentDate, JobFamily jobFamily);
+    List<QuestionResponse> findByJobFamilyOfActiveRecruit(LocalDateTime now, JobFamily jobFamily);
 }

--- a/src/main/java/org/ject/support/domain/recruit/repository/QuestionQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/QuestionQueryRepositoryImpl.java
@@ -8,7 +8,7 @@ import org.ject.support.domain.recruit.dto.QQuestionResponse;
 import org.ject.support.domain.recruit.dto.QuestionResponse;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.ject.support.domain.recruit.domain.QQuestion.question;
@@ -21,7 +21,7 @@ public class QuestionQueryRepositoryImpl implements QuestionQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<QuestionResponse> findByJobFamilyOfActiveRecruit(final LocalDate currentDate,
+    public List<QuestionResponse> findByJobFamilyOfActiveRecruit(final LocalDateTime now,
                                                                  final JobFamily jobFamily) {
         return queryFactory.select(new QQuestionResponse(
                         question.id,
@@ -34,12 +34,12 @@ public class QuestionQueryRepositoryImpl implements QuestionQueryRepository {
                         question.maxLength))
                 .from(question)
                 .leftJoin(question.recruit, recruit)
-                .where(isWithinRecruitPeriod(currentDate), recruit.jobFamily.eq(jobFamily))
+                .where(isWithinRecruitPeriod(now), recruit.jobFamily.eq(jobFamily))
                 .orderBy(question.sequence.asc())
                 .fetch();
     }
 
-    private BooleanExpression isWithinRecruitPeriod(LocalDate currentDate) {
-        return recruit.startDate.before(currentDate).and(recruit.endDate.after(currentDate));
+    private BooleanExpression isWithinRecruitPeriod(LocalDateTime now) {
+        return recruit.startDate.before(now).and(recruit.endDate.after(now));
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/repository/RecruitQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/RecruitQueryRepository.java
@@ -5,5 +5,5 @@ import java.util.Optional;
 import org.ject.support.domain.recruit.domain.Recruit;
 
 public interface RecruitQueryRepository {
-    Optional<Recruit> findByStartDateAfterAndEndDateBefore(LocalDateTime time);
+    Optional<Recruit> findByStartDateAfterAndEndDateBefore(LocalDateTime now);
 }

--- a/src/main/java/org/ject/support/domain/recruit/repository/RecruitQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/RecruitQueryRepositoryImpl.java
@@ -1,14 +1,14 @@
 package org.ject.support.domain.recruit.repository;
 
-import static org.ject.support.domain.recruit.domain.QRecruit.recruit;
-
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.ject.support.domain.recruit.domain.QRecruit.recruit;
 
 @Repository
 @RequiredArgsConstructor
@@ -16,10 +16,9 @@ public class RecruitQueryRepositoryImpl implements RecruitQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Optional<Recruit> findByStartDateAfterAndEndDateBefore(final LocalDateTime time) {
-        LocalDate date = time.toLocalDate();
+    public Optional<Recruit> findByStartDateAfterAndEndDateBefore(final LocalDateTime now) {
         Recruit fetched = jpaQueryFactory.selectFrom(recruit)
-                .where(recruit.startDate.before(date).and(recruit.endDate.after(date)))
+                .where(recruit.startDate.before(now).and(recruit.endDate.after(now)))
                 .fetchFirst();
         return Optional.ofNullable(fetched);
     }

--- a/src/main/java/org/ject/support/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/RecruitRepository.java
@@ -1,14 +1,15 @@
 package org.ject.support.domain.recruit.repository;
 
-import java.time.LocalDate;
-import java.util.List;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface RecruitRepository extends JpaRepository<Recruit, Long>, RecruitQueryRepository {
     @Query("SELECT r FROM Recruit r LEFT JOIN FETCH r.questions"
-           + " WHERE r.startDate <= :currentDate AND r.endDate >= :currentDate")
-    List<Recruit> findActiveRecruits(@Param("currentDate") LocalDate currentDate);
+            + " WHERE r.startDate <= :now AND r.endDate >= :now")
+    List<Recruit> findActiveRecruits(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/AccessPeriodInitializer.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/AccessPeriodInitializer.java
@@ -1,7 +1,5 @@
 package org.ject.support.domain.recruit.service;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.dto.Constants;
@@ -10,6 +8,9 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 /**
  * 기한 외 접근 제한을 위한 flag caching 초기화
@@ -24,15 +25,14 @@ public class AccessPeriodInitializer implements ApplicationRunner {
     public void run(final ApplicationArguments args) {
         if (Boolean.FALSE.equals(redisTemplate.hasKey(Constants.PERIOD_FLAG))) {// flag가 저장되어있지 않으면
             recruitRepository.findByStartDateAfterAndEndDateBefore(LocalDateTime.now())
-                            .ifPresent(this::setRecruitFlag);
+                    .ifPresent(this::setRecruitFlag);
 
         }
     }
 
     private void setRecruitFlag(final Recruit recruit) {
-        redisTemplate.opsForValue().set(Constants.PERIOD_FLAG, Boolean.toString(true),// 존재여부를 redis에 저장
-                Duration.between(
-                        recruit.getStartDate().atTime(0, 0, 0), // TODO 애초에 recruit 기간을 시간까지 관리하는게 낫지 않나?
-                        recruit.getEndDate().atTime(23, 59, 59)));// ttl은 지원 기간동안 살아있도록
+        redisTemplate.opsForValue().set(
+                Constants.PERIOD_FLAG, Boolean.toString(true),// 존재여부를 redis에 저장
+                Duration.between(recruit.getStartDate(), recruit.getEndDate()));// ttl은 지원 기간동안 살아있도록
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/ApplyService.java
@@ -25,7 +25,7 @@ import org.ject.support.domain.tempapply.service.TemporaryApplyService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -112,7 +112,7 @@ public class ApplyService implements ApplyUsecase {
 
     //TODO 2025 02 20 17:07:14 : caching
     private Recruit getPeriodRecruit(final JobFamily jobFamily) {
-        return recruitRepository.findActiveRecruits(LocalDate.now()).stream()
+        return recruitRepository.findActiveRecruits(LocalDateTime.now()).stream()
                 .filter(recruit -> recruit.getJobFamily().equals(jobFamily))
                 .findAny()
                 .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND));

--- a/src/main/java/org/ject/support/domain/recruit/service/QuestionService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/QuestionService.java
@@ -8,7 +8,7 @@ import org.ject.support.domain.recruit.repository.QuestionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -20,6 +20,6 @@ public class QuestionService {
     @PeriodAccessible
     @Transactional(readOnly = true)
     public List<QuestionResponse> findQuestions(final JobFamily jobFamily) {
-        return questionRepository.findByJobFamilyOfActiveRecruit(LocalDate.now(), jobFamily);
+        return questionRepository.findByJobFamilyOfActiveRecruit(LocalDateTime.now(), jobFamily);
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitScheduleService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitScheduleService.java
@@ -1,7 +1,5 @@
 package org.ject.support.domain.recruit.service;
 
-import java.time.Instant;
-import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.dto.Constants;
@@ -14,6 +12,9 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.Instant;
+import java.time.ZoneId;
 
 @Service
 @RequiredArgsConstructor
@@ -29,13 +30,13 @@ public class RecruitScheduleService {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleRecruitOpened(RecruitOpenedEvent event) {
         Recruit recruit = getRecruit(event);
+        System.out.println("recruit.getId() = " + recruit.getId());
 
         //end date 전에는 flag를 true로
         redisTemplate.opsForValue().set(Constants.PERIOD_FLAG, Boolean.TRUE.toString());
 
-
         Instant triggerTime = recruit.getEndDate()
-                .atStartOfDay(ZoneId.systemDefault())
+                .atZone(ZoneId.systemDefault())
                 .toInstant();
 
         recruitScheduler.schedule(() -> {

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -1,6 +1,5 @@
 package org.ject.support.domain.file.controller;
 
-import java.time.LocalDate;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.repository.MemberRepository;
@@ -18,6 +17,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.ject.support.domain.member.Role.USER;
@@ -65,8 +66,8 @@ class FileControllerTest extends ApplicationPeriodTest {
         recruitRepository.save(Recruit.builder()
                 .jobFamily(JobFamily.BE)
                 .semester("2021-1")
-                .startDate(LocalDate.now().minusDays(1))
-                .endDate(LocalDate.now().plusDays(1))
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
                 .build());
 
         mockMvc.perform(post("/upload/portfolios")
@@ -86,8 +87,8 @@ class FileControllerTest extends ApplicationPeriodTest {
         recruitRepository.save(Recruit.builder()
                 .jobFamily(JobFamily.BE)
                 .semester("2021-1")
-                .startDate(LocalDate.now().plusDays(3))
-                .endDate(LocalDate.now().plusDays(5))
+                .startDate(LocalDateTime.now().plusDays(3))
+                .endDate(LocalDateTime.now().plusDays(5))
                 .build());
 
         when(redisTemplate.opsForValue().get(Constants.PERIOD_FLAG)).thenReturn(Boolean.toString(false));
@@ -109,8 +110,8 @@ class FileControllerTest extends ApplicationPeriodTest {
         recruitRepository.save(Recruit.builder()
                 .jobFamily(JobFamily.BE)
                 .semester("2021-1")
-                .startDate(LocalDate.now().plusDays(3))
-                .endDate(LocalDate.now().plusDays(5))
+                .startDate(LocalDateTime.now().plusDays(3))
+                .endDate(LocalDateTime.now().plusDays(5))
                 .build());
 
         when(redisTemplate.opsForValue().get(Constants.PERIOD_FLAG)).thenReturn(Boolean.toString(false));

--- a/src/test/java/org/ject/support/domain/recruit/controller/ApplyControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/ApplyControllerTest.java
@@ -24,7 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -70,8 +70,8 @@ class ApplyControllerTest extends ApplicationPeriodTest {
         );
 
         Recruit recruit = Recruit.builder()
-                .startDate(LocalDate.now().minusDays(1))
-                .endDate(LocalDate.now().plusDays(1))
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
                 .semester("2025-1")
                 .jobFamily(JobFamily.BE)
                 .build();

--- a/src/test/java/org/ject/support/domain/recruit/domain/RecruitTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/domain/RecruitTest.java
@@ -27,4 +27,33 @@ class RecruitTest {
         // then
         assertThat(isRecruitingPeriod).isTrue();
     }
+
+    @Test
+    @DisplayName("is invalid question id")
+    void is_invalid_question_id() {
+        // given
+        Recruit recruit = Recruit.builder()
+                .semester("2025-1")
+                .jobFamily(JobFamily.BE)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        Question question = Question.builder()
+                .id(1L)
+                .sequence(1)
+                .inputType(Question.InputType.TEXT)
+                .isRequired(true)
+                .title("title")
+                .recruit(recruit)
+                .build();
+
+        recruit.addQuestion(question);
+
+        // when
+        boolean isInvalidQuestionId = recruit.isInvalidQuestionId(2L);
+
+        // then
+        assertThat(isInvalidQuestionId).isTrue();
+    }
 }

--- a/src/test/java/org/ject/support/domain/recruit/domain/RecruitTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/domain/RecruitTest.java
@@ -1,0 +1,30 @@
+package org.ject.support.domain.recruit.domain;
+
+import org.ject.support.domain.member.JobFamily;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecruitTest {
+
+    @Test
+    @DisplayName("is recruiting period")
+    void is_recruiting_period() {
+        // given
+        Recruit recruit = Recruit.builder()
+                .semester("2025-1")
+                .jobFamily(JobFamily.BE)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        // when
+        Boolean isRecruitingPeriod = recruit.isRecruitingPeriod();
+
+        // then
+        assertThat(isRecruitingPeriod).isTrue();
+    }
+}

--- a/src/test/java/org/ject/support/domain/recruit/repository/QuestionQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/repository/QuestionQueryRepositoryTest.java
@@ -1,6 +1,5 @@
 package org.ject.support.domain.recruit.repository;
 
-import org.assertj.core.api.Assertions;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Question;
 import org.ject.support.domain.recruit.domain.Recruit;
@@ -12,10 +11,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.ject.support.domain.member.JobFamily.BE;
 import static org.ject.support.domain.member.JobFamily.FE;
 import static org.ject.support.domain.recruit.domain.Question.InputType.FILE;
@@ -35,7 +34,7 @@ class QuestionQueryRepositoryTest {
     @DisplayName("현재 모집중인 직군의 지원서 문항 조회")
     void find_by_job_family() {
         // given
-        LocalDate now = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
         Recruit feRecruit = createRecruit(now, FE);
         Recruit beRecruit = createRecruit(now, BE);
         recruitRepository.saveAll(List.of(feRecruit, beRecruit));
@@ -56,11 +55,11 @@ class QuestionQueryRepositoryTest {
                 .containsExactly(1, 2, 3);
     }
 
-    private Recruit createRecruit(LocalDate currentDate, JobFamily be) {
+    private Recruit createRecruit(LocalDateTime now, JobFamily be) {
         return Recruit.builder()
                 .semester("1기")
-                .startDate(currentDate.minusDays(1))
-                .endDate(currentDate.plusDays(1))
+                .startDate(now.minusDays(1))
+                .endDate(now.plusDays(1))
                 .jobFamily(be)
                 .build();
     }

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitScheduleServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitScheduleServiceTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.verify;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.dto.Constants;
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -27,9 +30,6 @@ class RecruitScheduleServiceTest {
     @Autowired
     private RedisTemplate<String, String> redisTemplate;
 
-    @Autowired
-    private RecruitScheduleService recruitScheduleService;
-
     @MockitoBean
     private TaskScheduler recruitScheduler;
 
@@ -40,13 +40,10 @@ class RecruitScheduleServiceTest {
         Recruit recruit = Recruit.builder()
                 .semester("2025-1")
                 .jobFamily(JobFamily.BE)
-                .startDate(LocalDate.now())
-                .endDate(LocalDate.now().plusDays(1))
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(1))
                 .build();
         recruitRepository.save(recruit);
-
-        RecruitOpenedEvent event = new RecruitOpenedEvent(recruit.getId());
-        recruitScheduleService.handleRecruitOpened(event);
 
         // 스케줄 등록 직후
         Boolean beforeScheduleFinishedFlag = Boolean.valueOf(redisTemplate.opsForValue().get(Constants.PERIOD_FLAG));


### PR DESCRIPTION
## #️⃣연관된 이슈

close #149 

## 📝작업 내용
- Recruit의 startDate와 endDate의 타입을 LocalDateTime으로 변경
- 타입 변경으로 인한 RecruitScheduleServiceTest#test_schedule_end_date_of_recruit 실패 문제 해결
- Recruit의 isRecruitingPeriod와 isInvalidQuesionId 메서드 단위 테스트

## ✅테스트 결과
<img width="564" alt="스크린샷 2025-03-27 오후 4 33 52" src="https://github.com/user-attachments/assets/4ff4f7c2-2937-4088-aa83-f70b26a0bf92" />

<img width="564" alt="스크린샷 2025-03-27 오후 4 33 16" src="https://github.com/user-attachments/assets/064ba123-f0d4-4172-8c8b-cf0361ba16fe" />

## 🙏리뷰 요구사항
Recruit 엔티티의 시작/마감일을 LocalDateTime으로 변경 시, RecruitScheduleServiceTest#test_schedule_end_date_of_recruit 테스트가 실패했습니다.
![image](https://github.com/user-attachments/assets/6d4470fc-fe9c-4075-8a1d-b8024858d149)

기존 LocalDate 타입의 경우 isBefore 메서드가 같은 날짜를 포함하지 않아, Recruit의 isRecruitingPeriod 조건에 걸려 이벤트가 발행되지 않았습니다.
하지만 LocalDateTime의 isBefore 메서드는 시분초까지 다루기 때문에, 1초라도 과거라면 isBefore 메서드는 true를 반환합니다. 
이로 인해 이벤트가 정상 발행되는데, 테스트 코드에서 handleRecruitOpened 메서드를 또 한 번 호출해서 verify가 실패한 것입니다.

따라서, handleRecruitOpened 메서드를 호출하는 부분을 제거했습니다.

