### PR TITLE
쿠키 발급 시 setSecure 설정 활성화

### DIFF
--- a/src/main/java/org/ject/support/common/security/jwt/JwtCookieProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtCookieProvider.java
@@ -17,21 +17,21 @@ public class JwtCookieProvider {
 
     public Cookie createRefreshCookie(String refreshToken) {
         String cookieName = "refreshToken";
-        Cookie cookie = new Cookie(cookieName, refreshToken);
-        cookie.setHttpOnly(true);
-        //cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setMaxAge((int)(refreshExpirationTime / 1000));
-        return cookie;
+        return createCookie(cookieName, refreshToken);
     }
 
     public Cookie createAccessCookie(String accessToken) {
         String cookieName = "accessToken";
-        Cookie cookie = new Cookie(cookieName, accessToken);
+        return createCookie(cookieName, accessToken);
+    }
+
+    private Cookie createCookie(String cookieName, String token) {
+        Cookie cookie = new Cookie(cookieName, token);
         cookie.setHttpOnly(true);
-        //cookie.setSecure(true); TODO : HTTPS 적용 시 적용 가능
+        cookie.setSecure(true);
         cookie.setPath("/");
-        cookie.setMaxAge((int)(accessExpirationTime / 1000));
+        cookie.setMaxAge((int)(refreshExpirationTime / 1000));
+
         return cookie;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #186

## 📝작업 내용

- 프론트 https 배포 완료에 따른, 쿠키 발급 시 `setSecure` 설정 활성화
- 쿠키 발급 로직 메서드화

## ✅테스트 결과
<img width="304" alt="스크린샷 2025-04-11 오후 10 24 41" src="https://github.com/user-attachments/assets/ea8c56d1-961a-4e8e-ac70-f1a853f0a922" />
