### PR TITLE
핀번호 수정 시 이전과 동일한 핀번호도 허용하도록 수정

### DIFF
--- a/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
@@ -8,8 +8,7 @@ import org.ject.support.common.exception.ErrorCode;
 @AllArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
     NOT_FOUND_MEMBER("NOT_FOUND_MEMBER", "멤버를 찾을 수 없습니다."),
-    ALREADY_EXIST_MEMBER("ALREADY_EXIST_MEMBER", "이미 가입되어 있는 회원입니다."),
-    SAME_PIN("SAME_PIN", "기존과 같은 핀 번호입니다.");
+    ALREADY_EXIST_MEMBER("ALREADY_EXIST_MEMBER", "이미 가입되어 있는 회원입니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/org/ject/support/domain/member/service/MemberService.java
+++ b/src/main/java/org/ject/support/domain/member/service/MemberService.java
@@ -1,7 +1,6 @@
 package org.ject.support.domain.member.service;
 
 import static org.ject.support.domain.member.exception.MemberErrorCode.ALREADY_EXIST_MEMBER;
-import static org.ject.support.domain.member.exception.MemberErrorCode.SAME_PIN;
 
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
@@ -77,10 +76,6 @@ public class MemberService {
     public void updatePin(UpdatePinRequest request, Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
-
-        if (passwordEncoder.matches(request.pin(), member.getPin())) {
-            throw new MemberException(SAME_PIN);
-        }
 
         String encodedPin = passwordEncoder.encode(request.pin());
         member.updatePin(encodedPin);

--- a/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
@@ -156,6 +156,8 @@ class MemberControllerTest {
         // 테스트 후 인증 정보 초기화
         SecurityContextHolder.clearContext();
     }
+
+    /*
     
     @Test
     @DisplayName("핀번호 재설정 실패 - 동일한 PIN 번호")
@@ -183,6 +185,8 @@ class MemberControllerTest {
         // 테스트 후 인증 정보 초기화
         SecurityContextHolder.clearContext();
     }
+
+     */
     
     @Test
     @DisplayName("핀번호 재설정 실패 - 유효하지 않은 PIN 번호 형식")

--- a/src/test/java/org/ject/support/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/ject/support/domain/member/service/MemberServiceTest.java
@@ -157,7 +157,6 @@ class MemberServiceTest {
         String newEncodedPin = "new_encoded_pin";
         
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(passwordEncoder.matches(newPin, TEST_ENCODED_PIN)).willReturn(false); // 새 PIN이 기존과 다름
         given(passwordEncoder.encode(newPin)).willReturn(newEncodedPin);
         
         // when
@@ -166,7 +165,6 @@ class MemberServiceTest {
         // then
         assertThat(member.getPin()).isEqualTo(newEncodedPin);
         verify(memberRepository).findById(memberId);
-        verify(passwordEncoder).matches(newPin, TEST_ENCODED_PIN);
         verify(passwordEncoder).encode(newPin);
     }
     
@@ -185,7 +183,8 @@ class MemberServiceTest {
                 .extracting(e -> ((MemberException) e).getErrorCode())
                 .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
     }
-    
+
+    /*
     @Test
     @DisplayName("핀번호 재설정 실패 - 기존과 동일한 PIN 번호")
     void updatePin_SamePin_ThrowsException() {
@@ -208,4 +207,5 @@ class MemberServiceTest {
                 .extracting(e -> ((MemberException) e).getErrorCode())
                 .isEqualTo(MemberErrorCode.SAME_PIN);
     }
+     */
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #202

## 📝작업 내용

- 핀번호 동일 검증 로직 제거
- 관련 에러 코드 제거
- 테스트 코드 수정

## ✅테스트 결과
<img width="341" alt="스크린샷 2025-04-17 오후 2 52 21" src="https://github.com/user-attachments/assets/057662de-edeb-4268-a191-bacde5bdac0c" />
