### PR TITLE
관리자 로그인 관련 더미 API 추가

### DIFF
--- a/src/main/java/org/ject/support/common/util/CodeGeneratorUtil.java
+++ b/src/main/java/org/ject/support/common/util/CodeGeneratorUtil.java
@@ -1,0 +1,16 @@
+package org.ject.support.common.util;
+
+import java.security.SecureRandom;
+import java.util.stream.Collectors;
+
+public class CodeGeneratorUtil {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final int DIGIT_BOUND = 10;
+
+    public static String generateAuthCode(int length) {
+        return SECURE_RANDOM.ints(length, 0, DIGIT_BOUND)
+                .mapToObj(String::valueOf)
+                .collect(Collectors.joining());
+    }
+}

--- a/src/main/java/org/ject/support/common/util/CodeGeneratorUtil.java
+++ b/src/main/java/org/ject/support/common/util/CodeGeneratorUtil.java
@@ -5,6 +5,10 @@ import java.util.stream.Collectors;
 
 public class CodeGeneratorUtil {
 
+    private CodeGeneratorUtil() {
+        throw new UnsupportedOperationException("인스턴스화 방지");
+    }
+
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final int DIGIT_BOUND = 10;
 

--- a/src/main/java/org/ject/support/domain/admin/controller/AdminAuthApiSpec.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/AdminAuthApiSpec.java
@@ -1,0 +1,33 @@
+package org.ject.support.domain.admin.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.ject.support.domain.admin.dto.AdminVerifyEmailRequest;
+import org.ject.support.domain.admin.dto.AdminAuthSendEmailRequest;
+import org.ject.support.domain.admin.dto.AdminAuthSendEmailResponse;
+import org.ject.support.domain.admin.dto.AdminVerifyEmailResponse;
+import org.ject.support.domain.admin.dto.AdminVerifySlackRequest;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Admin", description = "관리자 API")
+public interface AdminAuthApiSpec {
+
+    @Operation(
+            summary = "관리자 인증 이메일 코드 전송",
+            description = "관리자 인증 코드를 이메일로 전송합니다."
+    )
+    AdminAuthSendEmailResponse sendAdminAuthEmailCode(@RequestBody @Valid AdminAuthSendEmailRequest request);
+
+    @Operation(
+            summary = "관리자 인증 이메일 코드 검증",
+            description = "관리자 인증 이메일 코드를 검증합니다."
+    )
+    AdminVerifyEmailResponse verifyAdminAuthEmailCode(@RequestBody @Valid AdminVerifyEmailRequest request);
+
+    @Operation(
+            summary = "관리자 인증 Slack 코드 검증",
+            description = "관리자 인증 Slack 코드를 검증합니다."
+    )
+    boolean verifyAdminAuthSlackCode(@RequestBody @Valid AdminVerifySlackRequest request);
+}

--- a/src/main/java/org/ject/support/domain/admin/controller/AdminAuthController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/AdminAuthController.java
@@ -1,0 +1,41 @@
+package org.ject.support.domain.admin.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.admin.dto.AdminVerifyEmailRequest;
+import org.ject.support.domain.admin.dto.AdminAuthSendEmailRequest;
+import org.ject.support.domain.admin.dto.AdminAuthSendEmailResponse;
+import org.ject.support.domain.admin.dto.AdminVerifyEmailResponse;
+import org.ject.support.domain.admin.dto.AdminVerifySlackRequest;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminAuthController implements AdminAuthApiSpec {
+
+    @PostMapping("/auth/email-codes")
+    public AdminAuthSendEmailResponse sendAdminAuthEmailCode(@RequestBody @Valid AdminAuthSendEmailRequest request) {
+        // TODO : 관리자 인증 코드 전송 로직 구현
+        return AdminAuthSendEmailResponse.builder()
+                .email("test@tset.com")
+                .build();
+    }
+
+    @PostMapping("/auth/email-codes/verify")
+    public AdminVerifyEmailResponse verifyAdminAuthEmailCode(@RequestBody @Valid AdminVerifyEmailRequest request) {
+        // TODO : 관리자 인증 이메일 코드 검증 로직 구현, Slack 인증 코드 전송
+        return AdminVerifyEmailResponse.builder()
+                .email("test@tset.com")
+                .build();
+    }
+
+    @PostMapping("/auth/slack-codes/verify")
+    public boolean verifyAdminAuthSlackCode(@RequestBody @Valid AdminVerifySlackRequest request) {
+        // TODO : 관리자 인증 Slack 코드 검증 로직 구현, accessToken 발급
+        return false;
+    }
+}

--- a/src/main/java/org/ject/support/domain/admin/dto/AdminAuthSendEmailRequest.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/AdminAuthSendEmailRequest.java
@@ -1,0 +1,9 @@
+package org.ject.support.domain.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminAuthSendEmailRequest(
+        @NotBlank(message = "Email은 필수 입력 값입니다.")
+        String email
+) {
+}

--- a/src/main/java/org/ject/support/domain/admin/dto/AdminAuthSendEmailRequest.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/AdminAuthSendEmailRequest.java
@@ -1,9 +1,11 @@
 package org.ject.support.domain.admin.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record AdminAuthSendEmailRequest(
         @NotBlank(message = "Email은 필수 입력 값입니다.")
+        @Email(message = "유효하지 않은 이메일 형식입니다.")
         String email
 ) {
 }

--- a/src/main/java/org/ject/support/domain/admin/dto/AdminAuthSendEmailResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/AdminAuthSendEmailResponse.java
@@ -1,0 +1,7 @@
+package org.ject.support.domain.admin.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AdminAuthSendEmailResponse(String email) {
+}

--- a/src/main/java/org/ject/support/domain/admin/dto/AdminVerifyEmailRequest.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/AdminVerifyEmailRequest.java
@@ -1,10 +1,12 @@
 package org.ject.support.domain.admin.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record AdminVerifyEmailRequest(
         @NotBlank(message = "Email은 필수 입력 값입니다.")
+        @Email(message = "유효하지 않은 이메일 형식입니다.")
         String email,
 
         @NotBlank(message = "Code는 필수 입력 값입니다.")

--- a/src/main/java/org/ject/support/domain/admin/dto/AdminVerifyEmailRequest.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/AdminVerifyEmailRequest.java
@@ -1,0 +1,14 @@
+package org.ject.support.domain.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminVerifyEmailRequest(
+        @NotBlank(message = "Email은 필수 입력 값입니다.")
+        String email,
+
+        @NotBlank(message = "Code는 필수 입력 값입니다.")
+        @Size(min = 6, max = 6, message = "Code는 6자리여야 합니다.")
+        String code
+) {
+}

--- a/src/main/java/org/ject/support/domain/admin/dto/AdminVerifyEmailResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/AdminVerifyEmailResponse.java
@@ -1,0 +1,7 @@
+package org.ject.support.domain.admin.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AdminVerifyEmailResponse(String email) {
+}

--- a/src/main/java/org/ject/support/domain/admin/dto/AdminVerifySlackRequest.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/AdminVerifySlackRequest.java
@@ -1,0 +1,14 @@
+package org.ject.support.domain.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminVerifySlackRequest(
+        @NotBlank(message = "Email은 필수 입력 값입니다.")
+        String email,
+
+        @NotBlank(message = "Code는 필수 입력 값입니다.")
+        @Size(min = 6, max = 6, message = "Code는 4자리여야 합니다.")
+        String code
+) {
+}

--- a/src/main/java/org/ject/support/domain/admin/dto/AdminVerifySlackRequest.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/AdminVerifySlackRequest.java
@@ -1,10 +1,12 @@
 package org.ject.support.domain.admin.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record AdminVerifySlackRequest(
         @NotBlank(message = "Email은 필수 입력 값입니다.")
+        @Email(message = "유효하지 않은 이메일 형식입니다.")
         String email,
 
         @NotBlank(message = "Code는 필수 입력 값입니다.")

--- a/src/main/java/org/ject/support/external/email/service/EmailAuthService.java
+++ b/src/main/java/org/ject/support/external/email/service/EmailAuthService.java
@@ -2,10 +2,10 @@ package org.ject.support.external.email.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.ject.support.common.util.CodeGeneratorUtil;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Map;
 
@@ -21,18 +21,9 @@ public class EmailAuthService {
     private final RedisTemplate<String, String> redisTemplate;
 
     public void sendAuthCode(String sendGroupCode, String toAddress) {
-        String authCode = generateAuthCode();
+        String authCode = CodeGeneratorUtil.generateAuthCode(AUTH_CODE_LENGTH);
         sendAuthCodeEmail(sendGroupCode, toAddress, authCode);
         storeAuthCode(toAddress, authCode);
-    }
-
-    private String generateAuthCode() {
-        SecureRandom random = new SecureRandom();
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < AUTH_CODE_LENGTH; i++) {
-            builder.append(random.nextInt(10));
-        }
-        return builder.toString();
     }
 
     private void sendAuthCodeEmail(String sendGroupCode, String toAddress, String authCode) {

--- a/src/test/java/org/ject/support/common/util/CodeGeneratorUtilTest.java
+++ b/src/test/java/org/ject/support/common/util/CodeGeneratorUtilTest.java
@@ -1,0 +1,24 @@
+package org.ject.support.common.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class CodeGeneratorUtilTest {
+
+    @Test
+    @DisplayName("랜덤 인증 코드 생성 테스트")
+    void generateAuthCode_length_check() {
+        // given
+        int length = 6;
+
+        // when
+        String code = CodeGeneratorUtil.generateAuthCode(length);
+
+        // then
+        assertNotNull(code);
+        assertEquals(length, code.length());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#242 

## 📝 작업 내용

### 1. 관리자 로그인에 필요한 더미 API를 만들었습니다.
1-1. 관리자 로그인 시도 -> Email로 인증 코드 발송
<img width="763" height="451" alt="image" src="https://github.com/user-attachments/assets/342de225-a40a-421a-9799-2dc967eca2ed" />
1-2. 이메일 인증 코드 검증 -> Slack 인증 코드 발송
<img width="1132" height="532" alt="image" src="https://github.com/user-attachments/assets/8dd27afd-62e3-4094-8667-2001f7c87370" />
1-3. Slack 인증 코드 검증 -> accessToken 발급

### 2. 기존에 사용중이던 랜덤 코드 생성 기능을 Util로 공통화 했습니다.


 ### 참고사항
  - Member테이블로 구현이 가능하기에 Member와 Admin 테이블을 따로 분리하지 않고, 작업할 예정입니다.
  - 인증 코드들은 Redis에 저장할 예정 입니다.(이메일, Slack 발송 코드)
  - 세부 구현은 승인 이후에 작업할 예정입니다
 
### Swagger Image
<img width="1359" height="231" alt="image" src="https://github.com/user-attachments/assets/8e25a013-2fe1-453d-9612-044c824597f9" />

## 🙏 리뷰 요구사항 (선택)
 - 참고사항 관련해서 좋은 의견 있으시면 코멘트 부탁드리겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 관리자 인증 API 추가: 이메일 인증 코드 발송, 이메일 코드 검증, 슬랙 코드 검증 엔드포인트 제공
  - 요청 페이로드 DTO 추가 및 서버측 유효성검증 메시지 포함(이메일/코드 필수 및 길이 제약)
- 리팩터링
  - 인증 코드 생성 로직을 공용 유틸로 통합하여 재사용성 향상
- 테스트
  - 인증 코드 생성 유틸에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->