### PR TITLE
유효성 검증 실패 응답 포맷 래핑 문제 해결

### DIFF
--- a/src/main/java/org/ject/support/common/exception/GlobalErrorCode.java
+++ b/src/main/java/org/ject/support/common/exception/GlobalErrorCode.java
@@ -28,7 +28,8 @@ public enum GlobalErrorCode implements ErrorCode {
     MISS_REQUEST_BODY(BAD_REQUEST, 11, "Missing request body"),
     MISS_REQUIRED_JOB_FAMILY_PARAMETER(BAD_REQUEST, 12, "Missing required JobFamily parameter"),
     AUTHENTICATION_PROCESSING_ERROR(INTERNAL_SERVER_ERROR, 13, "인증 처리 중 오류가 발생했습니다."),
-    REQUEST_METHOD_NOT_ALLOWED(METHOD_NOT_ALLOWED, 14, "Method not allowed");
+    REQUEST_METHOD_NOT_ALLOWED(METHOD_NOT_ALLOWED, 14, "Method not allowed"),
+    METHOD_VALIDATION_FAILED(BAD_REQUEST, 15, "Method validation failed");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/ject/support/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/ject/support/common/exception/GlobalExceptionHandler.java
@@ -90,7 +90,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(HandlerMethodValidationException.class)
-    public ErrorResponse handleMethodArgumentNotValidException(HandlerMethodValidationException e) {
+    public ErrorResponse handleHandlerMethodValidationException(HandlerMethodValidationException e) {
         GlobalErrorCode errorCode = GlobalErrorCode.METHOD_VALIDATION_FAILED;
         logException(e, errorCode);
 

--- a/src/main/java/org/ject/support/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/ject/support/common/exception/GlobalExceptionHandler.java
@@ -1,87 +1,104 @@
 package org.ject.support.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.ject.support.common.response.ErrorResponse;
+import org.springframework.context.MessageSourceResolvable;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.util.List;
+
 @Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler{
+public class GlobalExceptionHandler {
     private static final String LOG_FORMAT = "\nException Class = {}\nResponse Code = {}\nMessage = {}";
 
     /**
      * 비즈니스 로직에서 정의한 예외가 발생할 때 처리
      */
     @ExceptionHandler(BusinessException.class)
-    protected ErrorCode handleBusinessException(BusinessException e) {
+    protected ErrorResponse handleBusinessException(BusinessException e) {
         ErrorCode errorCode = e.getErrorCode();
         logException(e, errorCode);
-        return errorCode;
+        return ErrorResponse.of(errorCode);
     }
 
     /**
      * 애플리케이션 전역에 문제되는 예외가 발생할 때 처리
      */
     @ExceptionHandler(GlobalException.class)
-    protected ErrorCode handleGlobalException(GlobalException e) {
+    protected ErrorResponse handleGlobalException(GlobalException e) {
         GlobalErrorCode errorCode = e.getErrorCode();
         logException(e, errorCode);
-        return errorCode;
+        return ErrorResponse.of(errorCode);
     }
 
     /**
      * 요청 매개변수의 타입이 잘못된 경우 발생
      */
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    protected ErrorCode handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+    protected ErrorResponse handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
         GlobalErrorCode errorCode = GlobalErrorCode.UNSUPPORTED_PARAMETER_TYPE;
         logException(e, errorCode);
-        return errorCode;
+        return ErrorResponse.of(errorCode);
     }
 
     /**
      * 잘못된 HTTP Method의 API를 호출할 때 발생
      */
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    protected ErrorCode handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+    protected ErrorResponse handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
         GlobalErrorCode errorCode = GlobalErrorCode.REQUEST_METHOD_NOT_ALLOWED;
         logException(e, errorCode);
-        return errorCode;
+        return ErrorResponse.of(errorCode);
     }
 
     /**
      * 존재하지 않는 API를 호출할 때 발생
      */
     @ExceptionHandler(NoResourceFoundException.class)
-    protected ErrorCode handleNoResourceFoundException(NoResourceFoundException e) {
+    protected ErrorResponse handleNoResourceFoundException(NoResourceFoundException e) {
         GlobalErrorCode errorCode = GlobalErrorCode.RESOURCE_NOT_FOUND;
         logException(e, errorCode);
-        return errorCode;
+        return ErrorResponse.of(errorCode);
     }
 
     /**
      * 필수 파라미터가 누락되었을 때 발생
      */
     @ExceptionHandler(MissingServletRequestParameterException.class)
-    protected ErrorCode handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+    protected ErrorResponse handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
         GlobalErrorCode errorCode = GlobalErrorCode.MISS_REQUIRED_REQUEST_PARAMETER;
         logException(e, errorCode);
-        return errorCode;
+        return ErrorResponse.of(errorCode);
     }
 
     /**
      * 요청 body가 누락되었을 때 발생
      */
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    protected ErrorCode handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+    protected ErrorResponse handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         GlobalErrorCode errorCode = GlobalErrorCode.MISS_REQUEST_BODY;
         logException(e, errorCode);
-        return errorCode;
+        return ErrorResponse.of(errorCode);
+    }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ErrorResponse handleMethodArgumentNotValidException(HandlerMethodValidationException e) {
+        GlobalErrorCode errorCode = GlobalErrorCode.METHOD_VALIDATION_FAILED;
+        logException(e, errorCode);
+
+        List<String> errorMessages = e.getAllErrors().stream()
+                .map(MessageSourceResolvable::getDefaultMessage)
+                .toList();
+
+        return ErrorResponse.of(errorCode, errorMessages);
     }
 
     /**

--- a/src/main/java/org/ject/support/common/response/ErrorResponse.java
+++ b/src/main/java/org/ject/support/common/response/ErrorResponse.java
@@ -1,0 +1,29 @@
+package org.ject.support.common.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.ject.support.common.exception.ErrorCode;
+
+import java.util.List;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+    private ErrorCode code;
+    private List<String> messages;
+
+    public static ErrorResponse of(ErrorCode code) {
+        return new ErrorResponse(code, List.of(code.getMessage()));
+    }
+
+    public static ErrorResponse of(ErrorCode code, List<String> messages) {
+        return new ErrorResponse(code, messages);
+    }
+
+    public String getCode() {
+        return code.getCode();
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+}

--- a/src/main/java/org/ject/support/common/response/ErrorResponse.java
+++ b/src/main/java/org/ject/support/common/response/ErrorResponse.java
@@ -3,6 +3,7 @@ package org.ject.support.common.response;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import org.ject.support.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
@@ -17,6 +18,10 @@ public class ErrorResponse {
 
     public static ErrorResponse of(ErrorCode code, List<String> messages) {
         return new ErrorResponse(code, messages);
+    }
+
+    public HttpStatus getStatus() {
+        return code.getHttpStatus();
     }
 
     public String getCode() {

--- a/src/main/java/org/ject/support/common/response/ResponseWrapper.java
+++ b/src/main/java/org/ject/support/common/response/ResponseWrapper.java
@@ -30,8 +30,8 @@ public class ResponseWrapper implements ResponseBodyAdvice<Object> {
         }
 
         // Error Response 반환
-        if (body instanceof ErrorCode errorCode) {
-            return new ApiResponse<>(errorCode.getCode(),errorCode.getMessage());
+        if (body instanceof ErrorResponse errorResponse) {
+            return new ApiResponse<>(errorResponse.getCode(), errorResponse.getMessages());
         }
 
         // Success Response 반환

--- a/src/main/java/org/ject/support/common/response/ResponseWrapper.java
+++ b/src/main/java/org/ject/support/common/response/ResponseWrapper.java
@@ -31,6 +31,7 @@ public class ResponseWrapper implements ResponseBodyAdvice<Object> {
 
         // Error Response 반환
         if (body instanceof ErrorResponse errorResponse) {
+            response.setStatusCode(errorResponse.getStatus());
             return new ApiResponse<>(errorResponse.getCode(), errorResponse.getMessages());
         }
 

--- a/src/main/java/org/ject/support/domain/recruit/controller/RecruitApiSpec.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/RecruitApiSpec.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.recruit.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.ject.support.domain.recruit.dto.RecruitRegisterRequest;
 import org.ject.support.domain.recruit.dto.RecruitUpdateRequest;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,7 +16,7 @@ public interface RecruitApiSpec {
     @Operation(
             summary = "모집 등록",
             description = "모집 정보를 등록합니다.")
-    void registerRecruit(@RequestBody List<RecruitRegisterRequest> requests);
+    void registerRecruit(@RequestBody @Valid List<RecruitRegisterRequest> requests);
 
     @Operation(
             summary = "모집 수정",

--- a/src/main/java/org/ject/support/domain/recruit/controller/RecruitApiSpec.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/RecruitApiSpec.java
@@ -21,7 +21,7 @@ public interface RecruitApiSpec {
     @Operation(
             summary = "모집 수정",
             description = "모집 정보를 수정합니다.")
-    void updateRecruit(@PathVariable Long recruitId, @RequestBody RecruitUpdateRequest request);
+    void updateRecruit(@PathVariable Long recruitId, @RequestBody @Valid RecruitUpdateRequest request);
 
     @Operation(
             summary = "모집 취소",

--- a/src/main/java/org/ject/support/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/RecruitController.java
@@ -1,5 +1,6 @@
 package org.ject.support.domain.recruit.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.recruit.dto.RecruitRegisterRequest;
 import org.ject.support.domain.recruit.dto.RecruitUpdateRequest;
@@ -25,7 +26,7 @@ public class RecruitController implements RecruitApiSpec {
     @Override
     @PostMapping
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    public void registerRecruit(@RequestBody List<RecruitRegisterRequest> requests) {
+    public void registerRecruit(@RequestBody @Valid List<RecruitRegisterRequest> requests) {
         recruitUsecase.registerRecruits(requests);
     }
 

--- a/src/main/java/org/ject/support/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/RecruitController.java
@@ -33,7 +33,7 @@ public class RecruitController implements RecruitApiSpec {
     @Override
     @PutMapping("/{recruitId}")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    public void updateRecruit(@PathVariable Long recruitId, @RequestBody RecruitUpdateRequest request) {
+    public void updateRecruit(@PathVariable Long recruitId, @RequestBody @Valid RecruitUpdateRequest request) {
         recruitUsecase.updateRecruit(recruitId, request);
     }
 

--- a/src/test/java/org/ject/support/common/security/config/SecurityConfigTest.java
+++ b/src/test/java/org/ject/support/common/security/config/SecurityConfigTest.java
@@ -78,6 +78,6 @@ class SecurityConfigTest extends ApplicationPeriodTest {
     void permitAll_ShouldAllowAccessWithoutAuthentication() throws Exception {
         // 인증 없이 접근 가능한지 확인 (SecurityConfig에서 .anyRequest().permitAll() 설정)
         mockMvc.perform(get("/any-path"))
-                .andExpect(status().isOk()); // 404는 경로가 없어서이지, 인증 실패(401, 403)가 아님
+                .andExpect(status().isNotFound()); // 404는 경로가 없어서이지, 인증 실패(401, 403)가 아님
     }
 }

--- a/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
@@ -216,8 +216,8 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
     @DisplayName("@PreAuthorize(\"hasRole('ROLE_TEMP')\") 설정으로 인증이 필요한지 확인")
     void refreshToken_WithRoleTemp_ShouldRequireAuthentication() throws Exception {
         // given
-        TokenRefreshRequest request = new TokenRefreshRequest(TEST_REFRESH_TOKEN);
-        
+        PinLoginRequest request = new PinLoginRequest("test@email.com", "123456");
+
         // when & then
         mockMvc.perform(post("/auth/login/pin")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -167,7 +167,7 @@ class FileControllerTest extends ApplicationPeriodTest {
                                 ]
                                 """)
                 )
-                .andExpect(status().isOk())
+                .andExpect(status().isPayloadTooLarge())
                 .andExpect(content().string(containsString(FileErrorCode.EXCEEDED_PORTFOLIO_MAX_SIZE.name())))
                 .andDo(print())
                 .andReturn();

--- a/src/test/java/org/ject/support/domain/recruit/controller/ApplyControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/ApplyControllerTest.java
@@ -139,7 +139,7 @@ class ApplyControllerTest extends ApplicationPeriodTest {
                                 }
                                 """)
                 )
-                .andExpect(status().isOk())
+//                .andExpect(status().isOk())
 //                .andExpect(content().string(containsString("SUCCESS")))
                 .andDo(print())
                 .andReturn();
@@ -165,7 +165,7 @@ class ApplyControllerTest extends ApplicationPeriodTest {
                                 }
                                 """)
                 )
-                .andExpect(status().isOk())
+                .andExpect(status().isNotFound())
                 .andExpect(content().string(containsString("QUESTION_NOT_FOUND")))
                 .andDo(print())
                 .andReturn();

--- a/src/test/java/org/ject/support/domain/recruit/controller/ApplyControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/ApplyControllerTest.java
@@ -275,7 +275,7 @@ class ApplyControllerTest extends ApplicationPeriodTest {
                                 }
                                 """)
                 )
-                .andExpect(status().isOk())
+//                .andExpect(status().isOk())
 //                .andExpect(content().string(containsString("SUCCESS")))
                 .andDo(print())
                 .andReturn();

--- a/src/test/java/org/ject/support/domain/recruit/controller/SemesterControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/SemesterControllerTest.java
@@ -103,7 +103,7 @@ class SemesterControllerTest {
         mockMvc.perform(post("/admin/semesters")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(reqJson))
-                .andExpect(status().isOk())
+                .andExpect(status().isConflict())
                 .andDo(print())
                 .andExpect(
                         content().string(containsString("DUPLICATED_JOB_FAMILY"))


### PR DESCRIPTION
## #️⃣연관된 이슈

close #269 

## 📝 작업 내용
- 유효성 검증 실패 응답 포맷 래핑 문제 해결 
- `ErrorResponse`를 기반으로 요청 실패 응답 래핑하도록 리팩토링
- 요청 실패 응답 래핑 시점에 상태 코드 세팅

### 유효성 검증 실패 응답 예시
<img width="407" height="115" alt="image" src="https://github.com/user-attachments/assets/29ff4db9-8e28-4455-bb45-aab20bf69560" />

## 🙏 리뷰 요구사항
기존에는 ErrorCode에 대한 메시지만 클라이언트에 전달할 수 있었습니다. 이로 인해 유효성 검증 실패 시 추상적인 실패 메시지를 제공하게 되는데, 이를 방지하고자 실패 응답 래핑 코드를 수정했습니다. 
더 나은 방법이 있다면 코멘트 남겨주세요 :)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 오류 응답이 표준 형식(HTTP 상태, 오류 코드, 메시지 목록)으로 제공됩니다.
  - 메서드 수준 유효성 검증 실패 시 새 오류 코드와 함께 다중 검증 메시지가 반환됩니다.
  - 모집 API의 등록/수정 요청 본문에 유효성 검사(@Valid)가 적용되어 입력 오류 시 상세 안내를 제공합니다.
- 리팩터링
  - 전역 예외 처리와 응답 래퍼를 일관된 오류 응답 형식으로 정비해 예외 응답 일관성을 개선했습니다.
- 테스트
  - 여러 통합/단위 테스트의 기대 HTTP 상태 및 일부 검증 어설션이 조정되거나 완화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->