### PR TITLE
지원서 문항 조회 기능에 캐싱 적용

### DIFF
--- a/src/main/java/org/ject/support/common/data/redis/RedisConfig.java
+++ b/src/main/java/org/ject/support/common/data/redis/RedisConfig.java
@@ -88,7 +88,7 @@ public class RedisConfig {
         return RedisCacheConfiguration
                 .defaultCacheConfig()
                 .disableCachingNullValues()
-                .entryTtl(Duration.ofMinutes(2))
+                .entryTtl(Duration.ofDays(1))
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(redisKeySerializer))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(redisValueSerializer));
     }

--- a/src/main/java/org/ject/support/domain/recruit/service/QuestionService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/QuestionService.java
@@ -5,6 +5,7 @@ import org.ject.support.common.util.PeriodAccessible;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.dto.QuestionResponse;
 import org.ject.support.domain.recruit.repository.QuestionRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +18,7 @@ public class QuestionService {
 
     private final QuestionRepository questionRepository;
 
+    @Cacheable(value = "question", key = "#jobFamily")
     @PeriodAccessible
     @Transactional(readOnly = true)
     public List<QuestionResponse> findQuestions(final JobFamily jobFamily) {

--- a/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
@@ -1,0 +1,104 @@
+package org.ject.support.domain.recruit.controller;
+
+import org.assertj.core.api.Assertions;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.recruit.domain.Question;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.repository.QuestionRepository;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.ject.support.testconfig.AuthenticatedUser;
+import org.ject.support.testconfig.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.ject.support.domain.member.Role.USER;
+import static org.ject.support.domain.recruit.domain.Question.InputType.TEXT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+class QuestionControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    RecruitRepository recruitRepository;
+
+    @Autowired
+    QuestionRepository questionRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+
+    Member member;
+
+    @BeforeEach
+    void setUp() {
+        List<Question> questions = List.of(
+                Question.builder().sequence(1).inputType(TEXT).isRequired(true).title("title1").body("question1").build(),
+                Question.builder().sequence(2).inputType(TEXT).isRequired(true).title("title2").body("question2").build(),
+                Question.builder().sequence(3).inputType(TEXT).isRequired(true).title("title3").body("question3").build(),
+                Question.builder().sequence(4).inputType(TEXT).isRequired(true).title("title4").body("question4").build(),
+                Question.builder().sequence(5).inputType(TEXT).isRequired(true).title("title5").body("question5").build()
+        );
+
+        Recruit recruit = Recruit.builder()
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .semester("2025-1")
+                .jobFamily(JobFamily.BE)
+                .build();
+
+        for (Question question : questions) {
+            recruit.addQuestion(question);
+        }
+
+        recruitRepository.save(recruit);
+
+        member = Member.builder()
+                .email("test32@gmail.com")
+                .jobFamily(JobFamily.BE)
+                .name("김젝트")
+                .role(USER)
+                .phoneNumber("01012345678")
+                .semester("2025-1")
+                .pin("123456") // PIN 필드 추가
+                .build();
+        memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("지원서 문항 조회 시 redis에 캐싱")
+    @AuthenticatedUser
+    void find_questions_cache() throws Exception {
+        // when
+        mockMvc.perform(get("/apply/questions")
+                        .param("jobFamily", "BE"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("SUCCESS")))
+                .andDo(print());
+
+        // then
+        Long countExistingKeys = redisTemplate.countExistingKeys(List.of("question::BE"));
+        Assertions.assertThat(countExistingKeys).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #141 

## 📝작업 내용
- redis 캐시 기본 ttl을 1일로 변경
- 지원서 문항 조회 기능에 캐싱 적용

## ✅테스트 결과
<img width="592" alt="스크린샷 2025-03-29 오전 1 41 18" src="https://github.com/user-attachments/assets/166a09bb-db9f-48c7-a02c-b58e0c274d30" />
