### PR TITLE
모집 취소 시 recruit flag 제거 로직 구현

### DIFF
--- a/src/main/java/org/ject/support/domain/recruit/dto/RecruitCanceledEvent.java
+++ b/src/main/java/org/ject/support/domain/recruit/dto/RecruitCanceledEvent.java
@@ -1,0 +1,6 @@
+package org.ject.support.domain.recruit.dto;
+
+import org.ject.support.domain.member.JobFamily;
+
+public record RecruitCanceledEvent(JobFamily jobFamily) {
+}

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitCanceledEventHandler.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitCanceledEventHandler.java
@@ -1,0 +1,24 @@
+package org.ject.support.domain.recruit.service;
+
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.recruit.dto.RecruitCanceledEvent;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static org.ject.support.domain.recruit.dto.Constants.RECRUIT_FLAG_PREFIX;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitCanceledEventHandler {
+
+    private final RecruitFlagService recruitFlagService;
+
+    /**
+     * 모집 취소 시 호출됨
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleRecruitCanceled(RecruitCanceledEvent event) {
+        recruitFlagService.deleteRecruitFlag(String.format("%s%s", RECRUIT_FLAG_PREFIX, event.jobFamily()));
+    }
+}

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitFlagService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitFlagService.java
@@ -23,4 +23,8 @@ public class RecruitFlagService {
                 Duration.between(LocalDateTime.now(), recruit.getEndDate())
         );
     }
+
+    public void deleteRecruitFlag(String recruitFlag) {
+        redisTemplate.delete(recruitFlag);
+    }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitService.java
@@ -38,8 +38,6 @@ public class RecruitService implements RecruitUsecase {
                 .map(request -> request.toEntity(ongoingSemesterId))
                 .toList();
         recruitRepository.saveAll(recruits);
-
-        throw new RuntimeException();
     }
 
     @Override

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitFlagServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitFlagServiceTest.java
@@ -40,4 +40,14 @@ class RecruitFlagServiceTest {
         // then
         assertThat(redisTemplate.opsForValue().get("RECRUIT_FLAG:BE")).isEqualTo("true");
     }
+
+    @Test
+    @DisplayName("recruit flag 제거")
+    void delete_recruit_flag() {
+        // when
+        recruitFlagService.deleteRecruitFlag("RECRUIT_FLAG:BE");
+
+        // then
+        assertThat(redisTemplate.opsForValue().get("RECRUIT_FLAG:BE")).isEqualTo(null);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #191 

## 📝작업 내용
- 모집 취소 시 recruit flag 제거 로직 구현

## ✅테스트 결과
<img width="581" alt="image" src="https://github.com/user-attachments/assets/aec68854-9a81-4e59-9a4a-5b9aa6cf2e6e" />
