### PR TITLE
Spring Boot 타임존 Asia/Seoul 설정

### DIFF
--- a/src/main/java/org/ject/support/SupportApplication.java
+++ b/src/main/java/org/ject/support/SupportApplication.java
@@ -1,5 +1,7 @@
 package org.ject.support;
 
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -13,5 +15,10 @@ import org.springframework.scheduling.annotation.EnableAsync;
 public class SupportApplication {
     public static void main(String[] args) {
         SpringApplication.run(SupportApplication.class, args);
+    }
+
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #213 

## 📝작업 내용

- @PostConstruct로 스프링 부트 애플리케이션 실행 시 타임존을 Asia/Seoul로 설정

## ✅테스트 결과
![스크린샷 2025-04-22 오후 6 31 13](https://github.com/user-attachments/assets/1f31fe08-1a87-486a-9e5e-5118e474f4ee)
