### PR TITLE
Feat/211 check member inform api

### DIFF
--- a/src/main/java/org/ject/support/domain/member/controller/MemberController.java
+++ b/src/main/java/org/ject/support/domain/member/controller/MemberController.java
@@ -73,7 +73,7 @@ public class MemberController {
         memberService.updatePin(request, memberId);
     }
 
-    @GetMapping("/initial-status")
+    @GetMapping("/profile/initial/status")
     @PreAuthorize("hasRole('ROLE_TEMP')")
     public boolean isInitialMember(@AuthPrincipal Long memberId) {
         // 임시회원의 최초 프로필 정보 등록 여부 확인

--- a/src/main/java/org/ject/support/domain/member/controller/MemberController.java
+++ b/src/main/java/org/ject/support/domain/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import org.ject.support.domain.member.dto.MemberDto;
 import org.ject.support.domain.member.service.MemberService;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -70,5 +71,12 @@ public class MemberController {
 
         // 임시회원의 PIN 번호 재설정
         memberService.updatePin(request, memberId);
+    }
+
+    @GetMapping("/initial-status")
+    @PreAuthorize("hasRole('ROLE_TEMP')")
+    public boolean isInitialMember(@AuthPrincipal Long memberId) {
+        // 임시회원의 최초 프로필 정보 등록 여부 확인
+        return memberService.checkIsInitialed(memberId);
     }
 }

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -71,4 +71,8 @@ public class Member extends BaseTimeEntity {
     public void updatePin(String pin) {
         this.pin = pin;
     }
+
+    public boolean isInitialed() {
+        return this.name != null && this.phoneNumber != null;
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/service/MemberService.java
+++ b/src/main/java/org/ject/support/domain/member/service/MemberService.java
@@ -82,8 +82,8 @@ public class MemberService {
         member.updatePin(encodedPin);
     }
 
-    @Transactional
-    public boolean checkIsInitialed(@AuthPrincipal Long memberId) {
+    @Transactional(readOnly = true)
+    public boolean checkIsInitialed(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
 

--- a/src/main/java/org/ject/support/domain/member/service/MemberService.java
+++ b/src/main/java/org/ject/support/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package org.ject.support.domain.member.service;
 import static org.ject.support.domain.member.exception.MemberErrorCode.ALREADY_EXIST_MEMBER;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.security.AuthPrincipal;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
 import org.ject.support.domain.member.dto.MemberDto;
 import org.ject.support.domain.member.dto.MemberDto.RegisterRequest;
@@ -79,5 +80,13 @@ public class MemberService {
 
         String encodedPin = passwordEncoder.encode(request.pin());
         member.updatePin(encodedPin);
+    }
+
+    @Transactional
+    public boolean checkIsInitialed(@AuthPrincipal Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
+
+        return member.isInitialed();
     }
 }

--- a/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
@@ -227,7 +227,7 @@ class MemberControllerTest {
         SecurityContextHolder.getContext().setAuthentication(auth);
         
         // when & then
-        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/members/initial-status")
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/members/profile/initial/status")
                 .contentType(MediaType.APPLICATION_JSON)
                 .principal(auth))
                 .andExpect(status().isOk())
@@ -252,7 +252,7 @@ class MemberControllerTest {
         SecurityContextHolder.getContext().setAuthentication(auth);
         
         // when & then
-        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/members/initial-status")
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/members/profile/initial/status")
                 .contentType(MediaType.APPLICATION_JSON)
                 .principal(auth))
                 .andExpect(status().isOk())

--- a/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
@@ -211,6 +211,56 @@ class MemberControllerTest {
         // 테스트 후 인증 정보 초기화
         SecurityContextHolder.clearContext();
     }
+    
+    @Test
+    @DisplayName("임시회원 최초 프로필 등록 여부 확인 성공 - 등록된 경우")
+    void isInitialMember_Success_True() throws Exception {
+        // given
+        Long memberId = 1L;
+        
+        // 모킹 설정을 lenient로 변경하여 엄격한 스텁 검사를 비활성화
+        lenient().when(memberService.checkIsInitialed(any())).thenReturn(true);
+        
+        // CustomUserDetails를 사용하여 인증 정보 설정 (ROLE_TEMP 권한)
+        CustomUserDetails userDetails = new CustomUserDetails(TEST_EMAIL, memberId, Role.TEMP);
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        
+        // when & then
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/members/initial-status")
+                .contentType(MediaType.APPLICATION_JSON)
+                .principal(auth))
+                .andExpect(status().isOk())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().string("true"));
+        
+        // 테스트 후 인증 정보 초기화
+        SecurityContextHolder.clearContext();
+    }
+    
+    @Test
+    @DisplayName("임시회원 최초 프로필 등록 여부 확인 성공 - 미등록된 경우")
+    void isInitialMember_Success_False() throws Exception {
+        // given
+        Long memberId = 1L;
+        
+        // 모킹 설정을 lenient로 변경하여 엄격한 스텁 검사를 비활성화
+        lenient().when(memberService.checkIsInitialed(any())).thenReturn(false);
+        
+        // CustomUserDetails를 사용하여 인증 정보 설정 (ROLE_TEMP 권한)
+        CustomUserDetails userDetails = new CustomUserDetails(TEST_EMAIL, memberId, Role.TEMP);
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        
+        // when & then
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/members/initial-status")
+                .contentType(MediaType.APPLICATION_JSON)
+                .principal(auth))
+                .andExpect(status().isOk())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().string("false"));
+        
+        // 테스트 후 인증 정보 초기화
+        SecurityContextHolder.clearContext();
+    }
 
 
 @SpringBootTest


### PR DESCRIPTION
## #️⃣연관된 이슈

close #211 

## 📝작업 내용

- 임시 회원 최초 프로필 등록 여부 확인 API 구현
- 테스트 코드 작성

## ✅테스트 결과
![스크린샷 2025-04-18 오전 1 00 06](https://github.com/user-attachments/assets/282e9d9c-a5c8-41e3-a180-374a139d0bb9)
