### PR TITLE
swagger GroupedOpenApi에 response 커스터마이저 추가

### DIFF
--- a/src/main/java/org/ject/support/common/springdoc/SpringdocConfig.java
+++ b/src/main/java/org/ject/support/common/springdoc/SpringdocConfig.java
@@ -5,12 +5,19 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class SpringdocConfig {
+
+    private final SuccessResponseCustomizer successResponseCustomizer;
+    private final ErrorResponseCustomizer errorResponseCustomizer;
 
     @Bean
     public OpenAPI openAPI() {
@@ -36,7 +43,8 @@ public class SpringdocConfig {
         return GroupedOpenApi.builder()
                 .group("Core API")
                 .pathsToExclude("/admin/**")
-                .build();
+                .build()
+                .addAllOperationCustomizer(List.of(successResponseCustomizer, errorResponseCustomizer));
     }
 
     @Bean
@@ -44,6 +52,7 @@ public class SpringdocConfig {
         return GroupedOpenApi.builder()
                 .group("Admin API")
                 .pathsToMatch("/admin/**")
-                .build();
+                .build()
+                .addAllOperationCustomizer(List.of(successResponseCustomizer, errorResponseCustomizer));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #260 

## 📝 작업 내용
- swagger GroupedOpenApi에 response 커스터마이저 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 문서화
  * OpenAPI 문서에 모든 엔드포인트의 성공/오류 응답 정보가 자동으로 반영되어 가독성과 예측 가능성이 향상되었습니다.
  * 코어 및 관리자 API 그룹 모두 동일한 규칙을 적용해 일관성과 탐색성이 개선되었습니다.
  * 스키마나 엔드포인트 구조 변화 없이 문서 품질만 개선되므로 기존 통합에 영향이 없습니다.
  * 별도 설정 없이 즉시 적용되며, API 소비자가 응답 형식을 쉽게 파악할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->