### PR TITLE
에러 코드 구조 리팩토링

### DIFF
--- a/src/main/java/org/ject/support/common/exception/ErrorCode.java
+++ b/src/main/java/org/ject/support/common/exception/ErrorCode.java
@@ -1,7 +1,13 @@
 package org.ject.support.common.exception;
 
+import org.springframework.http.HttpStatus;
+
 public interface ErrorCode {
     String name();
+
+    HttpStatus getHttpStatus();
+
     String getCode();
+
     String getMessage();
 }

--- a/src/main/java/org/ject/support/common/exception/GlobalErrorCode.java
+++ b/src/main/java/org/ject/support/common/exception/GlobalErrorCode.java
@@ -2,25 +2,36 @@ package org.ject.support.common.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @Getter
 @AllArgsConstructor
 public enum GlobalErrorCode implements ErrorCode {
-    UNSUPPORTED_PARAMETER_TYPE("G-01", "Unsupported parameter type"),
-    RESOURCE_NOT_FOUND("G-02", "Resource not found"),
-    METHOD_NOT_ALLOWED("G-03", "Method not allowed"),
-    TEMPLATE_NOT_FOUND("G-04", "Template file not found"),
-    JSON_MARSHALLING_FAILURE("G-05", "Json marshalling failure"),
-    EMPTY_ACCESS_TOKEN("G-06", "Empty access token"),
-    INVALID_ACCESS_TOKEN("G-07", "Invalid access token"),
-    INVALID_PERMISSION("G-08", "Invalid permission"),
-    AUTHENTICATION_REQUIRED("G-09", "Authentication is required"),
-    INTERNAL_SERVER_ERROR("G-10", "Internal server error"),
-    OVER_PERIOD("G-11", "모집 기간이 아닙니다."),
-    MISS_REQUIRED_REQUEST_PARAMETER("G-12", "Missing required parameter"),
-    MISS_REQUEST_BODY("G-13", "Missing request body"),
-    MISS_REQUIRED_JOB_FAMILY_PARAMETER("G-14", "Missing required JobFamily parameter"),;
+    UNSUPPORTED_PARAMETER_TYPE(BAD_REQUEST, "G-01", "Unsupported parameter type"),
+    RESOURCE_NOT_FOUND(NOT_FOUND, "G-02", "Resource not found"),
+    TEMPLATE_NOT_FOUND(NOT_FOUND, "G-03", "Template file not found"),
+    JSON_MARSHALLING_FAILURE(INTERNAL_SERVER_ERROR, "G-04", "Json marshalling failure"),
+    EMPTY_ACCESS_TOKEN(UNAUTHORIZED, "G-05", "Empty access token"),
+    INVALID_ACCESS_TOKEN(UNAUTHORIZED, "G-06", "Invalid access token"),
+    INVALID_PERMISSION(FORBIDDEN, "G-07", "Invalid permission"),
+    AUTHENTICATION_REQUIRED(UNAUTHORIZED, "G-08", "Authentication is required"),
+    OVER_PERIOD(CONFLICT, "G-09", "모집 기간이 아닙니다."),
+    MISS_REQUIRED_REQUEST_PARAMETER(BAD_REQUEST, "G-10", "Missing required parameter"),
+    MISS_REQUEST_BODY(BAD_REQUEST, "G-11", "Missing request body"),
+    MISS_REQUIRED_JOB_FAMILY_PARAMETER(BAD_REQUEST, "G-12", "Missing required JobFamily parameter"),
+    AUTHENTICATION_PROCESSING_ERROR(INTERNAL_SERVER_ERROR, "G-13", "인증 처리 중 오류가 발생했습니다."),
+    REQUEST_METHOD_NOT_ALLOWED(METHOD_NOT_ALLOWED, "G-14", "Method not allowed");
 
+
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/common/exception/GlobalErrorCode.java
+++ b/src/main/java/org/ject/support/common/exception/GlobalErrorCode.java
@@ -15,23 +15,28 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 @Getter
 @AllArgsConstructor
 public enum GlobalErrorCode implements ErrorCode {
-    UNSUPPORTED_PARAMETER_TYPE(BAD_REQUEST, "G-01", "Unsupported parameter type"),
-    RESOURCE_NOT_FOUND(NOT_FOUND, "G-02", "Resource not found"),
-    TEMPLATE_NOT_FOUND(NOT_FOUND, "G-03", "Template file not found"),
-    JSON_MARSHALLING_FAILURE(INTERNAL_SERVER_ERROR, "G-04", "Json marshalling failure"),
-    EMPTY_ACCESS_TOKEN(UNAUTHORIZED, "G-05", "Empty access token"),
-    INVALID_ACCESS_TOKEN(UNAUTHORIZED, "G-06", "Invalid access token"),
-    INVALID_PERMISSION(FORBIDDEN, "G-07", "Invalid permission"),
-    AUTHENTICATION_REQUIRED(UNAUTHORIZED, "G-08", "Authentication is required"),
-    OVER_PERIOD(CONFLICT, "G-09", "모집 기간이 아닙니다."),
-    MISS_REQUIRED_REQUEST_PARAMETER(BAD_REQUEST, "G-10", "Missing required parameter"),
-    MISS_REQUEST_BODY(BAD_REQUEST, "G-11", "Missing request body"),
-    MISS_REQUIRED_JOB_FAMILY_PARAMETER(BAD_REQUEST, "G-12", "Missing required JobFamily parameter"),
-    AUTHENTICATION_PROCESSING_ERROR(INTERNAL_SERVER_ERROR, "G-13", "인증 처리 중 오류가 발생했습니다."),
-    REQUEST_METHOD_NOT_ALLOWED(METHOD_NOT_ALLOWED, "G-14", "Method not allowed");
-
+    UNSUPPORTED_PARAMETER_TYPE(BAD_REQUEST, 1, "Unsupported parameter type"),
+    RESOURCE_NOT_FOUND(NOT_FOUND, 2, "Resource not found"),
+    TEMPLATE_NOT_FOUND(NOT_FOUND, 3, "Template file not found"),
+    JSON_MARSHALLING_FAILURE(INTERNAL_SERVER_ERROR, 4, "Json marshalling failure"),
+    EMPTY_ACCESS_TOKEN(UNAUTHORIZED, 5, "Empty access token"),
+    INVALID_ACCESS_TOKEN(UNAUTHORIZED, 6, "Invalid access token"),
+    INVALID_PERMISSION(FORBIDDEN, 7, "Invalid permission"),
+    AUTHENTICATION_REQUIRED(UNAUTHORIZED, 8, "Authentication is required"),
+    OVER_PERIOD(CONFLICT, 9, "모집 기간이 아닙니다."),
+    MISS_REQUIRED_REQUEST_PARAMETER(BAD_REQUEST, 10, "Missing required parameter"),
+    MISS_REQUEST_BODY(BAD_REQUEST, 11, "Missing request body"),
+    MISS_REQUIRED_JOB_FAMILY_PARAMETER(BAD_REQUEST, 12, "Missing required JobFamily parameter"),
+    AUTHENTICATION_PROCESSING_ERROR(INTERNAL_SERVER_ERROR, 13, "인증 처리 중 오류가 발생했습니다."),
+    REQUEST_METHOD_NOT_ALLOWED(METHOD_NOT_ALLOWED, 14, "Method not allowed");
 
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;
+
+    GlobalErrorCode(HttpStatus httpStatus, int code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = String.format("GLOBAL-%d", code);
+        this.message = message;
+    }
 }

--- a/src/main/java/org/ject/support/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/ject/support/common/exception/GlobalExceptionHandler.java
@@ -49,7 +49,7 @@ public class GlobalExceptionHandler{
      */
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     protected ErrorCode handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
-        GlobalErrorCode errorCode = GlobalErrorCode.METHOD_NOT_ALLOWED;
+        GlobalErrorCode errorCode = GlobalErrorCode.REQUEST_METHOD_NOT_ALLOWED;
         logException(e, errorCode);
         return errorCode;
     }
@@ -88,9 +88,6 @@ public class GlobalExceptionHandler{
      * 예외 정보를 로깅 (ErrorCode 메시지 사용)
      */
     private void logException(final Exception e, final ErrorCode errorCode) {
-        log.error(LOG_FORMAT,
-                e.getClass(),
-                errorCode.getCode(),
-                errorCode.getMessage());
+        log.error(LOG_FORMAT, e.getClass(), errorCode.getCode(), errorCode.getMessage());
     }
 }

--- a/src/main/java/org/ject/support/common/security/jwt/JwtExceptionHandlerFilter.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtExceptionHandlerFilter.java
@@ -19,7 +19,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import static org.ject.support.common.exception.GlobalErrorCode.INTERNAL_SERVER_ERROR;
+import static org.ject.support.common.exception.GlobalErrorCode.AUTHENTICATION_PROCESSING_ERROR;
 import static org.ject.support.common.exception.GlobalErrorCode.INVALID_ACCESS_TOKEN;
 
 @Slf4j
@@ -51,7 +51,7 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
                 setErrorResponse(response, INVALID_ACCESS_TOKEN);
                 log.error("ClassCastException: {}", e.getCause().getMessage());
             } else {
-                setErrorResponse(response, INTERNAL_SERVER_ERROR);
+                setErrorResponse(response, AUTHENTICATION_PROCESSING_ERROR);
                 log.error("Exception: {}", e.getMessage());
             }
         } finally {

--- a/src/main/java/org/ject/support/common/springdoc/ApiErrorResponse.java
+++ b/src/main/java/org/ject/support/common/springdoc/ApiErrorResponse.java
@@ -12,8 +12,6 @@ import java.lang.annotation.Target;
 public @interface ApiErrorResponse {
     Class<? extends ErrorCode> value();
 
-    int code();
-
     String name();
 
     String description() default "";

--- a/src/main/java/org/ject/support/common/springdoc/ErrorResponseCustomizer.java
+++ b/src/main/java/org/ject/support/common/springdoc/ErrorResponseCustomizer.java
@@ -70,7 +70,7 @@ public class ErrorResponseCustomizer implements OperationCustomizer {
         example.description(apiErrorResponse.description());
         return ExampleHolder.builder()
                 .example(example)
-                .code(apiErrorResponse.code())
+                .code(errorCode.getHttpStatus().value())
                 .name(apiErrorResponse.name())
                 .build();
     }

--- a/src/main/java/org/ject/support/domain/auth/controller/AuthApiSpec.java
+++ b/src/main/java/org/ject/support/domain/auth/controller/AuthApiSpec.java
@@ -59,8 +59,7 @@ public interface AuthApiSpec {
     )
     @ApiErrorResponses(responses = {
             @ApiErrorResponse(value = AuthErrorCode.class, name = "INVALID_REFRESH_TOKEN"),
-            @ApiErrorResponse(value = AuthErrorCode.class, name = "EXPIRED_REFRESH_TOKEN"),
-            @ApiErrorResponse(value = AuthErrorCode.class, name = "INVALID_REFRESH_TOKEN")
+            @ApiErrorResponse(value = AuthErrorCode.class, name = "EXPIRED_REFRESH_TOKEN")
     })
     boolean refreshToken(HttpServletRequest request, HttpServletResponse response);
 

--- a/src/main/java/org/ject/support/domain/auth/controller/AuthApiSpec.java
+++ b/src/main/java/org/ject/support/domain/auth/controller/AuthApiSpec.java
@@ -45,9 +45,9 @@ public interface AuthApiSpec {
             }
     )
     @ApiErrorResponses(responses = {
-            @ApiErrorResponse(value = AuthErrorCode.class, code = 400, name = "INVALID_AUTH_CODE"),
-            @ApiErrorResponse(value = AuthErrorCode.class, code = 404, name = "NOT_FOUND_AUTH_CODE"),
-            @ApiErrorResponse(value = EmailErrorCode.class, code = 400, name = "INVALID_EMAIL_TEMPLATE")
+            @ApiErrorResponse(value = AuthErrorCode.class, name = "INVALID_AUTH_CODE"),
+            @ApiErrorResponse(value = AuthErrorCode.class, name = "NOT_FOUND_AUTH_CODE"),
+            @ApiErrorResponse(value = EmailErrorCode.class, name = "INVALID_EMAIL_TEMPLATE")
     })
     boolean verifyAuthCode(@RequestBody AuthDto.VerifyAuthCodeRequest verifyAuthCodeRequest,
                            HttpServletRequest request, HttpServletResponse response,
@@ -58,9 +58,9 @@ public interface AuthApiSpec {
             description = "리프레시 토큰이 유효한 경우 새로운 액세스 토큰을 발급합니다."
     )
     @ApiErrorResponses(responses = {
-            @ApiErrorResponse(value = AuthErrorCode.class, code = 400, name = "INVALID_REFRESH_TOKEN"),
-            @ApiErrorResponse(value = AuthErrorCode.class, code = 400, name = "EXPIRED_REFRESH_TOKEN"),
-            @ApiErrorResponse(value = AuthErrorCode.class, code = 400, name = "INVALID_REFRESH_TOKEN")
+            @ApiErrorResponse(value = AuthErrorCode.class, name = "INVALID_REFRESH_TOKEN"),
+            @ApiErrorResponse(value = AuthErrorCode.class, name = "EXPIRED_REFRESH_TOKEN"),
+            @ApiErrorResponse(value = AuthErrorCode.class, name = "INVALID_REFRESH_TOKEN")
     })
     boolean refreshToken(HttpServletRequest request, HttpServletResponse response);
 

--- a/src/main/java/org/ject/support/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/org/ject/support/domain/auth/exception/AuthErrorCode.java
@@ -3,16 +3,20 @@ package org.ject.support.domain.auth.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.ject.support.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @Getter
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-    INVALID_AUTH_CODE("INVALID_AUTH_CODE", "인증 번호가 유효하지 않습니다."),
-    NOT_FOUND_AUTH_CODE("NOT_FOUND_AUTH_CODE", "인증 번호를 찾을 수 없습니다."),
-    INVALID_REFRESH_TOKEN("INVALID_REFRESH_TOKEN", "유효하지 않은 리프레시 토큰입니다."),
-    EXPIRED_REFRESH_TOKEN("EXPIRED_REFRESH_TOKEN", "만료된 리프레시 토큰입니다."),
-    INVALID_CREDENTIALS("INVALID_CREDENTIALS", "PIN 번호가 올바르지 않습니다.");
+    INVALID_AUTH_CODE(UNAUTHORIZED, "INVALID_AUTH_CODE", "인증 번호가 유효하지 않습니다."),
+    NOT_FOUND_AUTH_CODE(UNAUTHORIZED, "NOT_FOUND_AUTH_CODE", "인증 번호를 찾을 수 없습니다."),
+    INVALID_REFRESH_TOKEN(UNAUTHORIZED, "INVALID_REFRESH_TOKEN", "유효하지 않은 리프레시 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(UNAUTHORIZED, "EXPIRED_REFRESH_TOKEN", "만료된 리프레시 토큰입니다."),
+    INVALID_CREDENTIALS(UNAUTHORIZED, "INVALID_CREDENTIALS", "PIN 번호가 올바르지 않습니다.");
 
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/domain/file/controller/FileApiSpec.java
+++ b/src/main/java/org/ject/support/domain/file/controller/FileApiSpec.java
@@ -20,8 +20,8 @@ public interface FileApiSpec {
             description = "프로젝트 썸네일, 소개서 등 콘텐츠를 업로드합니다."
     )
     @ApiErrorResponses(responses = {
-            @ApiErrorResponse(value = FileErrorCode.class, code = 400, name = "INVALID_EXTENSION"),
-            @ApiErrorResponse(value = FileErrorCode.class, code = 400, name = "EXCEEDED_PORTFOLIO_MAX_SIZE")
+            @ApiErrorResponse(value = FileErrorCode.class, name = "INVALID_EXTENSION"),
+            @ApiErrorResponse(value = FileErrorCode.class, name = "EXCEEDED_PORTFOLIO_MAX_SIZE")
     })
     List<UploadFileResponse> uploadContents(@AuthPrincipal final Long memberId,
                                             @RequestBody final List<UploadFileRequest> requests);
@@ -31,8 +31,8 @@ public interface FileApiSpec {
             description = "지원자의 포트폴리오를 업로드합니다."
     )
     @ApiErrorResponses(responses = {
-            @ApiErrorResponse(value = FileErrorCode.class, code = 400, name = "INVALID_EXTENSION"),
-            @ApiErrorResponse(value = FileErrorCode.class, code = 400, name = "EXCEEDED_PORTFOLIO_MAX_SIZE")
+            @ApiErrorResponse(value = FileErrorCode.class, name = "INVALID_EXTENSION"),
+            @ApiErrorResponse(value = FileErrorCode.class, name = "EXCEEDED_PORTFOLIO_MAX_SIZE")
     })
     List<UploadFileResponse> uploadPortfolios(@AuthPrincipal final Long memberId,
                                               @RequestBody final List<UploadFileRequest> requests);

--- a/src/main/java/org/ject/support/domain/file/exception/FileErrorCode.java
+++ b/src/main/java/org/ject/support/domain/file/exception/FileErrorCode.java
@@ -3,13 +3,18 @@ package org.ject.support.domain.file.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.ject.support.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE;
 
 @Getter
 @AllArgsConstructor
 public enum FileErrorCode implements ErrorCode {
-    INVALID_EXTENSION("INVALID_EXTENSION", "유효하지 않은 확장자입니다."),
-    EXCEEDED_PORTFOLIO_MAX_SIZE("EXCEEDED_PORTFOLIO_SIZE", "첨부 가능한 포트폴리오 최대 용량을 초과했습니다.");
+    INVALID_EXTENSION(BAD_REQUEST, "INVALID_EXTENSION", "유효하지 않은 확장자입니다."),
+    EXCEEDED_PORTFOLIO_MAX_SIZE(PAYLOAD_TOO_LARGE, "EXCEEDED_PORTFOLIO_SIZE", "첨부 가능한 포트폴리오 최대 용량을 초과했습니다.");
 
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/domain/file/exception/FileErrorCode.java
+++ b/src/main/java/org/ject/support/domain/file/exception/FileErrorCode.java
@@ -12,7 +12,7 @@ import static org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE;
 @AllArgsConstructor
 public enum FileErrorCode implements ErrorCode {
     INVALID_EXTENSION(BAD_REQUEST, "INVALID_EXTENSION", "유효하지 않은 확장자입니다."),
-    EXCEEDED_PORTFOLIO_MAX_SIZE(PAYLOAD_TOO_LARGE, "EXCEEDED_PORTFOLIO_SIZE", "첨부 가능한 포트폴리오 최대 용량을 초과했습니다.");
+    EXCEEDED_PORTFOLIO_MAX_SIZE(PAYLOAD_TOO_LARGE, "EXCEEDED_PORTFOLIO_MAX_SIZE", "첨부 가능한 포트폴리오 최대 용량을 초과했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
@@ -3,13 +3,18 @@ package org.ject.support.domain.member.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.ject.support.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
-    NOT_FOUND_MEMBER("NOT_FOUND_MEMBER", "멤버를 찾을 수 없습니다."),
-    ALREADY_EXIST_MEMBER("ALREADY_EXIST_MEMBER", "이미 가입되어 있는 회원입니다.");
+    NOT_FOUND_MEMBER(NOT_FOUND, "NOT_FOUND_MEMBER", "멤버를 찾을 수 없습니다."),
+    ALREADY_EXIST_MEMBER(CONFLICT, "ALREADY_EXIST_MEMBER", "이미 가입되어 있는 회원입니다.");
 
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/domain/project/exception/ProjectErrorCode.java
+++ b/src/main/java/org/ject/support/domain/project/exception/ProjectErrorCode.java
@@ -3,13 +3,17 @@ package org.ject.support.domain.project.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.ject.support.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor
 public enum ProjectErrorCode implements ErrorCode {
-    NOT_FOUND("PROJECT_NOT_FOUND", "프로젝트를 찾을 수 없습니다."),
+    NOT_FOUND_PROJECT(NOT_FOUND, "PROJECT_NOT_FOUND", "프로젝트를 찾을 수 없습니다."),
     ;
 
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/domain/project/service/ProjectService.java
+++ b/src/main/java/org/ject/support/domain/project/service/ProjectService.java
@@ -46,7 +46,7 @@ public class ProjectService {
     @Transactional(readOnly = true)
     public ProjectDetailResponse findProjectDetails(final Long projectId) {
         Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new ProjectException(ProjectErrorCode.NOT_FOUND));
+                .orElseThrow(() -> new ProjectException(ProjectErrorCode.NOT_FOUND_PROJECT));
 
         TeamMemberNames teamMemberNames = memberRepository.findMemberNamesByTeamId(project.getTeam().getId());
 

--- a/src/main/java/org/ject/support/domain/recruit/exception/ApplyErrorCode.java
+++ b/src/main/java/org/ject/support/domain/recruit/exception/ApplyErrorCode.java
@@ -3,12 +3,16 @@ package org.ject.support.domain.recruit.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.ject.support.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
 
 @Getter
 @AllArgsConstructor
 public enum ApplyErrorCode implements ErrorCode {
-    DUPLICATE_JOB_FAMILY("DUPLICATE_JOB_FAMILY", "변경하려는 직군이 기존 직군과 동일합니다.");
+    DUPLICATE_JOB_FAMILY(CONFLICT, "DUPLICATE_JOB_FAMILY", "변경하려는 직군이 기존 직군과 동일합니다.");
 
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/domain/recruit/exception/QuestionErrorCode.java
+++ b/src/main/java/org/ject/support/domain/recruit/exception/QuestionErrorCode.java
@@ -3,11 +3,17 @@ package org.ject.support.domain.recruit.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.ject.support.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 @Getter
 @AllArgsConstructor
 public enum QuestionErrorCode implements ErrorCode {
-    NOT_FOUND("QUESTION_NOT_FOUND", "해당 질문을 찾을 수 없습니다."),;
+    NOT_FOUND_QUESTION(NOT_FOUND, "QUESTION_NOT_FOUND", "해당 질문을 찾을 수 없습니다."),
+    ;
 
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/domain/recruit/exception/RecruitErrorCode.java
+++ b/src/main/java/org/ject/support/domain/recruit/exception/RecruitErrorCode.java
@@ -3,14 +3,19 @@ package org.ject.support.domain.recruit.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.ject.support.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor
 public enum RecruitErrorCode implements ErrorCode {
-    NOT_FOUND("RECRUIT_NOT_FOUND", "모집 공고를 찾을 수 없습니다."),
-    DUPLICATED_JOB_FAMILY("DUPLICATED_JOB_FAMILY", "이미 모집중인 직군입니다."),
-    UPDATE_NOT_ALLOW_FOR_CLOSED("UPDATE_NOT_ALLOW_FOR_CLOSED", "마감된 모집 정보는 수정할 수 없습니다.");
+    NOT_FOUND_RECRUIT(NOT_FOUND, "RECRUIT_NOT_FOUND", "모집 공고를 찾을 수 없습니다."),
+    DUPLICATED_JOB_FAMILY(CONFLICT, "DUPLICATED_JOB_FAMILY", "이미 모집중인 직군입니다."),
+    UPDATE_NOT_ALLOW_FOR_CLOSED(CONFLICT, "UPDATE_NOT_ALLOW_FOR_CLOSED", "마감된 모집 정보는 수정할 수 없습니다.");
 
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/domain/recruit/exception/SemesterErrorCode.java
+++ b/src/main/java/org/ject/support/domain/recruit/exception/SemesterErrorCode.java
@@ -3,12 +3,17 @@ package org.ject.support.domain.recruit.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.ject.support.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor
 public enum SemesterErrorCode implements ErrorCode {
-    ONGOING_SEMESTER_NOT_FOUND("ONGOING_SEMESTER_NOT_FOUND", "Ongoing semester not found."),;
+    ONGOING_SEMESTER_NOT_FOUND(NOT_FOUND, "ONGOING_SEMESTER_NOT_FOUND", "Ongoing semester not found."),
+    ;
 
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/ApplyService.java
@@ -105,7 +105,7 @@ public class ApplyService implements ApplyUsecase {
                 .map(Long::parseLong)
                 .filter(recruit::isInvalidQuestionId)
                 .forEach(key -> {
-                    throw new QuestionException(QuestionErrorCode.NOT_FOUND);
+                    throw new QuestionException(QuestionErrorCode.NOT_FOUND_QUESTION);
                 });
     }
 
@@ -114,7 +114,7 @@ public class ApplyService implements ApplyUsecase {
         return recruitRepository.findActiveRecruits(LocalDateTime.now()).stream()
                 .filter(recruit -> recruit.getJobFamily().equals(jobFamily))
                 .findAny()
-                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND));
+                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
     }
 
     private ApplicationForm createApplicationForm(Map<String, String> answers, Member applicant, Recruit recruit) {

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitSavedEventHandler.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitSavedEventHandler.java
@@ -24,7 +24,7 @@ public class RecruitSavedEventHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleRecruitSaved(RecruitSavedEvent event) {
         Recruit recruit = recruitRepository.findById(event.recruitId())
-                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND));
+                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
 
         if (recruit.isRecruitingPeriod()) {
             // 등록된 모집이 활성화되어 있다면 즉시 flag 캐싱

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitService.java
@@ -73,6 +73,6 @@ public class RecruitService implements RecruitUsecase {
 
     private Recruit getRecruit(Long recruitId) {
         return recruitRepository.findById(recruitId)
-                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND));
+                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitUpdatedEventHandler.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitUpdatedEventHandler.java
@@ -28,7 +28,7 @@ public class RecruitUpdatedEventHandler {
 
         // 수정된 모집 정보 조회
         Recruit recruit = recruitRepository.findById(event.recruitId())
-                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND));
+                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
 
         if (recruit.isRecruitingPeriod()) {
             // 등록된 모집이 활성화되어 있다면 즉시 flag 캐싱

--- a/src/main/java/org/ject/support/domain/tempapply/exception/TemporaryApplicationErrorCode.java
+++ b/src/main/java/org/ject/support/domain/tempapply/exception/TemporaryApplicationErrorCode.java
@@ -3,11 +3,16 @@ package org.ject.support.domain.tempapply.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.ject.support.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor
 public enum TemporaryApplicationErrorCode implements ErrorCode {
-    NOT_FOUND("TEMP_APPLICATION_NOT_FOUND", "임시 지원서가 존재하지 않습니다.");
+    NOT_FOUND_TEMP_APPLICATION_FORM(NOT_FOUND, "TEMP_APPLICATION_NOT_FOUND", "임시 지원서가 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/domain/tempapply/service/TemporaryApplyServiceImpl.java
+++ b/src/main/java/org/ject/support/domain/tempapply/service/TemporaryApplyServiceImpl.java
@@ -6,13 +6,14 @@ import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.dto.ApplyPortfolioDto;
 import org.ject.support.domain.recruit.dto.ApplyTemporaryResponse;
 import org.ject.support.domain.tempapply.domain.TemporaryApplication;
-import org.ject.support.domain.tempapply.exception.TemporaryApplicationErrorCode;
 import org.ject.support.domain.tempapply.exception.TemporaryApplicationException;
 import org.ject.support.domain.tempapply.repository.TemporaryApplicationRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
+
+import static org.ject.support.domain.tempapply.exception.TemporaryApplicationErrorCode.NOT_FOUND_TEMP_APPLICATION_FORM;
 
 @Service
 @RequiredArgsConstructor
@@ -23,7 +24,7 @@ public class TemporaryApplyServiceImpl implements TemporaryApplyService {
     public ApplyTemporaryResponse findMembersRecentTemporaryApplication(final Long memberId) {
         TemporaryApplication latestApplication =
                 temporaryApplicationRepository.findLatestByMemberId(memberId.toString())
-                        .orElseThrow(() -> new TemporaryApplicationException(TemporaryApplicationErrorCode.NOT_FOUND));
+                        .orElseThrow(() -> new TemporaryApplicationException(NOT_FOUND_TEMP_APPLICATION_FORM));
 
         return ApplyTemporaryResponse.from(latestApplication);
     }

--- a/src/main/java/org/ject/support/external/email/exception/EmailErrorCode.java
+++ b/src/main/java/org/ject/support/external/email/exception/EmailErrorCode.java
@@ -3,13 +3,19 @@ package org.ject.support.external.email.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.ject.support.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor
 public enum EmailErrorCode implements ErrorCode {
-    INVALID_EMAIL_TEMPLATE("INVALID_MAIL_TEMPLATE", "유효하지 않은 메일 템플릿입니다."),
-    NOT_FOUND_SEND_GROUP("NOT_FOUND_SEND_GROUP", "존재하지 않는 전송 그룹입니다."),;
+    INVALID_EMAIL_TEMPLATE(BAD_REQUEST, "INVALID_MAIL_TEMPLATE", "유효하지 않은 메일 템플릿입니다."),
+    NOT_FOUND_SEND_GROUP(NOT_FOUND, "NOT_FOUND_SEND_GROUP", "존재하지 않는 전송 그룹입니다."),
+    ;
 
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/src/main/java/org/ject/support/external/email/exception/EmailErrorCode.java
+++ b/src/main/java/org/ject/support/external/email/exception/EmailErrorCode.java
@@ -11,7 +11,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @Getter
 @AllArgsConstructor
 public enum EmailErrorCode implements ErrorCode {
-    INVALID_EMAIL_TEMPLATE(BAD_REQUEST, "INVALID_MAIL_TEMPLATE", "유효하지 않은 메일 템플릿입니다."),
+    INVALID_EMAIL_TEMPLATE(BAD_REQUEST, "INVALID_EMAIL_TEMPLATE", "유효하지 않은 메일 템플릿입니다."),
     NOT_FOUND_SEND_GROUP(NOT_FOUND, "NOT_FOUND_SEND_GROUP", "존재하지 않는 전송 그룹입니다."),
     ;
 

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -1,5 +1,6 @@
 package org.ject.support.domain.file.controller;
 
+import org.ject.support.domain.file.exception.FileErrorCode;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.ject.support.domain.recruit.domain.Recruit;
@@ -167,7 +168,7 @@ class FileControllerTest extends ApplicationPeriodTest {
                                 """)
                 )
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("EXCEEDED_PORTFOLIO_SIZE")))
+                .andExpect(content().string(containsString(FileErrorCode.EXCEEDED_PORTFOLIO_MAX_SIZE.name())))
                 .andDo(print())
                 .andReturn();
     }

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -108,7 +108,7 @@ class FileControllerTest extends ApplicationPeriodTest {
                         .contentType("application/json")
                         .param("memberId", member.getId().toString())
                         .content(getContent()))
-                .andExpect(content().string(containsString("G-11")))
+                .andExpect(content().string(containsString("G-09")))
                 .andDo(print());
     }
 

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -108,7 +108,7 @@ class FileControllerTest extends ApplicationPeriodTest {
                         .contentType("application/json")
                         .param("memberId", member.getId().toString())
                         .content(getContent()))
-                .andExpect(content().string(containsString("G-09")))
+                .andExpect(content().string(containsString("GLOBAL-9")))
                 .andDo(print());
     }
 

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitServiceTest.java
@@ -1,23 +1,32 @@
 package org.ject.support.domain.recruit.service;
 
-import org.assertj.core.api.Assertions;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.service.OngoingSemesterProvider;
 import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.dto.RecruitRegisterRequest;
 import org.ject.support.domain.recruit.dto.RecruitUpdateRequest;
 import org.ject.support.domain.recruit.exception.RecruitException;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.ject.support.domain.member.JobFamily.BE;
 import static org.ject.support.domain.member.JobFamily.FE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RecruitServiceTest {
@@ -28,9 +37,76 @@ class RecruitServiceTest {
     @Mock
     RecruitRepository recruitRepository;
 
+    @Mock
+    OngoingSemesterProvider ongoingSemesterProvider;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+
     @Test
-    @DisplayName("마감된 모집 정보는 수정 불가")
-    void update_not_allow_for_closed_recruit() {
+    void 모집_등록_성공() {
+        // given
+        Long ongoingSemesterId = 1L;
+        when(ongoingSemesterProvider.getOngoingSemesterId()).thenReturn(ongoingSemesterId);
+        when(recruitRepository.existsByJobFamilyAndIsNotClosed(eq(ongoingSemesterId), any())).thenReturn(false);
+
+        List<RecruitRegisterRequest> requests = List.of(
+                new RecruitRegisterRequest(BE, LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1)),
+                new RecruitRegisterRequest(FE, LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1))
+        );
+
+        // when
+        recruitService.registerRecruits(requests);
+
+        // then
+        ArgumentCaptor<List<JobFamily>> jobFamiliesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(recruitRepository).existsByJobFamilyAndIsNotClosed(eq(ongoingSemesterId), jobFamiliesCaptor.capture());
+        assertThat(jobFamiliesCaptor.getValue()).containsExactly(BE, FE);
+
+        ArgumentCaptor<List<Recruit>> recruitsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(recruitRepository).saveAll(recruitsCaptor.capture());
+        assertThat(recruitsCaptor.getValue()).hasSize(2);
+    }
+
+    @Test
+    void 모집_등록_시_이미_모집중인_직군이면_실패() {
+        // given
+        RecruitRegisterRequest request =
+                new RecruitRegisterRequest(BE, LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1));
+        when(ongoingSemesterProvider.getOngoingSemesterId()).thenReturn(1L);
+        when(recruitRepository.existsByJobFamilyAndIsNotClosed(any(), any())).thenReturn(true);
+
+        // when, then
+        assertThatThrownBy(() -> recruitService.registerRecruits(List.of(request)))
+                .isInstanceOf(RecruitException.class);
+    }
+
+    @Test
+    void 모집_정보_수정_성공() {
+        // given
+        Recruit recruit = Recruit.builder()
+                .id(1L)
+                .semesterId(1L)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .jobFamily(BE)
+                .build();
+        when(recruitRepository.findById(1L)).thenReturn(Optional.of(recruit));
+
+        // 직군은 FE로, 마감일은 3일 후로 수정
+        LocalDateTime newEndDate = LocalDateTime.now().plusDays(3);
+        RecruitUpdateRequest request = new RecruitUpdateRequest(FE, LocalDateTime.now().minusDays(1), newEndDate);
+
+        // when
+        recruitService.updateRecruit(recruit.getId(), request);
+
+        // then
+        assertThat(recruit.getJobFamily()).isEqualTo(FE);
+        assertThat(recruit.getEndDate()).isEqualTo(newEndDate);
+    }
+
+    @Test
+    void 마감된_모집_정보는_수정_불가() {
         // given
         Recruit recruit = Recruit.builder()
                 .semesterId(1L)
@@ -39,13 +115,74 @@ class RecruitServiceTest {
                 .jobFamily(BE)
                 .build();
 
-        Mockito.when(recruitRepository.findById(1L)).thenReturn(Optional.ofNullable(recruit));
+        when(recruitRepository.findById(1L)).thenReturn(Optional.ofNullable(recruit));
 
         RecruitUpdateRequest request
                 = new RecruitUpdateRequest(FE, LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1));
 
         // when, then
-        Assertions.assertThatThrownBy(() -> recruitService.updateRecruit(1L, request))
+        assertThatThrownBy(() -> recruitService.updateRecruit(1L, request))
+                .isInstanceOf(RecruitException.class);
+    }
+
+    @Test
+    void 수정하려는_recruit이_존재하지_않으면_실패() {
+        // given
+        RecruitUpdateRequest request =
+                new RecruitUpdateRequest(BE, LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1));
+
+        // when, then
+        assertThatThrownBy(() -> recruitService.updateRecruit(100L, request))
+                .isInstanceOf(RecruitException.class);
+    }
+
+    @Test
+    void 수정_시점이_모집기간이_아닌_경우_실패() {
+        // given
+        Recruit recruit = Recruit.builder()
+                .id(1L)
+                .semesterId(1L)
+                .startDate(LocalDateTime.now().minusDays(3))
+                .endDate(LocalDateTime.now().minusDays(1))
+                .jobFamily(BE)
+                .build();
+
+        when(recruitRepository.findById(1L)).thenReturn(Optional.ofNullable(recruit));
+
+        RecruitUpdateRequest request
+                = new RecruitUpdateRequest(FE, LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1));
+
+        // when, then
+        assertThatThrownBy(() -> recruitService.updateRecruit(1L, request))
+                .isInstanceOf(RecruitException.class);
+    }
+
+    @Test
+    void 모집_취소_성공() {
+        // given
+        Recruit recruit = Recruit.builder()
+                .id(1L)
+                .semesterId(1L)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .jobFamily(BE)
+                .build();
+
+        when(recruitRepository.findById(1L)).thenReturn(Optional.ofNullable(recruit));
+
+        // when
+        recruitService.cancelRecruit(1L);
+
+        // then
+        ArgumentCaptor<Recruit> recruitCaptor = ArgumentCaptor.forClass(Recruit.class);
+        verify(recruitRepository).delete(recruitCaptor.capture());
+        assertThat(recruitCaptor.getValue()).isSameAs(recruit);
+    }
+
+    @Test
+    void 취소하려는_recruit이_존재하지_않으면_실패() {
+        // when, then
+        assertThatThrownBy(() -> recruitService.cancelRecruit(100L))
                 .isInstanceOf(RecruitException.class);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #251 

## 📝 작업 내용
- ErrorCode에 http status 필드 추가 및 관련 코드 리팩토링
- GlobalErrorCode code 포맷 변경

### ErrorCode 생성자
문자열 입력에 대한 휴먼에러를 최소화하기 위해, 정수 입력 시 생성자에서 코드 포매팅하도록 했습니다.
```java
public enum GlobalErrorCode implements ErrorCode {
    UNSUPPORTED_PARAMETER_TYPE(BAD_REQUEST, 1, "Unsupported parameter type"),
    RESOURCE_NOT_FOUND(NOT_FOUND, 2, "Resource not found"),
    ...

    private final HttpStatus httpStatus;
    private final String code;
    private final String message;

    GlobalErrorCode(HttpStatus httpStatus, int code, String message) {
        this.httpStatus = httpStatus;
        this.code = String.format("GLOBAL-%d", code);
        this.message = message;
    }
}
```

## 🙏 리뷰 요구사항 (선택)
본 PR merge 이후에는 에러 코드 컨벤션에 맞게 작성 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 에러 코드에 HTTP 상태 공식 매핑 추가로 응답 일관성 강화
  - 신규 에러 코드 추가: AUTHENTICATION_PROCESSING_ERROR, REQUEST_METHOD_NOT_ALLOWED
  - 글로벌 에러 코드 포맷을 GLOBAL-<번호>로 표준화
- Documentation
  - API 에러 응답에서 숫자 코드 제거, 이름 기반 표기로 간소화
  - 예시 응답이 에러별 HTTP 상태를 반영하도록 개선
- Refactor
  - NOT_FOUND 계열 명칭 정비 및 관련 예외 매핑 업데이트
- Tests
  - 글로벌 코드 포맷 및 일부 에러명에 맞춰 테스트 기대값 수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->