### PR TITLE
fix: 배포 워크플로우에서 불필요한 SCP 단계 제거

### DIFF
--- a/.github/workflows/continuous-deployment-dev.yml
+++ b/.github/workflows/continuous-deployment-dev.yml
@@ -77,14 +77,14 @@ jobs:
           
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-      - name: Copy deployment script to EC2
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ env.EC2_HOST }}
-          username: ec2-user
-          key: ${{ env.EC2_SSH_KEY }}
-          source: "deploy.sh"
-          target: "/home/ec2-user/app/"
+      # - name: Copy deployment script to EC2
+      #   uses: appleboy/scp-action@v0.1.7
+      #   with:
+      #     host: ${{ env.EC2_HOST }}
+      #     username: ec2-user
+      #     key: ${{ env.EC2_SSH_KEY }}
+      #     source: "deploy.sh"
+      #     target: "/home/ec2-user/app/"
 
       - name: Blue-Green Deploy to EC2
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
## #️⃣연관된 이슈

- #237 

## 📝 작업 내용

- `tar: empty archive` 에러 발생
  - appleboy/scp-action에서 deploy.sh 파일을 찾지 못해서 발생하는 거로 보임
  - 사실 불필요한 플로우라 제거

```shell
tar all files into /tmp/JIjZBZyJQg.tar.gz
tar: empty archive
exit status 1
```

## 🙏 리뷰 요구사항 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 개발 환경 배포 파이프라인을 정리했습니다. 배포 스크립트를 원격 호스트로 사전 복사하는 단계가 비활성화되었으며, 이제 배포 시 스크립트가 호스트에 미리 존재해야 합니다.
  - 블루-그린 배포 단계는 그대로 유지됩니다.
  - 운영 기능 변화는 없으며, 배포 실패 시 원격 호스트의 스크립트 존재 여부를 확인해 주세요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->