### PR TITLE
인증 코드 이메일 템플릿 수정

### DIFF
--- a/src/main/java/org/ject/support/domain/auth/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthService.java
@@ -40,7 +40,7 @@ public class AuthService {
      */
     @Transactional
     public AuthVerificationResult verifyAuthCodeByTemplate(String email, String authCode, EmailTemplate template) {
-        if (template == EmailTemplate.CERTIFICATE) {
+        if (template == EmailTemplate.AUTH_CODE) {
             // 인증번호 검증 후 이메일 반환
             verifyAuthCode(email, authCode);
             deleteAuthCode(email);

--- a/src/main/java/org/ject/support/domain/auth/AuthVerificationResult.java
+++ b/src/main/java/org/ject/support/domain/auth/AuthVerificationResult.java
@@ -13,7 +13,7 @@ public class AuthVerificationResult {
     private final Authentication authentication;
     private final String email;
 
-    // CERTIFICATE 템플릿용 생성자
+    // AUTH_CODE 템플릿용 생성자
     public AuthVerificationResult(Authentication authentication) {
         this.authentication = authentication;
         this.email = null;

--- a/src/main/java/org/ject/support/external/email/EmailTemplate.java
+++ b/src/main/java/org/ject/support/external/email/EmailTemplate.java
@@ -19,8 +19,8 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 public enum EmailTemplate {
     ACCEPTANCE("email-template", "ject notification"),
     REJECTION("email-template", "ject notification"),
-    CERTIFICATE("email-template", "젝트 인증 번호 안내"),
-    PIN_RESET("email-template", "젝트 PIN 재설정 인증 번호 안내");
+    CERTIFICATE("email-template", "젝트 인증 코드 안내"),
+    PIN_RESET("email-template", "젝트 PIN 재설정 인증 코드 안내");
 
     private final String templateName;// template file name
     private final String subject;// email subject

--- a/src/main/java/org/ject/support/external/email/EmailTemplate.java
+++ b/src/main/java/org/ject/support/external/email/EmailTemplate.java
@@ -19,8 +19,8 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 public enum EmailTemplate {
     ACCEPTANCE("email-template", "ject notification"),
     REJECTION("email-template", "ject notification"),
-    CERTIFICATE("email-template", "ject certificate"),
-    PIN_RESET("email-template", "ject pin reset"); // TODO: HTML 템플릿별로 수정 필요
+    CERTIFICATE("email-template", "젝트 인증 번호 안내"),
+    PIN_RESET("email-template", "젝트 PIN 재설정 인증 번호 안내");
 
     private final String templateName;// template file name
     private final String subject;// email subject

--- a/src/main/java/org/ject/support/external/email/EmailTemplate.java
+++ b/src/main/java/org/ject/support/external/email/EmailTemplate.java
@@ -19,7 +19,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 public enum EmailTemplate {
     ACCEPTANCE("email-template", "ject notification"),
     REJECTION("email-template", "ject notification"),
-    CERTIFICATE("email-template", "젝트 인증 코드 안내"),
+    AUTH_CODE("email-template", "젝트 인증 코드 안내"),
     PIN_RESET("email-template", "젝트 PIN 재설정 인증 코드 안내");
 
     private final String templateName;// template file name

--- a/src/main/resources/templates/email-template.html
+++ b/src/main/resources/templates/email-template.html
@@ -31,7 +31,7 @@
                 <!-- 인증 코드 -->
                 <tr>
                     <td style="padding-top: 32px; padding-bottom: 16px; background-color: rgba(161, 162, 255, 0.08); font-size: 32px; color: #302dbe;" align="center">
-                        <div style="font-weight: 600; letter-spacing: -0.01em; line-height: 140%;" th:text="${value}">000000</div>
+                        <div style="font-weight: 600; letter-spacing: -0.01em; line-height: 140%;" th:text="${value}"></div>
                     </td>
                 </tr>
                 <!-- 안내 -->

--- a/src/main/resources/templates/email-template.html
+++ b/src/main/resources/templates/email-template.html
@@ -1,11 +1,66 @@
 <!DOCTYPE html>
-
-<html lang="ko" xmlns:th ="http://www.thymeleaf.org">
-<body><img
-        src='https://scontent-gmp1-1.cdninstagram.com/v/t51.2885-15/471970303_18254051023275582_6103452474397798501_n.jpg?stp=dst-jpg_e35_s1080x1080_sh0.08_tt6&_nc_ht=scontent-gmp1-1.cdninstagram.com&_nc_cat=106&_nc_ohc=BrPR5Li-ibAQ7kNvgE2G-xJ&_nc_gid=348e26554c954a0594a011e1587769d7&edm=ANTKIIoBAAAA&ccb=7-5&oh=00_AYB0rtEAiBlSZ5zDeM_XvexDZ4nu4gGZvi6YgKaCNFenTQ&oe=679BB04F&_nc_sid=d885a2' alt="cat">
-<h1>안녕하세요! <span th:text="${to}"/>님</h1>
-    <p>이메일 인증을 위해 아래 링크를 클릭해주세요.</p>
-    <p>from <span th:text="${value}"/></p>
-
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>젝트 이메일 인증 코드 안내</title>
+</head>
+<body style="margin: 0; padding: 12px; background-color: #f7f5ff; font-family: 'Pretendard Variable', sans-serif; text-align: center; font-size: 16px; color: #3a3b43;">
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #f7f5ff; min-width: 320px;">
+    <tr>
+        <td align="center">
+            <table width="560" cellpadding="0" cellspacing="0" border="0" style="background-color: #ffffff; padding: 32px 24px; box-sizing: border-box; max-width: 560px; min-width: 256px; text-align: center;">
+                <!-- 로고 -->
+                <tr>
+                    <td style="padding-bottom: 48px;" align="center">
+                        <img src="https://ject-content.s3.ap-northeast-2.amazonaws.com/1stjeckathon/ject_logo_email_code.png" alt="젝트 로고" style="max-width: 100%; height: auto;">
+                    </td>
+                </tr>
+                <!-- 타이틀 -->
+                <tr>
+                    <td style="font-size: 25px; color: #1a1b23; font-weight: 600; line-height: 140%; letter-spacing: -0.01em;" align="center">
+                        젝트 이메일 인증 코드 안내
+                    </td>
+                </tr>
+                <!-- 설명 -->
+                <tr>
+                    <td style="padding-top: 32px; padding-bottom: 45px; font-size: 16px; color: #3a3b43; line-height: 160%;" align="center">
+                        이메일 인증을 위해 요청하신 코드는 다음과 같아요.
+                    </td>
+                </tr>
+                <!-- 인증 코드 -->
+                <tr>
+                    <td style="padding-top: 32px; padding-bottom: 16px; background-color: rgba(161, 162, 255, 0.08); font-size: 32px; color: #302dbe;" align="center">
+                        <div style="font-weight: 600; letter-spacing: -0.01em; line-height: 140%;" th:text="${value}">000000</div>
+                    </td>
+                </tr>
+                <!-- 안내 -->
+                <tr>
+                    <td style="padding-top: 45px; font-size: 16px; color: #3a3b43; line-height: 160%;" align="center">
+                        이 코드를 타인과 공유하지 마세요.<br>
+                        만일 인증 코드를 요청하지 않으셨다면, 이 이메일을 무시해주세요.
+                    </td>
+                </tr>
+                <!-- 감사 인사 -->
+                <tr>
+                    <td style="padding-top: 32px; font-size: 16px; color: #3a3b43; line-height: 160%;" align="center">
+                        감사합니다.
+                    </td>
+                </tr>
+                <!-- 푸터 -->
+                <tr>
+                    <td style="padding-top: 32px; font-size: 15px; color: #3a3b43; line-height: 160%;">
+                        <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                            <tr>
+                                <td align="left">젝트 운영진 드림</td>
+                                <td align="right" style="color: #2473e6; text-decoration: underline;">ject.kr</td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
 </body>
 </html>

--- a/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
@@ -56,11 +56,11 @@ class AuthControllerTest {
     private final Long TEST_MEMBER_ID = 1L;
 
     @Test
-    @DisplayName("인증 코드 검증 - CERTIFICATE 템플릿 - 이메일만 반환 성공")
+    @DisplayName("인증 코드 검증 - AUTH_CODE 템플릿 - 이메일만 반환 성공")
     void verifyAuthCode_WithCertificateTemplate_Success() {
         // given
         VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE);
-        EmailTemplate template = EmailTemplate.CERTIFICATE;
+        EmailTemplate template = EmailTemplate.AUTH_CODE;
         
         AuthVerificationResult mockResult = new AuthVerificationResult(TEST_EMAIL);
         

--- a/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
@@ -3,12 +3,9 @@ package org.ject.support.domain.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.ject.support.domain.auth.AuthErrorCode.EXPIRED_REFRESH_TOKEN;
-import static org.ject.support.domain.auth.AuthErrorCode.INVALID_AUTH_CODE;
 import static org.ject.support.domain.auth.AuthErrorCode.INVALID_REFRESH_TOKEN;
 import static org.ject.support.domain.auth.AuthErrorCode.INVALID_CREDENTIALS;
-import static org.ject.support.domain.auth.AuthErrorCode.NOT_FOUND_AUTH_CODE;
 import static org.ject.support.domain.member.exception.MemberErrorCode.NOT_FOUND_MEMBER;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -245,13 +242,13 @@ class AuthServiceTest {
     }
     
     @Test
-    @DisplayName("인증번호 검증 - CERTIFICATE 템플릿")
+    @DisplayName("인증번호 검증 - AUTH_CODE 템플릿")
     void verifyAuthCodeByTemplate_WithCertificateTemplate_ReturnsEmailResult() {
         // given
         given(redisTemplate.opsForValue().get(TEST_EMAIL)).willReturn(TEST_AUTH_CODE);
         
         // when
-        AuthVerificationResult result = authService.verifyAuthCodeByTemplate(TEST_EMAIL, TEST_AUTH_CODE, EmailTemplate.CERTIFICATE);
+        AuthVerificationResult result = authService.verifyAuthCodeByTemplate(TEST_EMAIL, TEST_AUTH_CODE, EmailTemplate.AUTH_CODE);
         
         // then
         assertThat(result).isNotNull();


### PR DESCRIPTION
## #️⃣연관된 이슈

close #181 

## 📝작업 내용

- 이메일 HTML 템플릿을 수정했습니다.
- SMTP 공급자 수정은 여러 이슈 때문에 현재는 불가합니다. (+다음 메일이 지메일에 비해 발송이 너무 느린 문제도 있습니다.)

## ✅테스트 결과
![스크린샷 2025-04-15 오전 1 51 53](https://github.com/user-attachments/assets/c56fd204-434c-49ac-a748-e7cceb19b3ea)
지메일

![스크린샷 2025-04-15 오전 1 52 10](https://github.com/user-attachments/assets/62c70fb6-063a-4ddb-84b3-b617a19c44d1)
네이버

