### PR TITLE
recruit flag 관리 로직 개선

### DIFF
--- a/src/main/java/org/ject/support/common/exception/GlobalErrorCode.java
+++ b/src/main/java/org/ject/support/common/exception/GlobalErrorCode.java
@@ -18,7 +18,8 @@ public enum GlobalErrorCode implements ErrorCode {
     INTERNAL_SERVER_ERROR("G-10", "Internal server error"),
     OVER_PERIOD("G-11", "모집 기간이 아닙니다."),
     MISS_REQUIRED_REQUEST_PARAMETER("G-12", "Missing required parameter"),
-    MISS_REQUEST_BODY("G-13", "Missing request body"),;
+    MISS_REQUEST_BODY("G-13", "Missing request body"),
+    MISS_REQUIRED_JOB_FAMILY_PARAMETER("G-14", "Missing required JobFamily parameter"),;
 
     private final String code;
     private final String message;

--- a/src/main/java/org/ject/support/common/util/PeriodAccessible.java
+++ b/src/main/java/org/ject/support/common/util/PeriodAccessible.java
@@ -9,4 +9,5 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Target(ElementType.METHOD)
 public @interface PeriodAccessible {
+    boolean permitAllJob() default false;
 }

--- a/src/main/java/org/ject/support/domain/recruit/domain/Recruit.java
+++ b/src/main/java/org/ject/support/domain/recruit/domain/Recruit.java
@@ -50,10 +50,6 @@ public class Recruit extends BaseTimeEntity {
     @Column(name = "job_family", columnDefinition = "varchar(45)", nullable = false)
     private JobFamily jobFamily;
 
-    @Column(name = "is_closed", nullable = false)
-    @Builder.Default
-    private boolean isClosed = false;
-
     @OneToMany(mappedBy = "recruit", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<Question> questions = new ArrayList<>();
@@ -79,5 +75,9 @@ public class Recruit extends BaseTimeEntity {
         this.jobFamily = jobFamily;
         this.startDate = startDate;
         this.endDate = endDate;
+    }
+
+    public boolean isClosed() {
+        return endDate.isBefore(LocalDateTime.now());
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/domain/RecruitEntityListener.java
+++ b/src/main/java/org/ject/support/domain/recruit/domain/RecruitEntityListener.java
@@ -15,8 +15,6 @@ public class RecruitEntityListener {
     @PostPersist
     @PostUpdate
     public void postPersist(Recruit recruit) {
-        if(recruit.isRecruitingPeriod()) {
-            applicationEventPublisher.publishEvent(new RecruitSavedEvent(recruit.getId()));
-        }
+        applicationEventPublisher.publishEvent(new RecruitSavedEvent(recruit.getId()));
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/domain/RecruitEntityListener.java
+++ b/src/main/java/org/ject/support/domain/recruit/domain/RecruitEntityListener.java
@@ -3,7 +3,7 @@ package org.ject.support.domain.recruit.domain;
 import jakarta.persistence.PostPersist;
 import jakarta.persistence.PostUpdate;
 import lombok.RequiredArgsConstructor;
-import org.ject.support.domain.recruit.dto.RecruitOpenedEvent;
+import org.ject.support.domain.recruit.dto.RecruitSavedEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +16,7 @@ public class RecruitEntityListener {
     @PostUpdate
     public void postPersist(Recruit recruit) {
         if(recruit.isRecruitingPeriod()) {
-            applicationEventPublisher.publishEvent(new RecruitOpenedEvent(recruit.getId()));
+            applicationEventPublisher.publishEvent(new RecruitSavedEvent(recruit.getId()));
         }
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/dto/Constants.java
+++ b/src/main/java/org/ject/support/domain/recruit/dto/Constants.java
@@ -5,5 +5,5 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class Constants {
-    public static final String PERIOD_FLAG = "PERIOD_FLAG";
+    public static final String RECRUIT_FLAG_PREFIX = "RECRUIT_FLAG:";
 }

--- a/src/main/java/org/ject/support/domain/recruit/dto/RecruitOpenedEvent.java
+++ b/src/main/java/org/ject/support/domain/recruit/dto/RecruitOpenedEvent.java
@@ -1,4 +1,0 @@
-package org.ject.support.domain.recruit.dto;
-
-public record RecruitOpenedEvent(Long recruitId) {
-}

--- a/src/main/java/org/ject/support/domain/recruit/dto/RecruitRegisterRequest.java
+++ b/src/main/java/org/ject/support/domain/recruit/dto/RecruitRegisterRequest.java
@@ -12,7 +12,6 @@ public record RecruitRegisterRequest(
         JobFamily jobFamily,
 
         @NotNull(message = "모집 시작일은 필수입니다.")
-        @Future(message = "모집 시작일은 현재 시각보다 이후여야 합니다.")
         LocalDateTime startDate,
 
         @NotNull(message = "모집 종료일은 필수입니다.")

--- a/src/main/java/org/ject/support/domain/recruit/dto/RecruitSavedEvent.java
+++ b/src/main/java/org/ject/support/domain/recruit/dto/RecruitSavedEvent.java
@@ -1,0 +1,4 @@
+package org.ject.support.domain.recruit.dto;
+
+public record RecruitSavedEvent(Long recruitId) {
+}

--- a/src/main/java/org/ject/support/domain/recruit/dto/RecruitUpdateRequest.java
+++ b/src/main/java/org/ject/support/domain/recruit/dto/RecruitUpdateRequest.java
@@ -11,7 +11,6 @@ public record RecruitUpdateRequest(
         JobFamily jobFamily,
 
         @NotNull(message = "모집 시작일은 필수입니다.")
-        @Future(message = "모집 시작일은 현재 시각보다 이후여야 합니다.")
         LocalDateTime startDate,
 
         @NotNull(message = "모집 종료일은 필수입니다.")

--- a/src/main/java/org/ject/support/domain/recruit/repository/RecruitQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/RecruitQueryRepository.java
@@ -2,8 +2,10 @@ package org.ject.support.domain.recruit.repository;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+
+import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Recruit;
 
 public interface RecruitQueryRepository {
-    Optional<Recruit> findByStartDateAfterAndEndDateBefore(LocalDateTime now);
+    Optional<Recruit> findActiveRecruitByJobFamily(JobFamily jobFamily, LocalDateTime now);
 }

--- a/src/main/java/org/ject/support/domain/recruit/repository/RecruitQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/RecruitQueryRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.recruit.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.springframework.stereotype.Repository;
 
@@ -16,9 +17,9 @@ public class RecruitQueryRepositoryImpl implements RecruitQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Optional<Recruit> findByStartDateAfterAndEndDateBefore(final LocalDateTime now) {
+    public Optional<Recruit> findActiveRecruitByJobFamily(final JobFamily jobFamily, final LocalDateTime now) {
         Recruit fetched = jpaQueryFactory.selectFrom(recruit)
-                .where(recruit.startDate.before(now).and(recruit.endDate.after(now)))
+                .where(recruit.jobFamily.eq(jobFamily), recruit.startDate.before(now).and(recruit.endDate.after(now)))
                 .fetchFirst();
         return Optional.ofNullable(fetched);
     }

--- a/src/main/java/org/ject/support/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/RecruitRepository.java
@@ -15,7 +15,7 @@ public interface RecruitRepository extends JpaRepository<Recruit, Long>, Recruit
     List<Recruit> findActiveRecruits(@Param("now") LocalDateTime now);
 
     @Query("SELECT EXISTS(SELECT 1 FROM Recruit r "
-            + "WHERE r.semesterId = :semesterId AND r.jobFamily IN :jobFamilies AND r.isClosed = false)")
+            + "WHERE r.semesterId = :semesterId AND r.jobFamily IN :jobFamilies AND r.endDate >= now())")
     boolean existsByJobFamilyAndIsNotClosed(@Param("semesterId") Long semesterId,
                                             @Param("jobFamilies") List<JobFamily> jobFamilies);
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/AccessPeriodVerificator.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/AccessPeriodVerificator.java
@@ -6,9 +6,13 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.ject.support.common.exception.GlobalErrorCode;
 import org.ject.support.common.exception.GlobalException;
+import org.ject.support.common.util.PeriodAccessible;
+import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.dto.Constants;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
 
 @Aspect
 @Component
@@ -16,12 +20,40 @@ import org.springframework.stereotype.Component;
 public class AccessPeriodVerificator {
     private final RedisTemplate<String, String> redisTemplate;
 
-    @Around("@annotation(org.ject.support.common.util.PeriodAccessible)")
-    public Object checkRecruitmentPeriod(ProceedingJoinPoint joinPoint) throws Throwable {
-        Boolean isRecruiting = Boolean.valueOf(redisTemplate.opsForValue().get(Constants.PERIOD_FLAG));
-        if (Boolean.FALSE.equals(isRecruiting)){
+    @Around("@annotation(org.ject.support.common.util.PeriodAccessible) && @annotation(target)")
+    public Object checkRecruitmentPeriod(ProceedingJoinPoint joinPoint, PeriodAccessible target) throws Throwable {
+        // 모든 직군에 대한 요청인 경우, 하나의 어떤 RECRUIT_FLAG만 있어도 허용
+        if (target.permitAllJob()) {
+            boolean isAnyRecruiting = Arrays.stream(JobFamily.values())
+                    .anyMatch(jobFamily -> Boolean.parseBoolean(redisTemplate.opsForValue()
+                            .get(getKeyName(jobFamily.name()))));
+            validateRecruiting(isAnyRecruiting);
+            return joinPoint.proceed();
+        }
+
+        // 특정 직군을 파라미터로 받은 경우, 해당 직군에 대한 모집 여부로 판단
+        JobFamily jobFamily = extractJobFamily(joinPoint);
+        boolean isRecruiting = Boolean.parseBoolean(redisTemplate.opsForValue()
+                .get(getKeyName(jobFamily.name())));
+        validateRecruiting(isRecruiting);
+        return joinPoint.proceed();
+    }
+
+    private String getKeyName(String jobFamilyName) {
+        return String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, jobFamilyName);
+    }
+
+    private void validateRecruiting(boolean isRecruiting) {
+        if (Boolean.FALSE.equals(isRecruiting)) {
             throw new GlobalException(GlobalErrorCode.OVER_PERIOD);
         }
-        return joinPoint.proceed();
+    }
+
+    private JobFamily extractJobFamily(ProceedingJoinPoint joinPoint) {
+        return Arrays.stream(joinPoint.getArgs())
+                .filter(arg -> arg instanceof JobFamily)
+                .map(JobFamily.class::cast)
+                .findFirst()
+                .orElseThrow(() -> new GlobalException(GlobalErrorCode.MISS_REQUIRED_JOB_FAMILY_PARAMETER));
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/AccessPeriodVerifier.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/AccessPeriodVerifier.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 @Aspect
 @Component
 @RequiredArgsConstructor
-public class AccessPeriodVerificator {
+public class AccessPeriodVerifier {
     private final RedisTemplate<String, String> redisTemplate;
 
     @Around("@annotation(org.ject.support.common.util.PeriodAccessible) && @annotation(target)")

--- a/src/main/java/org/ject/support/domain/recruit/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/ApplyService.java
@@ -38,7 +38,7 @@ public class ApplyService implements ApplyUsecase {
     private final Map2JsonSerializer map2JsonSerializer;
 
     @Override
-    @PeriodAccessible
+    @PeriodAccessible(permitAllJob = true)
     @Transactional(readOnly = true)
     public ApplyTemporaryResponse getTemporaryApplication(final Long memberId) {
         return temporaryApplyService.findMembersRecentTemporaryApplication(memberId);
@@ -62,7 +62,7 @@ public class ApplyService implements ApplyUsecase {
     }
 
     @Override
-    @PeriodAccessible
+    @PeriodAccessible(permitAllJob = true)
     @Transactional
     public void deleteTemporaryApplications(Long memberId) {
         // memberId를 통해 기존 임시 지원서 모두 제거

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitFlagService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitFlagService.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 
 import static org.ject.support.domain.recruit.dto.Constants.RECRUIT_FLAG_PREFIX;
 
@@ -19,7 +20,7 @@ public class RecruitFlagService {
         redisTemplate.opsForValue().set(
                 String.format("%s%s", RECRUIT_FLAG_PREFIX, recruit.getJobFamily().name()),
                 Boolean.TRUE.toString(),
-                Duration.between(recruit.getStartDate(), recruit.getEndDate())
+                Duration.between(LocalDateTime.now(), recruit.getEndDate())
         );
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitFlagService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitFlagService.java
@@ -1,0 +1,25 @@
+package org.ject.support.domain.recruit.service;
+
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+import static org.ject.support.domain.recruit.dto.Constants.RECRUIT_FLAG_PREFIX;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitFlagService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void setRecruitFlag(Recruit recruit) {
+        redisTemplate.opsForValue().set(
+                String.format("%s%s", RECRUIT_FLAG_PREFIX, recruit.getJobFamily().name()),
+                Boolean.TRUE.toString(),
+                Duration.between(recruit.getStartDate(), recruit.getEndDate())
+        );
+    }
+}

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitSavedEventHandler.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitSavedEventHandler.java
@@ -1,0 +1,38 @@
+package org.ject.support.domain.recruit.service;
+
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.dto.RecruitSavedEvent;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitSavedEventHandler {
+
+    private final RecruitRepository recruitRepository;
+    private final RecruitFlagService recruitFlagService;
+    private final RecruitScheduleService recruitScheduleService;
+
+    /**
+     * 모집 등록 또는 수정 시 호출됨
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleRecruitSaved(RecruitSavedEvent event) {
+        Recruit recruit = recruitRepository.findById(event.recruitId())
+                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND));
+
+        // 등록된 모집이 활성화되어 있다면 즉시 flag 캐싱
+        if (recruit.isRecruitingPeriod()) {
+            recruitFlagService.setRecruitFlag(recruit);
+            return;
+        }
+
+        // 등록된 모집의 시작일이 미래 시점이라면 스케줄 등록
+        recruitScheduleService.scheduleRecruitOpen(recruit);
+    }
+}

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitScheduleService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitScheduleService.java
@@ -2,16 +2,8 @@ package org.ject.support.domain.recruit.service;
 
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.recruit.domain.Recruit;
-import org.ject.support.domain.recruit.dto.Constants;
-import org.ject.support.domain.recruit.dto.RecruitOpenedEvent;
-import org.ject.support.domain.recruit.exception.RecruitErrorCode;
-import org.ject.support.domain.recruit.exception.RecruitException;
-import org.ject.support.domain.recruit.repository.RecruitRepository;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -21,32 +13,15 @@ import java.time.ZoneId;
 public class RecruitScheduleService {
 
     private final TaskScheduler recruitScheduler;
-    private final RecruitRepository recruitRepository;
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RecruitFlagService recruitFlagService;
 
-    /**
-     * 지원기간이면 호출됨
-     */
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleRecruitOpened(RecruitOpenedEvent event) {
-        Recruit recruit = getRecruit(event);
-
-        //end date 전에는 flag를 true로
-        redisTemplate.opsForValue().set(Constants.PERIOD_FLAG, Boolean.TRUE.toString());
-
-        Instant triggerTime = recruit.getEndDate()
+    public void scheduleRecruitOpen(Recruit recruit) {
+        Instant triggerTime = recruit.getStartDate()
                 .atZone(ZoneId.systemDefault())
                 .toInstant();
 
         recruitScheduler.schedule(() -> {
-            //end date에 도달하면 redis의 flag를 false로 변경
-            redisTemplate.opsForValue().set(Constants.PERIOD_FLAG, Boolean.FALSE.toString());
+            recruitFlagService.setRecruitFlag(recruit);
         }, triggerTime);
-    }
-
-    private Recruit getRecruit(final RecruitOpenedEvent event) {
-        Long recruitId = event.recruitId();
-        return recruitRepository.findById(recruitId)
-                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND));
     }
 }

--- a/src/main/java/org/ject/support/external/s3/S3Service.java
+++ b/src/main/java/org/ject/support/external/s3/S3Service.java
@@ -38,7 +38,7 @@ public class S3Service {
     /**
      * 지원자가 첨부한 포트폴리오 파일 이름과 해당 지원자의 식별자를 토대로 Pre-signed URL 생성
      */
-    @PeriodAccessible
+    @PeriodAccessible(permitAllJob = true)
     public List<UploadFileResponse> uploadPortfolios(Long memberId, List<UploadFileRequest> requests) {
         validatePortfolioExtension(requests);
         validatePortfolioSize(requests);

--- a/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
@@ -1,15 +1,5 @@
 package org.ject.support.domain.recruit.controller;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.ject.support.domain.member.Role.USER;
-import static org.ject.support.domain.recruit.domain.Question.InputType.TEXT;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.time.LocalDateTime;
-import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.entity.Member;
@@ -26,11 +16,23 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.ject.support.domain.member.Role.USER;
+import static org.ject.support.domain.recruit.domain.Question.InputType.TEXT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @IntegrationTest
 @AutoConfigureMockMvc
+@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
 class QuestionControllerTest {
 
     @Autowired

--- a/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodInitializerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodInitializerTest.java
@@ -39,6 +39,8 @@ class AccessPeriodInitializerTest {
     @DisplayName("애플리케이션 구동 시 RECRUIT_FLAG 세팅")
     void set_recruit_flag_by_run_application() {
         // given
+        redisTemplate.delete(List.of("RECRUIT_FLAG:PM", "RECRUIT_FLAG:PD", "RECRUIT_FLAG:FE", "RECRUIT_FLAG:BE"));
+
         recruitRepository.saveAll(List.of(
                 Recruit.builder()
                         .semesterId(1L)

--- a/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodInitializerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodInitializerTest.java
@@ -1,0 +1,76 @@
+package org.ject.support.domain.recruit.service;
+
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.dto.Constants;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.ject.support.testconfig.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.member.JobFamily.BE;
+import static org.ject.support.domain.member.JobFamily.FE;
+import static org.ject.support.domain.member.JobFamily.PD;
+import static org.ject.support.domain.member.JobFamily.PM;
+
+@IntegrationTest
+@Transactional
+@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
+class AccessPeriodInitializerTest {
+
+    @Autowired
+    AccessPeriodInitializer accessPeriodInitializer;
+
+    @Autowired
+    RecruitRepository recruitRepository;
+
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+
+    @Test
+    @DisplayName("애플리케이션 구동 시 RECRUIT_FLAG 세팅")
+    void set_recruit_flag_by_run_application() {
+        // given
+        recruitRepository.saveAll(List.of(
+                Recruit.builder()
+                        .semesterId(1L)
+                        .startDate(LocalDateTime.now().minusDays(1))
+                        .endDate(LocalDateTime.now().plusDays(1))
+                        .jobFamily(PM)
+                        .build(),
+                Recruit.builder()
+                        .semesterId(1L)
+                        .startDate(LocalDateTime.now().minusDays(1))
+                        .endDate(LocalDateTime.now().plusDays(1))
+                        .jobFamily(PD)
+                        .build(),
+                Recruit.builder()
+                        .semesterId(1L)
+                        .startDate(LocalDateTime.now().plusDays(3))
+                        .endDate(LocalDateTime.now().plusDays(5))
+                        .jobFamily(FE)
+                        .build()
+        ));
+
+        // when
+        accessPeriodInitializer.run(null);
+
+        // then
+        assertThat(Boolean.parseBoolean(getRecruitFlag(PM))).isTrue();
+        assertThat(Boolean.parseBoolean(getRecruitFlag(PD))).isTrue();
+        assertThat(Boolean.parseBoolean(getRecruitFlag(FE))).isFalse();
+        assertThat(Boolean.parseBoolean(getRecruitFlag(BE))).isFalse();
+    }
+
+    private String getRecruitFlag(JobFamily jobFamily) {
+        return redisTemplate.opsForValue().get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, jobFamily));
+    }
+}

--- a/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodVerificatorTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodVerificatorTest.java
@@ -1,0 +1,115 @@
+package org.ject.support.domain.recruit.service;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.ject.support.common.exception.GlobalException;
+import org.ject.support.common.util.PeriodAccessible;
+import org.ject.support.domain.member.JobFamily;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AccessPeriodVerificatorTest {
+
+    @InjectMocks
+    AccessPeriodVerificator accessPeriodVerificator;
+
+    @Mock
+    ProceedingJoinPoint joinPoint;
+
+    @Mock
+    PeriodAccessible target;
+
+    @Mock
+    RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    ValueOperations<String, String> valueOperations;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("하나의 직군이라도 모집중인 상태에서 permitAllJob이 true면 통과")
+    void permit_all_job_success_by_recruiting_anyone() throws Throwable {
+        // given
+        when(target.permitAllJob()).thenReturn(true); // 모든 직군에 대한 요청
+        when(valueOperations.get(anyString())).thenReturn("false");
+        when(valueOperations.get("RECRUIT_FLAG:FE")).thenReturn("true"); // 하나라도 모집중
+        when(joinPoint.proceed()).thenReturn("OK");
+
+        // when
+        Object result = accessPeriodVerificator.checkRecruitmentPeriod(joinPoint, target);
+
+        // then
+        assertThat(result).isEqualTo("OK");
+    }
+
+    @Test
+    @DisplayName("모집중인 직군이 없는 상태에서 permitAllJob이 true이면 실패")
+    void permit_all_job_fail_by_not_recruiting_all() {
+        // given
+        when(target.permitAllJob()).thenReturn(true); // 모든 직군에 대한 요청
+        when(valueOperations.get(anyString())).thenReturn("false");
+
+        // when, then
+        assertThatThrownBy(() -> accessPeriodVerificator.checkRecruitmentPeriod(joinPoint, target))
+                .isInstanceOf(GlobalException.class);
+    }
+
+    @Test
+    @DisplayName("permitAllJob이 false인 상태에서 모집중인 직군을 파라미터로 전달하면 통과")
+    void check_success_by_has_job_family() throws Throwable {
+        // given
+        when(target.permitAllJob()).thenReturn(false);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{JobFamily.BE});
+        when(valueOperations.get(anyString())).thenReturn("false");
+        when(valueOperations.get("RECRUIT_FLAG:BE")).thenReturn("true");
+        when(joinPoint.proceed()).thenReturn("OK");
+
+        // when
+        Object result = accessPeriodVerificator.checkRecruitmentPeriod(joinPoint, target);
+
+        // then
+        assertThat(result).isEqualTo("OK");
+    }
+
+    @Test
+    @DisplayName("permitAllJob이 false인 상태에서 모집중이지 않은 직군을 파라미터로 전달하면 실패")
+    void test_method_name() {
+        // given
+        when(target.permitAllJob()).thenReturn(false);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{JobFamily.BE});
+        when(valueOperations.get(anyString())).thenReturn("false");
+
+        // when, then
+        assertThatThrownBy(() -> accessPeriodVerificator.checkRecruitmentPeriod(joinPoint, target))
+                .isInstanceOf(GlobalException.class);
+    }
+
+    @Test
+    @DisplayName("permitAll이 false인데 JobFamily 파라미터 없으면 실패")
+    void check_fail_by_has_not_job_family() {
+        // given
+        when(target.permitAllJob()).thenReturn(false);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{"string", 123}); // JobFamily 없음
+
+        // when, then
+        assertThatThrownBy(() -> accessPeriodVerificator.checkRecruitmentPeriod(joinPoint, target))
+                .isInstanceOf(GlobalException.class);
+    }
+}

--- a/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodVerifierTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodVerifierTest.java
@@ -21,10 +21,10 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class AccessPeriodVerificatorTest {
+class AccessPeriodVerifierTest {
 
     @InjectMocks
-    AccessPeriodVerificator accessPeriodVerificator;
+    AccessPeriodVerifier accessPeriodVerifier;
 
     @Mock
     ProceedingJoinPoint joinPoint;
@@ -53,7 +53,7 @@ class AccessPeriodVerificatorTest {
         when(joinPoint.proceed()).thenReturn("OK");
 
         // when
-        Object result = accessPeriodVerificator.checkRecruitmentPeriod(joinPoint, target);
+        Object result = accessPeriodVerifier.checkRecruitmentPeriod(joinPoint, target);
 
         // then
         assertThat(result).isEqualTo("OK");
@@ -67,7 +67,7 @@ class AccessPeriodVerificatorTest {
         when(valueOperations.get(anyString())).thenReturn("false");
 
         // when, then
-        assertThatThrownBy(() -> accessPeriodVerificator.checkRecruitmentPeriod(joinPoint, target))
+        assertThatThrownBy(() -> accessPeriodVerifier.checkRecruitmentPeriod(joinPoint, target))
                 .isInstanceOf(GlobalException.class);
     }
 
@@ -82,7 +82,7 @@ class AccessPeriodVerificatorTest {
         when(joinPoint.proceed()).thenReturn("OK");
 
         // when
-        Object result = accessPeriodVerificator.checkRecruitmentPeriod(joinPoint, target);
+        Object result = accessPeriodVerifier.checkRecruitmentPeriod(joinPoint, target);
 
         // then
         assertThat(result).isEqualTo("OK");
@@ -97,7 +97,7 @@ class AccessPeriodVerificatorTest {
         when(valueOperations.get(anyString())).thenReturn("false");
 
         // when, then
-        assertThatThrownBy(() -> accessPeriodVerificator.checkRecruitmentPeriod(joinPoint, target))
+        assertThatThrownBy(() -> accessPeriodVerifier.checkRecruitmentPeriod(joinPoint, target))
                 .isInstanceOf(GlobalException.class);
     }
 
@@ -109,7 +109,7 @@ class AccessPeriodVerificatorTest {
         when(joinPoint.getArgs()).thenReturn(new Object[]{"string", 123}); // JobFamily 없음
 
         // when, then
-        assertThatThrownBy(() -> accessPeriodVerificator.checkRecruitmentPeriod(joinPoint, target))
+        assertThatThrownBy(() -> accessPeriodVerifier.checkRecruitmentPeriod(joinPoint, target))
                 .isInstanceOf(GlobalException.class);
     }
 }

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitFlagServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitFlagServiceTest.java
@@ -1,0 +1,43 @@
+package org.ject.support.domain.recruit.service;
+
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.testconfig.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
+class RecruitFlagServiceTest {
+
+    @Autowired
+    RecruitFlagService recruitFlagService;
+
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+
+    @Test
+    @DisplayName("recruit flag 세팅")
+    void set_recruit_flag() {
+        // given
+        Recruit recruit = Recruit.builder()
+                .semesterId(1L)
+                .jobFamily(JobFamily.BE)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        // when
+        recruitFlagService.setRecruitFlag(recruit);
+
+        // then
+        assertThat(redisTemplate.opsForValue().get("RECRUIT_FLAG:BE")).isEqualTo("true");
+    }
+}

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitSavedEventHandlerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitSavedEventHandlerTest.java
@@ -1,0 +1,71 @@
+package org.ject.support.domain.recruit.service;
+
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.dto.RecruitSavedEvent;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecruitSavedEventHandlerTest {
+
+    @InjectMocks
+    RecruitSavedEventHandler recruitSavedEventHandler;
+
+    @Mock
+    RecruitRepository recruitRepository;
+
+    @Mock
+    RecruitFlagService recruitFlagService;
+
+    @Mock
+    RecruitScheduleService recruitScheduleService;
+
+    Recruit recruit;
+
+    @BeforeEach
+    void setUp() {
+        Recruit recruit = Recruit.builder()
+                .id(1L)
+                .semesterId(1L)
+                .jobFamily(JobFamily.BE)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        when(recruitRepository.findById(1L)).thenReturn(Optional.of(recruit));
+    }
+
+    @Test
+    @DisplayName("등록된 모집이 활성화되어 있다면 즉시 flag 캐싱 메서드 호출")
+    void call_set_recruit_flag_method() {
+        // when
+        recruitSavedEventHandler.handleRecruitSaved(new RecruitSavedEvent(1L));
+
+        // then
+        verify(recruitFlagService, atMostOnce()).setRecruitFlag(recruit);
+    }
+
+    @Test
+    @DisplayName("등록된 모집의 시작일이 미래 시점이라면 스케줄 등록 메서드 호출")
+    void call_schedule_open() {
+        // when
+        recruitSavedEventHandler.handleRecruitSaved(new RecruitSavedEvent(1L));
+
+        // then
+        verify(recruitScheduleService, atMostOnce()).scheduleRecruitOpen(recruit);
+    }
+}

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitServiceTest.java
@@ -34,10 +34,9 @@ class RecruitServiceTest {
         // given
         Recruit recruit = Recruit.builder()
                 .semesterId(1L)
-                .startDate(LocalDateTime.now().minusDays(1))
-                .endDate(LocalDateTime.now().plusDays(1))
+                .startDate(LocalDateTime.now().minusDays(3))
+                .endDate(LocalDateTime.now().minusDays(1))
                 .jobFamily(BE)
-                .isClosed(true)
                 .build();
 
         Mockito.when(recruitRepository.findById(1L)).thenReturn(Optional.ofNullable(recruit));

--- a/src/test/java/org/ject/support/testconfig/ApplicationPeriodTest.java
+++ b/src/test/java/org/ject/support/testconfig/ApplicationPeriodTest.java
@@ -2,6 +2,7 @@ package org.ject.support.testconfig;
 
 import static org.mockito.Mockito.when;
 
+import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.dto.Constants;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
@@ -23,7 +24,14 @@ public abstract class ApplicationPeriodTest {
     @BeforeEach
     void setUp() {
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        when(valueOperations.get(Constants.PERIOD_FLAG)).thenReturn(Boolean.toString(true));
+        when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.PM.name())))
+                .thenReturn(Boolean.toString(true));
+        when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.PD.name())))
+                .thenReturn(Boolean.toString(true));
+        when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.FE.name())))
+                .thenReturn(Boolean.toString(true));
+        when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.BE.name())))
+                .thenReturn(Boolean.toString(true));
         when(redisTemplate.getConnectionFactory()).thenReturn(redisConnectionFactory);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #188 

## 📝작업 내용
- Recruit 등록/수정 dto의 startDate에 있는 `@Future` 제거
- 모집 여부에 따른 접근 제한 시 사용하는 플래그를 PERIOD_FLAG에서 RECRUIT_FLAG로 수정
- Recruit의 isClosed 필드 제거

## ✅테스트 결과
![image](https://github.com/user-attachments/assets/14cce8f5-4c1f-4605-83e8-9dfb532d631f)
![image](https://github.com/user-attachments/assets/384decac-590e-4967-8e68-37f7dbdeb806)
![image](https://github.com/user-attachments/assets/c74ae8aa-130b-4123-90a9-7352280be23a)
![image](https://github.com/user-attachments/assets/1a0a5810-341b-46b8-8039-8900f75ba502)
![image](https://github.com/user-attachments/assets/a38314a6-1b79-40c9-a7c5-8c4259e3368e)
![image](https://github.com/user-attachments/assets/2e555c2a-7241-4a4d-bf9d-e218d5f864bd)
![image](https://github.com/user-attachments/assets/9c03e581-10af-462e-b580-e8a969acb6dc)

