### PR TITLE
인증 API 호출 완료 시 클라이언트에 명시적인 응답 반환

### DIFF
--- a/src/main/java/org/ject/support/domain/auth/AuthController.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthController.java
@@ -34,8 +34,8 @@ public class AuthController {
      */
     @PostMapping("/code")
     @PreAuthorize("permitAll()")
-    public void verifyAuthCode(@RequestBody VerifyAuthCodeRequest verifyAuthCodeRequest, HttpServletRequest request,
-                               HttpServletResponse response, @RequestParam EmailTemplate template) {
+    public boolean verifyAuthCode(@RequestBody VerifyAuthCodeRequest verifyAuthCodeRequest, HttpServletRequest request,
+                                       HttpServletResponse response, @RequestParam EmailTemplate template) {
         // 서비스 레이어에서 템플릿 타입에 따른 인증 검증 결과 반환
         AuthVerificationResult result = authService.verifyAuthCodeByTemplate(
                 verifyAuthCodeRequest.email(), verifyAuthCodeRequest.authCode(), template);
@@ -46,6 +46,8 @@ public class AuthController {
         } else {
             customSuccessHandler.onAuthenticationSuccess(response, result.getEmail());
         }
+
+        return true;
     }
     
     /**
@@ -54,10 +56,12 @@ public class AuthController {
      */
     @PostMapping("/refresh")
     @PreAuthorize("permitAll()")
-    public void refreshToken(HttpServletRequest request, HttpServletResponse response) {
+    public boolean refreshToken(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
         Long memberId = authService.refreshAccessToken(refreshToken);
         customSuccessHandler.onAuthenticationSuccess(response, refreshToken, memberId);
+
+        return true;
     }
 
     /**
@@ -67,10 +71,12 @@ public class AuthController {
      */
     @PostMapping("/login/pin")
     @PreAuthorize("permitAll()")
-    public void loginWithPin(@RequestBody @Valid PinLoginRequest request, HttpServletRequest httpRequest, HttpServletResponse response) {
+    public boolean loginWithPin(@RequestBody @Valid PinLoginRequest request, HttpServletRequest httpRequest, HttpServletResponse response) {
         Authentication authentication = authService.loginWithPin(request.email(), request.pin());
         
         customSuccessHandler.onAuthenticationSuccess(httpRequest, response, authentication);
+
+        return true;
     }
 
     @GetMapping("/login/exist")

--- a/src/main/java/org/ject/support/domain/auth/AuthDto.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthDto.java
@@ -9,10 +9,6 @@ public class AuthDto {
     public record VerifyAuthCodeRequest(String email, String authCode) {
         // 이메일 인증 코드 검증 요청 DTO
     }
-
-    public record VerifyAuthCodeOnlyResponse(String token) {
-        // 인증번호 검증 성공 시 발급되는 access 또는 vericiation 토큰
-    }
     
     public record PinLoginRequest(
         @NotBlank @Email String email,
@@ -20,15 +16,7 @@ public class AuthDto {
         // PIN 로그인 요청 DTO
     }
     
-    public record PinLoginResponse(String accessToken, String refreshToken) {
-        // 로그인 성공 시 발급되는 토큰 응답 DTO
-    }
-    
     public record TokenRefreshRequest(String refreshToken) {
         // 토큰 재발급 요청 DTO
-    }
-    
-    public record TokenRefreshResponse(String accessToken) {
-        // 토큰 재발급 응답 DTO
     }
 }

--- a/src/main/java/org/ject/support/domain/member/controller/MemberController.java
+++ b/src/main/java/org/ject/support/domain/member/controller/MemberController.java
@@ -34,7 +34,7 @@ public class MemberController {
      */
     @PostMapping
     @PreAuthorize("hasRole('ROLE_VERIFICATION')")
-    public void registerMember(HttpServletRequest request, HttpServletResponse response,
+    public boolean registerMember(HttpServletRequest request, HttpServletResponse response,
                                            @Valid @RequestBody MemberDto.RegisterRequest registerRequest) {
 
         // 쿠키에서 verification 토큰 추출
@@ -46,6 +46,8 @@ public class MemberController {
         // 임시 회원 생성 및 토큰 발급
         Authentication authentication = memberService.registerTempMember(registerRequest, email);
         customSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+        return true;
     }
 
     /**

--- a/src/main/java/org/ject/support/domain/member/dto/MemberDto.java
+++ b/src/main/java/org/ject/support/domain/member/dto/MemberDto.java
@@ -34,9 +34,6 @@ public class MemberDto {
 
     }
 
-    public record RegisterResponse(String accessToken, String refreshToken) {
-    }
-
     public record UpdatePinRequest(
             @NotBlank @Pattern(regexp = "^\\d{6}$", message = "PIN 번호는 6자리 숫자여야 합니다.") String pin) {
     }

--- a/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.mock;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
-import org.ject.support.domain.auth.AuthDto.TokenRefreshResponse;
 import org.ject.support.external.email.EmailTemplate;
 import org.ject.support.external.email.MailErrorCode;
 import org.ject.support.external.email.MailSendException;
@@ -25,8 +24,6 @@ import static org.mockito.Mockito.lenient;
 
 import java.util.Optional;
 
-import org.ject.support.domain.auth.AuthDto.PinLoginResponse;
-import org.ject.support.domain.auth.AuthDto.VerifyAuthCodeOnlyResponse;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.exception.MemberException;


### PR DESCRIPTION
## #️⃣연관된 이슈

close #183 

## 📝작업 내용

클라이언트에서는 인증 관련 API 호출 후 반환되는 `SUCCESS` status를 통해 api 호출 여부를 검증하고 있습니다.
기존에는 서버에서 Response로 토큰 값을 제공해줬는데, 이제 클라이언트에 직접 body response로 토큰을 제공하지 않아서 명시적으로 응답을 제공하기 위해 true를 반환하도록 수정했습니다. (void 나 null로 API 응답 반환시에는 전역적으로 적용되는 `ApiResponse`가 적용되지 않습니다.)

## ✅테스트 결과
![스크린샷 2025-04-15 오전 12 05 51](https://github.com/user-attachments/assets/50c51c07-1131-4c4c-a870-147fb4cc42cc)

