### PR TITLE
토큰을 쿠키에서 가져오도록 인증 로직 수정

### DIFF
--- a/src/main/java/org/ject/support/common/security/CustomSuccessHandler.java
+++ b/src/main/java/org/ject/support/common/security/CustomSuccessHandler.java
@@ -33,4 +33,10 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         response.addCookie(jwtCookieProvider.createVerificationCookie(verificationToken));
     }
+
+    public void onAuthenticationSuccess(HttpServletResponse response, String refreshToken, Long memberId) {
+        String newAccessToken = jwtTokenProvider.reissueAccessToken(refreshToken, memberId);
+
+        response.addCookie(jwtCookieProvider.createAccessCookie(newAccessToken));
+    }
 }

--- a/src/main/java/org/ject/support/common/security/CustomSuccessHandler.java
+++ b/src/main/java/org/ject/support/common/security/CustomSuccessHandler.java
@@ -28,12 +28,23 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.addCookie(jwtCookieProvider.createAccessCookie(accessToken));
     }
 
+    /**
+     * 이메일 인증 성공 시 호출되는 메서드
+     * @param response HttpServletResponse
+     * @param email 인증된 이메일
+     */
     public void onAuthenticationSuccess(HttpServletResponse response, String email) {
         String verificationToken = jwtTokenProvider.createVerificationToken(email);
 
         response.addCookie(jwtCookieProvider.createVerificationCookie(verificationToken));
     }
 
+    /**
+     * 리프레시 토큰을 통한 액세스 토큰 재발급 성공 시 호출되는 메서드
+     * @param response HttpServletResponse
+     * @param refreshToken 재발급된 리프레시 토큰
+     * @param memberId 회원 ID
+     */
     public void onAuthenticationSuccess(HttpServletResponse response, String refreshToken, Long memberId) {
         String newAccessToken = jwtTokenProvider.reissueAccessToken(refreshToken, memberId);
 

--- a/src/main/java/org/ject/support/common/security/CustomSuccessHandler.java
+++ b/src/main/java/org/ject/support/common/security/CustomSuccessHandler.java
@@ -20,13 +20,17 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) {
-
-
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
         String accessToken = jwtTokenProvider.createAccessToken(authentication, customUserDetails.getMemberId());
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication, customUserDetails.getMemberId());
 
         response.addCookie(jwtCookieProvider.createRefreshCookie(refreshToken));
         response.addCookie(jwtCookieProvider.createAccessCookie(accessToken));
+    }
+
+    public void onAuthenticationSuccess(HttpServletResponse response, String email) {
+        String verificationToken = jwtTokenProvider.createVerificationToken(email);
+
+        response.addCookie(jwtCookieProvider.createVerificationCookie(verificationToken));
     }
 }

--- a/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
@@ -41,7 +41,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
-        String token = jwtTokenProvider.resolveToken(request);
+        String token = jwtTokenProvider.resolveAccessToken(request);
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
             try {

--- a/src/main/java/org/ject/support/common/security/jwt/JwtCookieProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtCookieProvider.java
@@ -15,7 +15,7 @@ public class JwtCookieProvider {
     @Value("${security.cors.cookie.domain}")
     private String domain;
 
-    public Cookie createRefreshCookie(String refreshToken) {
+    public Cookie createRefreshCookie(String refreshToken) { // TODO: 토큰 생성 로직 통합 및 토큰 정보 enum에서 관리하도록 리팩토링
         String cookieName = "refreshToken";
         return createCookie(cookieName, refreshToken);
     }
@@ -23,6 +23,11 @@ public class JwtCookieProvider {
     public Cookie createAccessCookie(String accessToken) {
         String cookieName = "accessToken";
         return createCookie(cookieName, accessToken);
+    }
+
+    public Cookie createVerificationCookie(String verificationToken) {
+        String cookieName = "verificationToken";
+        return createCookie(cookieName, verificationToken);
     }
 
     private Cookie createCookie(String cookieName, String token) {

--- a/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.util.Date;
@@ -43,7 +44,7 @@ public class JwtTokenProvider {
         this.secretKey = Keys.hmacShaKeyFor(decodeSecret);
     }
 
-    public String createAccessToken(Authentication authentication, Long memberId) {
+    public String createAccessToken(Authentication authentication, Long memberId) { // TODO: 리팩토링 필요
         validateAuthentication(authentication);
         Claims claims = Jwts.claims();
         claims.put("memberId", memberId);
@@ -101,10 +102,22 @@ public class JwtTokenProvider {
     }
 
     public String resolveToken(HttpServletRequest request) {
+        // 헤더에서 토큰 가져오기
         String bearerToken = request.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }
+        
+        // 헤더에 토큰이 없으면 쿠키에서 토큰 가져오기
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        
         return null;
     }
 

--- a/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
@@ -101,7 +101,7 @@ public class JwtTokenProvider {
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
-    public String resolveToken(HttpServletRequest request) {
+    public String resolveAccessToken(HttpServletRequest request) {
         // 헤더에서 토큰 가져오기
         String bearerToken = request.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
@@ -118,6 +118,18 @@ public class JwtTokenProvider {
             }
         }
         
+        return null;
+    }
+
+    public String resolveRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refreshToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
         return null;
     }
 

--- a/src/main/java/org/ject/support/domain/auth/AuthController.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthController.java
@@ -1,15 +1,12 @@
 package org.ject.support.domain.auth;
 
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import org.ject.support.domain.auth.AuthDto.TokenRefreshRequest;
-import org.ject.support.domain.auth.AuthDto.TokenRefreshResponse;
+import org.ject.support.common.security.CustomSuccessHandler;
+import org.ject.support.common.security.jwt.JwtTokenProvider;
 import org.ject.support.domain.auth.AuthDto.PinLoginRequest;
-import org.ject.support.domain.auth.AuthDto.PinLoginResponse;
-import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeRequest;
 import org.ject.support.external.email.EmailTemplate;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,12 +14,19 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
+    private final CustomSuccessHandler customSuccessHandler;
+    private final JwtTokenProvider jwtTokenProvider;
 
     /**
      * 인증번호 검증 API
@@ -30,9 +34,15 @@ public class AuthController {
      */
     @PostMapping("/code")
     @PreAuthorize("permitAll()")
-    public VerifyAuthCodeOnlyResponse verifyAuthCode(@RequestBody VerifyAuthCodeRequest request,
-                                                     @RequestParam EmailTemplate template) {
-        return authService.verifyEmailByAuthCodeOnly(request.email(), request.authCode(), template);
+    public void verifyAuthCode(@RequestBody VerifyAuthCodeRequest verifyAuthCodeRequest, HttpServletRequest request,
+                               HttpServletResponse response, @RequestParam EmailTemplate template) {
+        if (template == EmailTemplate.CERTIFICATE) { // TODO: 추후 리팩토링 필요
+            Authentication authentication = authService.verifyEmailByAuthCodeOnly(verifyAuthCodeRequest.email(),
+                    verifyAuthCodeRequest.authCode());
+            customSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+        } else if (template == EmailTemplate.PIN_RESET) {
+            customSuccessHandler.onAuthenticationSuccess(response, verifyAuthCodeRequest.email());
+        }
     }
     
     /**
@@ -41,18 +51,23 @@ public class AuthController {
      */
     @PostMapping("/refresh")
     @PreAuthorize("permitAll()")
-    public TokenRefreshResponse refreshToken(@RequestBody TokenRefreshRequest request) {
-        return authService.refreshAccessToken(request.refreshToken());
+    public void refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
+        Long memberId = authService.refreshAccessToken(refreshToken);
+        customSuccessHandler.onAuthenticationSuccess(response, refreshToken, memberId);
     }
 
     /**
      * PIN 로그인 API
      * 이메일과 PIN 번호로 로그인하고 액세스 토큰과 리프레시 토큰을 발급합니다.
+     * CustomSuccessHandler를 통해 쿠키에 토큰을 저장합니다.
      */
     @PostMapping("/login/pin")
     @PreAuthorize("permitAll()")
-    public PinLoginResponse loginWithPin(@RequestBody @Valid PinLoginRequest request) {
-        return authService.loginWithPin(request.email(), request.pin());
+    public void loginWithPin(@RequestBody @Valid PinLoginRequest request, HttpServletRequest httpRequest, HttpServletResponse response) {
+        Authentication authentication = authService.loginWithPin(request.email(), request.pin());
+        
+        customSuccessHandler.onAuthenticationSuccess(httpRequest, response, authentication);
     }
 
     @GetMapping("/login/exist")

--- a/src/main/java/org/ject/support/domain/auth/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthService.java
@@ -5,13 +5,9 @@ import static org.ject.support.domain.auth.AuthErrorCode.*;
 import static org.ject.support.domain.member.exception.MemberErrorCode.*;
 
 import org.ject.support.common.security.jwt.JwtTokenProvider;
-import org.ject.support.domain.auth.AuthDto.PinLoginResponse;
-import org.ject.support.domain.auth.AuthDto.TokenRefreshResponse;
-import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberRepository;
-import org.ject.support.external.email.EmailTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -35,36 +31,20 @@ public class AuthService {
     /**
      * 인증번호 검증만 수행하고 임시 토큰을 발급합니다.
      * 이메일 인증 -> 인증번호 입력 단계에서 호출됩니다.
-     * 인증번호 검증이 성공하면 임시 토큰을 발급하여 반환합니다.
-     * 이 토큰은 사용자 정보를 포함하지 않고, 인증번호 검증이 완료되었음을 증명하는 용도로만 사용됩니다.
+     * 인증번호 검증이 성공하면 Authentication 객체를 반환합니다.
      * @param email 인증할 이메일 주소
      * @param userInputCode 사용자가 입력한 인증번호
      */
     @Transactional
-    public VerifyAuthCodeOnlyResponse verifyEmailByAuthCodeOnly(String email, String userInputCode,
-                                                                EmailTemplate template) {
+    public Authentication verifyEmailByAuthCodeOnly(String email, String userInputCode) {
         // 인증번호 검증
         verifyAuthCode(email, userInputCode);
+        Member member = findMember(email);
 
-        // 핀 재설정 이메일 요청일 경우, accessToken 발급
-        if (template == EmailTemplate.PIN_RESET) {
-            Member member = findMember(email);
-
-            Authentication authentication = jwtTokenProvider.createAuthenticationByMember(member);
-            String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
-
-            deleteAuthCode(email);
-
-            return new VerifyAuthCodeOnlyResponse(accessToken);
-        }
-
-        // 임시 토큰 발급 - 인증번호 검증이 완료되었음을 증명하는 토큰
-        String verificationToken = jwtTokenProvider.createVerificationToken(email);
-
+        Authentication authentication = jwtTokenProvider.createAuthenticationByMember(member);
         deleteAuthCode(email);
 
-        // 임시 토큰 반환
-        return new VerifyAuthCodeOnlyResponse(verificationToken);
+        return authentication;
     }
     
     /**
@@ -75,7 +55,7 @@ public class AuthService {
      * @param pin 사용자 PIN 번호
      */
     @Transactional
-    public PinLoginResponse loginWithPin(String email, String pin) {
+    public Authentication loginWithPin(String email, String pin) {
         // 이메일로 회원 조회
         Member member = findMember(email);
         
@@ -85,11 +65,7 @@ public class AuthService {
         }
         
         // 인증 및 토큰 발급
-        Authentication authentication = jwtTokenProvider.createAuthenticationByMember(member);
-        String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
-        String refreshToken = jwtTokenProvider.createRefreshToken(authentication, member.getId());
-        
-        return new PinLoginResponse(accessToken, refreshToken);
+        return jwtTokenProvider.createAuthenticationByMember(member);
     }
 
     private Member findMember(String email) {
@@ -124,7 +100,7 @@ public class AuthService {
      * @throws AuthException 리프레시 토큰이 유효하지 않거나 만료된 경우
      */
     @Transactional
-    public TokenRefreshResponse refreshAccessToken(String refreshToken) {
+    public Long refreshAccessToken(String refreshToken) {
         try {
             // 리프레시 토큰 유효성 검증
             if (!jwtTokenProvider.validateToken(refreshToken)) {
@@ -132,11 +108,7 @@ public class AuthService {
             }
 
             Long memberId = jwtTokenProvider.extractMemberId(refreshToken);
-          
-            // 새 액세스 토큰 발급
-            String newAccessToken = jwtTokenProvider.reissueAccessToken(refreshToken, memberId);
-
-            return new TokenRefreshResponse(newAccessToken);
+            return memberId;
         } catch (ExpiredJwtException e) {
             throw new AuthException(EXPIRED_REFRESH_TOKEN);
         } catch (JwtException e) {

--- a/src/main/java/org/ject/support/domain/auth/AuthVerificationResult.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthVerificationResult.java
@@ -1,0 +1,31 @@
+package org.ject.support.domain.auth;
+
+import lombok.Getter;
+import org.springframework.security.core.Authentication;
+
+/**
+ * 인증 검증 결과를 담는 클래스
+ * 템플릿 타입에 따라 다른 결과를 반환하기 위한 래퍼 클래스
+ */
+
+@Getter
+public class AuthVerificationResult {
+    private final Authentication authentication;
+    private final String email;
+
+    // CERTIFICATE 템플릿용 생성자
+    public AuthVerificationResult(Authentication authentication) {
+        this.authentication = authentication;
+        this.email = null;
+    }
+
+    // PIN_RESET 템플릿용 생성자
+    public AuthVerificationResult(String email) {
+        this.authentication = null;
+        this.email = email;
+    }
+
+    public boolean hasAuthentication() {
+        return authentication != null;
+    }
+}

--- a/src/main/java/org/ject/support/external/email/MailErrorCode.java
+++ b/src/main/java/org/ject/support/external/email/MailErrorCode.java
@@ -9,6 +9,7 @@ import org.ject.support.common.exception.ErrorCode;
 public enum MailErrorCode implements ErrorCode {
     MAIL_SEND_FAILURE("MAIL_SEND_FAILURE", "메일 전송에 실패하였습니다."),
     MAIL_PARAMETER_PARSE_FAILURE("MAIL_PARAMETER_PARSE_FAILURE", "메일 생성을 위한 객체 변환에 실패했습니다."),
+    INVALID_MAIL_TEMPLATE("INVALID_MAIL_TEMPLATE", "유효하지 않은 메일 템플릿입니다."),
     ;
     private final String code;
     private final String message;

--- a/src/test/java/org/ject/support/common/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/ject/support/common/security/jwt/JwtTokenProviderTest.java
@@ -106,7 +106,7 @@ class JwtTokenProviderTest {
         when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
 
         // when
-        String resolvedToken = jwtTokenProvider.resolveToken(request);
+        String resolvedToken = jwtTokenProvider.resolveAccessToken(request);
 
         // then
         assertThat(resolvedToken).isEqualTo(token);

--- a/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
@@ -1,13 +1,21 @@
 package org.ject.support.domain.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 
 import org.ject.support.external.email.EmailTemplate;
+import org.ject.support.common.security.CustomSuccessHandler;
+import org.ject.support.common.security.jwt.JwtTokenProvider;
 
 import org.ject.support.domain.auth.AuthDto.TokenRefreshRequest;
 import org.ject.support.domain.auth.AuthDto.TokenRefreshResponse;
@@ -15,6 +23,7 @@ import org.ject.support.domain.auth.AuthDto.PinLoginRequest;
 import org.ject.support.domain.auth.AuthDto.PinLoginResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeRequest;
+import org.ject.support.domain.auth.AuthVerificationResult;
 import org.ject.support.testconfig.ApplicationPeriodTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,11 +34,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @ExtendWith(MockitoExtension.class)
 class AuthControllerTest {
@@ -38,68 +57,75 @@ class AuthControllerTest {
 
     @Mock
     private AuthService authService;
+    
+    @Mock
+    private CustomSuccessHandler customSuccessHandler;
+    
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
 
     private final String TEST_EMAIL = "test@example.com";
     private final String TEST_AUTH_CODE = "123456";
-    private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
     private final String TEST_REFRESH_TOKEN = "test.refresh.token";
-    private final String TEST_ACCESS_TOKEN = "test.access.token";
     private final Long TEST_MEMBER_ID = 1L;
 
     @Test
-    @DisplayName("인증 코드 검증 및 인증 토큰 발급 성공")
-    void verifyAuthCode_Success() {
+    @DisplayName("인증 코드 검증 - CERTIFICATE 템플릿 - 인증 토큰 발급 성공")
+    void verifyAuthCode_WithCertificateTemplate_Success() {
         // given
         VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE);
-        VerifyAuthCodeOnlyResponse response = new VerifyAuthCodeOnlyResponse(TEST_VERIFICATION_TOKEN);
         EmailTemplate template = EmailTemplate.CERTIFICATE;
         
-        given(authService.verifyEmailByAuthCodeOnly(request.email(), request.authCode(), template))
-            .willReturn(response);
+        Authentication mockAuthentication = mock(Authentication.class);
+        AuthVerificationResult mockResult = new AuthVerificationResult(mockAuthentication);
+        
+        given(authService.verifyAuthCodeByTemplate(request.email(), request.authCode(), template))
+            .willReturn(mockResult);
 
         // when
-        VerifyAuthCodeOnlyResponse result = authController.verifyAuthCode(request, template);
+        authController.verifyAuthCode(request, mock(HttpServletRequest.class), mock(HttpServletResponse.class), template);
 
         // then
-        verify(authService).verifyEmailByAuthCodeOnly(TEST_EMAIL, TEST_AUTH_CODE, template);
-        assertThat(result.token()).isEqualTo(TEST_VERIFICATION_TOKEN);
+        verify(authService).verifyAuthCodeByTemplate(TEST_EMAIL, TEST_AUTH_CODE, template);
+        verify(customSuccessHandler).onAuthenticationSuccess(any(HttpServletRequest.class), any(HttpServletResponse.class), eq(mockAuthentication));
     }
     
     @Test
-    @DisplayName("PIN 재설정을 위한 인증 코드 검증 및 액세스 토큰 발급 성공")
-    void verifyAuthCode_PinReset_Success() {
+    @DisplayName("인증 코드 검증 - PIN_RESET 템플릿 - 성공")
+    void verifyAuthCode_WithPinResetTemplate_Success() {
         // given
         VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE);
-        VerifyAuthCodeOnlyResponse response = new VerifyAuthCodeOnlyResponse(TEST_ACCESS_TOKEN);
         EmailTemplate template = EmailTemplate.PIN_RESET;
         
-        given(authService.verifyEmailByAuthCodeOnly(request.email(), request.authCode(), template))
-            .willReturn(response);
+        AuthVerificationResult mockResult = new AuthVerificationResult(TEST_EMAIL);
+        
+        given(authService.verifyAuthCodeByTemplate(request.email(), request.authCode(), template))
+            .willReturn(mockResult);
 
         // when
-        VerifyAuthCodeOnlyResponse result = authController.verifyAuthCode(request, template);
+        authController.verifyAuthCode(request, mock(HttpServletRequest.class), mock(HttpServletResponse.class), template);
 
         // then
-        verify(authService).verifyEmailByAuthCodeOnly(TEST_EMAIL, TEST_AUTH_CODE, template);
-        assertThat(result.token()).isEqualTo(TEST_ACCESS_TOKEN);
+        verify(authService).verifyAuthCodeByTemplate(TEST_EMAIL, TEST_AUTH_CODE, template);
+        verify(customSuccessHandler).onAuthenticationSuccess(any(HttpServletResponse.class), eq(TEST_EMAIL));
     }
     
     @Test
     @DisplayName("리프레시 토큰을 사용한 액세스 토큰 재발급 성공")
     void refreshToken_Success() {
         // given
-        TokenRefreshRequest request = new TokenRefreshRequest(TEST_REFRESH_TOKEN);
-        TokenRefreshResponse response = new TokenRefreshResponse(TEST_ACCESS_TOKEN);
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
         
-        given(authService.refreshAccessToken(request.refreshToken()))
-            .willReturn(response);
+        given(jwtTokenProvider.resolveRefreshToken(mockRequest)).willReturn(TEST_REFRESH_TOKEN);
+        given(authService.refreshAccessToken(TEST_REFRESH_TOKEN)).willReturn(TEST_MEMBER_ID);
 
         // when
-        TokenRefreshResponse result = authController.refreshToken(request);
+        authController.refreshToken(mockRequest, mockResponse);
 
         // then
         verify(authService).refreshAccessToken(TEST_REFRESH_TOKEN);
-        assertThat(result.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+        verify(customSuccessHandler).onAuthenticationSuccess(mockResponse, TEST_REFRESH_TOKEN, TEST_MEMBER_ID);
     }
     
     @Test
@@ -107,18 +133,19 @@ class AuthControllerTest {
     void loginWithPin_Success() {
         // given
         PinLoginRequest request = new PinLoginRequest(TEST_EMAIL, TEST_AUTH_CODE);
-        PinLoginResponse response = new PinLoginResponse(TEST_ACCESS_TOKEN, TEST_REFRESH_TOKEN);
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+        Authentication mockAuthentication = mock(Authentication.class);
         
         given(authService.loginWithPin(request.email(), request.pin()))
-            .willReturn(response);
+            .willReturn(mockAuthentication);
 
         // when
-        PinLoginResponse result = authController.loginWithPin(request);
+        authController.loginWithPin(request, mockRequest, mockResponse);
 
         // then
         verify(authService).loginWithPin(TEST_EMAIL, TEST_AUTH_CODE);
-        org.assertj.core.api.Assertions.assertThat(result.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
-        org.assertj.core.api.Assertions.assertThat(result.refreshToken()).isEqualTo(TEST_REFRESH_TOKEN);
+        verify(customSuccessHandler).onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
     }
     
     @Test
@@ -142,6 +169,12 @@ class AuthControllerTest {
 @TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false", "server.port=0"})
 class AuthControllerIntegrationTest extends ApplicationPeriodTest {
 
+    @Mock
+    private AuthService authService;
+    
+    @Mock
+    private CustomSuccessHandler customSuccessHandler;
+
     @Autowired
     private MockMvc mockMvc;
     
@@ -153,18 +186,38 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
     private final String TEST_REFRESH_TOKEN = "test.refresh.token";
     
     @Test
-    @DisplayName("@PreAuthorize(\"permitAll()\") 설정으로 인증 없이 접근 가능한지 확인")
-    void verifyAuthCode_WithPermitAll_ShouldAllowAccessWithoutAuthentication() throws Exception {
+    @DisplayName("인증 코드 검증 API - 인증 없이 접근 가능 및 쿠키 발급 테스트")
+    void verifyAuthCode_WithPermitAll_ShouldAllowAccessAndSetCookies() throws Exception {
         // given
         VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE);
         
+        // AuthService의 verifyAuthCodeByTemplate 메서드를 모킹
+        AuthVerificationResult mockResult = new AuthVerificationResult(TEST_EMAIL);
+        given(authService.verifyAuthCodeByTemplate(TEST_EMAIL, TEST_AUTH_CODE, EmailTemplate.CERTIFICATE))
+            .willReturn(mockResult);
+        
+        // 쿠키 발급을 위한 모킹 설정
+        doAnswer(invocation -> {
+            HttpServletResponse response = invocation.getArgument(0);
+            response.addCookie(new Cookie("verification", "test-verification-token"));
+            return null;
+        }).when(customSuccessHandler).onAuthenticationSuccess(any(HttpServletResponse.class), eq(TEST_EMAIL));
+        
         // when & then
         // 인증 없이 접근 가능한지 확인 (permitAll 설정)
-        mockMvc.perform(post("/auth/code")
+        MvcResult result = mockMvc.perform(post("/auth/code")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .param("template", EmailTemplate.CERTIFICATE.name()))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andReturn();
+        
+        // 응답 상태 코드 확인
+        MockHttpServletResponse response = result.getResponse();
+        assertThat(response.getStatus()).isEqualTo(200);
+        
+        // 쿠키 발급 확인
+        verify(customSuccessHandler).onAuthenticationSuccess(any(HttpServletResponse.class), eq(TEST_EMAIL));
     }
     
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

close #174 
close #175

## 📝작업 내용

- `verificationToken` 및 `accessToken` 재발급시에도 쿠키에 토큰 발급하도록 토큰 발급 방식 일관성 확보
- 클라이언트의 API 요청 시 Authorizatoin 헤더 대신 쿠키에서 토큰 가져오도록 토큰 확인 방식 일관성 확보
- `CustomSuccessHandler` 를 통해 쿠키가 발급되도록 개선
- 인증 검증 결과 래퍼 클래스 `AuthVerificationResult` 작성

`CustomSuccessHandler`는 스프링 시큐리티 기본 로그인시에만 동작하고 있어서 쿠키가 정상적으로 발급 되지 않는 이슈가 있었습니다.
또한, 쿠키 발급 시 `HttpOnly` 설정이 켜져 있어서 프론트에서 쿠키를 열어볼 수 없어 Authorization 헤더로 토큰을 보낼 수 없는 이슈도 있었습니다. 보안성을 위해 `HttpOnly` 설정을 사용하는 건 불가피하므로, 서버에서 쿠키에 저장된 토큰을 가져오는 방식으로 토큰 수용 방식 또한 개선했습니다.

## ✅테스트 결과
![스크린샷 2025-04-13 오후 11 03 11](https://github.com/user-attachments/assets/86116537-ff1d-4e65-9f92-60ae7f2374e0)


## 🙏리뷰 요구사항(선택)

서블렛 리퀘스트, 리스폰스가 서비스 레이어까지 침투하지 않게 하기 위해 불가피하게 `AuthController`에 조건부 응답 처리를 구현했습니다. 전략 패턴, 팩토리 패턴을 도입하는 방법도 있으나, 해당 부분은 서비스 로직을 처리하는 조건문이 아닌 어떤 메서드를 호출할 지에 대한 조건문이므로 상관 없다고 판단했습니다. 그리고 무엇보다 빠른 개선이 필요한 작업이므로 직관적이면서도 빠르게 해결할 수 있는 방법으로 구현했습니다.
