### PR TITLE
핀 재설정 시 이메일 발송 및 인증 번호 검증 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/domain/auth/AuthController.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthController.java
@@ -2,13 +2,13 @@ package org.ject.support.domain.auth;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.ject.support.common.security.AuthPrincipal;
 import org.ject.support.domain.auth.AuthDto.TokenRefreshRequest;
 import org.ject.support.domain.auth.AuthDto.TokenRefreshResponse;
 import org.ject.support.domain.auth.AuthDto.PinLoginRequest;
 import org.ject.support.domain.auth.AuthDto.PinLoginResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeRequest;
+import org.ject.support.external.email.EmailTemplate;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,8 +30,9 @@ public class AuthController {
      */
     @PostMapping("/code")
     @PreAuthorize("permitAll()")
-    public VerifyAuthCodeOnlyResponse verifyAuthCode(@RequestBody VerifyAuthCodeRequest request) {
-        return authService.verifyEmailByAuthCodeOnly(request.email(), request.authCode());
+    public VerifyAuthCodeOnlyResponse verifyAuthCode(@RequestBody VerifyAuthCodeRequest request,
+                                                     @RequestParam EmailTemplate template) {
+        return authService.verifyEmailByAuthCodeOnly(request.email(), request.authCode(), template);
     }
     
     /**

--- a/src/main/java/org/ject/support/domain/auth/AuthDto.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthDto.java
@@ -10,8 +10,8 @@ public class AuthDto {
         // 이메일 인증 코드 검증 요청 DTO
     }
 
-    public record VerifyAuthCodeOnlyResponse(String verificationToken) {
-        // 인증번호 검증 성공 시 발급되는 임시 토큰과 기존 회원 여부
+    public record VerifyAuthCodeOnlyResponse(String token) {
+        // 인증번호 검증 성공 시 발급되는 토큰
     }
     
     public record PinLoginRequest(

--- a/src/main/java/org/ject/support/domain/auth/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthService.java
@@ -53,6 +53,8 @@ public class AuthService {
             Authentication authentication = jwtTokenProvider.createAuthenticationByMember(member);
             String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
 
+            deleteAuthCode(email);
+
             return new VerifyAuthCodeOnlyResponse(accessToken);
         }
 

--- a/src/main/java/org/ject/support/domain/auth/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthService.java
@@ -1,28 +1,26 @@
 package org.ject.support.domain.auth;
 
 
-import static org.ject.support.domain.auth.AuthErrorCode.EXPIRED_REFRESH_TOKEN;
-import static org.ject.support.domain.auth.AuthErrorCode.INVALID_AUTH_CODE;
-import static org.ject.support.domain.auth.AuthErrorCode.INVALID_REFRESH_TOKEN;
-import static org.ject.support.domain.auth.AuthErrorCode.INVALID_CREDENTIALS;
-import static org.ject.support.domain.auth.AuthErrorCode.NOT_FOUND_AUTH_CODE;
-import static org.ject.support.domain.member.exception.MemberErrorCode.NOT_FOUND_MEMBER;
+import static org.ject.support.domain.auth.AuthErrorCode.*;
+import static org.ject.support.domain.member.exception.MemberErrorCode.*;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
-import lombok.RequiredArgsConstructor;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
-import org.ject.support.domain.auth.AuthDto.TokenRefreshResponse;
 import org.ject.support.domain.auth.AuthDto.PinLoginResponse;
+import org.ject.support.domain.auth.AuthDto.TokenRefreshResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.external.email.EmailTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -43,12 +41,25 @@ public class AuthService {
      * @param userInputCode 사용자가 입력한 인증번호
      */
     @Transactional
-    public VerifyAuthCodeOnlyResponse verifyEmailByAuthCodeOnly(String email, String userInputCode) {
+    public VerifyAuthCodeOnlyResponse verifyEmailByAuthCodeOnly(String email, String userInputCode,
+                                                                EmailTemplate template) {
         // 인증번호 검증
         verifyAuthCode(email, userInputCode);
 
+        // 핀 재설정 이메일 요청일 경우, accessToken 발급
+        if (template == EmailTemplate.PIN_RESET) {
+            Member member = findMember(email);
+
+            Authentication authentication = jwtTokenProvider.createAuthenticationByMember(member);
+            String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
+
+            return new VerifyAuthCodeOnlyResponse(accessToken);
+        }
+
         // 임시 토큰 발급 - 인증번호 검증이 완료되었음을 증명하는 토큰
         String verificationToken = jwtTokenProvider.createVerificationToken(email);
+
+        deleteAuthCode(email);
 
         // 임시 토큰 반환
         return new VerifyAuthCodeOnlyResponse(verificationToken);
@@ -64,8 +75,7 @@ public class AuthService {
     @Transactional
     public PinLoginResponse loginWithPin(String email, String pin) {
         // 이메일로 회원 조회
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+        Member member = findMember(email);
         
         // PIN 번호 검증
         if (!passwordEncoder.matches(pin, member.getPin())) {
@@ -78,6 +88,11 @@ public class AuthService {
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication, member.getId());
         
         return new PinLoginResponse(accessToken, refreshToken);
+    }
+
+    private Member findMember(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
     }
 
     private void verifyAuthCode(String email, String userInputCode) {
@@ -93,8 +108,9 @@ public class AuthService {
         if (!userInputCode.equals(redisCode)) {
             throw new AuthException(INVALID_AUTH_CODE);
         }
+    }
 
-        // 인증 성공
+    private void deleteAuthCode(String email) {
         redisTemplate.delete(email);
     }
 

--- a/src/main/java/org/ject/support/external/email/EmailAuthService.java
+++ b/src/main/java/org/ject/support/external/email/EmailAuthService.java
@@ -20,10 +20,10 @@ public class EmailAuthService {
     private final RedisTemplate<String, String> redisTemplate;
     private final EmailSendService emailSendService;
 
-    public void sendAuthCode(String email) {
+    public void sendAuthCode(String email, EmailTemplate template) {
         String authCode = generateAuthCode();
         storeAuthCode(email, authCode);
-        sendAuthCodeEmail(email, authCode);
+        sendAuthCodeEmail(email, authCode, template);
     }
 
     private String generateAuthCode() {
@@ -40,11 +40,11 @@ public class EmailAuthService {
         log.info("인증 번호 전송 - email: {}, code: {}", email, authCode);
     }
 
-    private void sendAuthCodeEmail(String email, String authCode) {
+    private void sendAuthCodeEmail(String email, String authCode, EmailTemplate template) {
         // TODO: 정책 추가 시 인증 번호 전송 횟수 제한 로직 추가
         emailSendService.sendEmail(
             email,
-            EmailTemplate.CERTIFICATE,
+            template,
             Map.of("to", email, "value", authCode)
         );
     }

--- a/src/main/java/org/ject/support/external/email/EmailController.java
+++ b/src/main/java/org/ject/support/external/email/EmailController.java
@@ -17,7 +17,7 @@ public class EmailController {
 
     @PostMapping("/send/auth")
     @PreAuthorize("permitAll()")
-    public void sendAuthEmail(@RequestParam String email) {
-        authEmailService.sendAuthCode(email);
+    public void sendAuthEmail(@RequestParam String email, @RequestParam EmailTemplate template) {
+        authEmailService.sendAuthCode(email, template);
     }
 }

--- a/src/main/java/org/ject/support/external/email/EmailTemplate.java
+++ b/src/main/java/org/ject/support/external/email/EmailTemplate.java
@@ -19,7 +19,8 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 public enum EmailTemplate {
     ACCEPTANCE("email-template", "ject notification"),
     REJECTION("email-template", "ject notification"),
-    CERTIFICATE("email-template", "ject certificate");
+    CERTIFICATE("email-template", "ject certificate"),
+    PIN_RESET("email-template", "ject pin reset"); // TODO: HTML 템플릿별로 수정 필요
 
     private final String templateName;// template file name
     private final String subject;// email subject


### PR DESCRIPTION
## #️⃣연관된 이슈

close #156

## 📝작업 내용

- 인증 이메일 발송 시 기존 구현 되어 있던 EmailTemplate 사용
- 인증 번호 검증 시 파라미터의 EmailTemplate에 따라 다른 토큰 발급하도록 구현

## ✅테스트 결과
<img width="359" alt="스크린샷 2025-04-03 오후 5 22 29" src="https://github.com/user-attachments/assets/5f8f5542-c8d6-4286-9602-e043cd1086b9" />


## 🙏리뷰 요구사항(선택)

인증 번호 검증 부분을 조금 더 확장 가능하게 할 수 있을 거 같긴 합니다. 그런데 아직 기획 측면에서 예정된 확장 가능성이 없다보니, 고민이 많이 되었습니다.

전략 패턴을 도입하자니 배보다 배꼽이 더 커지는 것 같고, switch문은 좀.. 짜치다고 생각했습니다.
그래서 그냥 조건문으로만 이메일 템플릿을 검증하도록 구현했습니다. 사실 '인증 번호 발송' 메일은 그 범주가 되게 제한적이니까요.
'어디까지 확장 가능성을 열어 놓을 것인가' - '정말 필요한 구현인가' 의 트레이드 오프 사이에서 꽤 고민했습니다. 
좋은 의견이 있으시면 알려주세요!