### PR TITLE
Logback + CloudWatch 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // logback
+    implementation "ca.pjer:logback-awslogs-appender:1.6.0"
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.0")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter'
+
 }
 
 configurations {

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -58,10 +58,6 @@ decorator:
       enable-logging: false
 
 logging:
-  level:
-    org:
-      springframework:
-        jdbc: trace
   config: classpath:logs/logback-local.xml
 
 security:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -62,6 +62,7 @@ logging:
     org:
       springframework:
         jdbc: trace
+  config: classpath:logs/logback-local.xml
 
 security:
   cors:

--- a/src/main/resources/logs/logback-local.xml
+++ b/src/main/resources/logs/logback-local.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%5level) %cyan(%logger) - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="org.ject.support" level="DEBUG" />
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>

--- a/src/main/resources/logs/logback-prod.xml
+++ b/src/main/resources/logs/logback-prod.xml
@@ -1,0 +1,27 @@
+<configuration>
+    <springProperty name="ACCESS_KEY" source="aws.cloudwatch.access-key"/>
+    <springProperty name="SECRET_KEY" source="aws.cloudwatch.secret-key"/>
+    <springProperty name="LOG_REGION" source="aws.cloudwatch.region"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%5level) %cyan(%logger) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="AWS_LOGS" class="ca.pjer.logback.AwsLogsAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>info</level>
+        </filter>
+        <logGroupName>JECT-log</logGroupName>
+        <logStreamUuidPrefix>JECT-log-</logStreamUuidPrefix>
+        <logRegion>${LOG_REGION}</logRegion>
+        <accessKeyId>${ACCESS_KEY}</accessKeyId>
+        <secretAccessKey>${SECRET_KEY}</secretAccessKey>
+    </appender>
+
+    <logger name="org.ject.support" level="DEBUG" />
+    <root level="INFO">
+        <appender-ref ref="AWS_LOGS"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## #️⃣연관된 이슈

close #165 

## 📝작업 내용

- 운영환경별 (local, prod) logback.xml 파일 작성
- CloudWatch 전용 IAM 관련 키 prod.yml 에 작성

## ✅테스트 결과
![스크린샷 2025-04-12 오후 11 58 31](https://github.com/user-attachments/assets/ddc6351a-1376-47fb-be87-7898142d9552)
![스크린샷 2025-04-12 오후 11 59 27](https://github.com/user-attachments/assets/829b5558-63e7-4c48-a5f5-0a5aef1bc784)

## 다음 작업
- 로컬에서 그라파나 볼 수 있게 설정