### PR TITLE
기수 목록 조회 시 redis 역직렬화 이슈 해결

### DIFF
--- a/src/main/java/org/ject/support/domain/recruit/controller/QuestionController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/QuestionController.java
@@ -2,15 +2,13 @@ package org.ject.support.domain.recruit.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.member.JobFamily;
-import org.ject.support.domain.recruit.dto.QuestionResponse;
+import org.ject.support.domain.recruit.dto.QuestionResponses;
 import org.ject.support.domain.recruit.service.QuestionService;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/apply/questions")
@@ -21,7 +19,7 @@ public class QuestionController {
 
     @GetMapping
     @PreAuthorize("hasRole('ROLE_TEMP')")
-    public List<QuestionResponse> findQuestions(@RequestParam JobFamily jobFamily) {
+    public QuestionResponses findQuestions(@RequestParam JobFamily jobFamily) {
         return questionService.findQuestions(jobFamily);
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/controller/SemesterController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/SemesterController.java
@@ -1,9 +1,8 @@
 package org.ject.support.domain.recruit.controller;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.ject.support.domain.recruit.dto.SemesterListResponse;
 import org.ject.support.domain.recruit.dto.SemesterRegisterRequest;
+import org.ject.support.domain.recruit.dto.SemesterResponses;
 import org.ject.support.domain.recruit.service.SemesterInquiryUsecase;
 import org.ject.support.domain.recruit.service.SemesterRegisterUsecase;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -25,13 +24,14 @@ public class SemesterController {
     public void register(@RequestBody SemesterRegisterRequest request) {
         semesterRegisterUsecase.registerSemester(request);
     }
-    
+
     /**
      * 모든 기수 목록을 조회합니다.
+     *
      * @return 기수 목록
      */
     @GetMapping
-    public List<SemesterListResponse> getAllSemesters() {
+    public SemesterResponses getAllSemesters() {
         return semesterInquiryUsecase.getAllSemesters();
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/dto/QuestionResponses.java
+++ b/src/main/java/org/ject/support/domain/recruit/dto/QuestionResponses.java
@@ -1,0 +1,6 @@
+package org.ject.support.domain.recruit.dto;
+
+import java.util.List;
+
+public record QuestionResponses(List<QuestionResponse> questionResponses) {
+}

--- a/src/main/java/org/ject/support/domain/recruit/dto/SemesterResponse.java
+++ b/src/main/java/org/ject/support/domain/recruit/dto/SemesterResponse.java
@@ -2,12 +2,9 @@ package org.ject.support.domain.recruit.dto;
 
 import org.ject.support.domain.recruit.domain.Semester;
 
-public record SemesterListResponse(
-        Long id,
-        String name
-) {
-    public static SemesterListResponse from(Semester semester) {
-        return new SemesterListResponse(
+public record SemesterResponse(Long id, String name) {
+    public static SemesterResponse from(Semester semester) {
+        return new SemesterResponse(
                 semester.getId(), 
                 semester.getName()
         );

--- a/src/main/java/org/ject/support/domain/recruit/dto/SemesterResponses.java
+++ b/src/main/java/org/ject/support/domain/recruit/dto/SemesterResponses.java
@@ -1,0 +1,6 @@
+package org.ject.support.domain.recruit.dto;
+
+import java.util.List;
+
+public record SemesterResponses(List<SemesterResponse> semesterResponses) {
+}

--- a/src/main/java/org/ject/support/domain/recruit/service/QuestionService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/QuestionService.java
@@ -3,14 +3,13 @@ package org.ject.support.domain.recruit.service;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.util.PeriodAccessible;
 import org.ject.support.domain.member.JobFamily;
-import org.ject.support.domain.recruit.dto.QuestionResponse;
+import org.ject.support.domain.recruit.dto.QuestionResponses;
 import org.ject.support.domain.recruit.repository.QuestionRepository;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,7 +20,7 @@ public class QuestionService {
     @Cacheable(value = "question", key = "#jobFamily")
     @PeriodAccessible
     @Transactional(readOnly = true)
-    public List<QuestionResponse> findQuestions(final JobFamily jobFamily) {
-        return questionRepository.findByJobFamilyOfActiveRecruit(LocalDateTime.now(), jobFamily);
+    public QuestionResponses findQuestions(final JobFamily jobFamily) {
+        return new QuestionResponses(questionRepository.findByJobFamilyOfActiveRecruit(LocalDateTime.now(), jobFamily));
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/SemesterInquiryService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/SemesterInquiryService.java
@@ -1,8 +1,8 @@
 package org.ject.support.domain.recruit.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.ject.support.domain.recruit.dto.SemesterListResponse;
+import org.ject.support.domain.recruit.dto.SemesterResponse;
+import org.ject.support.domain.recruit.dto.SemesterResponses;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -15,11 +15,12 @@ public class SemesterInquiryService implements SemesterInquiryUsecase {
     private final SemesterRepository semesterRepository;
 
     @Override
-    @Cacheable(value = "semester", key = "'allSemesters'")
+    @Cacheable(value = "semester", key = "'all'")
     @Transactional(readOnly = true)
-    public List<SemesterListResponse> getAllSemesters() {
-        return semesterRepository.findAll().stream()
-                .map(SemesterListResponse::from)
-                .toList();
+    public SemesterResponses getAllSemesters() {
+        return new SemesterResponses(semesterRepository.findAll()
+                .stream()
+                .map(SemesterResponse::from)
+                .toList());
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/SemesterInquiryUsecase.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/SemesterInquiryUsecase.java
@@ -1,12 +1,12 @@
 package org.ject.support.domain.recruit.service;
 
-import java.util.List;
-import org.ject.support.domain.recruit.dto.SemesterListResponse;
+import org.ject.support.domain.recruit.dto.SemesterResponses;
 
 public interface SemesterInquiryUsecase {
     /**
      * 모든 기수 목록을 조회합니다.
+     *
      * @return 기수 목록
      */
-    List<SemesterListResponse> getAllSemesters();
+    SemesterResponses getAllSemesters();
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #179 

## 📝작업 내용
- List<SemesterResponse> 타입 객체를 wrapper 클래스로 감싸도록 수정
- List<QuestionResponse> 타입 객체를 wrapper 클래스로 감싸도록 수정

## ✅테스트 결과
<img width="580" alt="스크린샷 2025-04-15 오전 1 54 52" src="https://github.com/user-attachments/assets/4cbd77da-8a8d-4e78-a558-02b5670ea379" />

