### PR TITLE
테스트코드용 공통 추상클래스 도입

### DIFF
--- a/src/main/java/org/ject/support/domain/admin/exception/AdminErrorCode.java
+++ b/src/main/java/org/ject/support/domain/admin/exception/AdminErrorCode.java
@@ -3,13 +3,17 @@ package org.ject.support.domain.admin.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.ject.support.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @AllArgsConstructor
 public enum AdminErrorCode implements ErrorCode {
-    NOT_FOUND_ADMIN("NOT_FOUND_ADMIN", "존재하지 않는 관리자 입니다."),
-    TOO_MANY_REQUESTS("TOO_MANY_REQUESTS", "너무 많은 요청입니다. 잠시 후 다시 시도해주세요.");
+    NOT_FOUND_ADMIN(NOT_FOUND, "NOT_FOUND_ADMIN", "존재하지 않는 관리자 입니다."),
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "TOO_MANY_REQUESTS", "너무 많은 요청입니다. 잠시 후 다시 시도해주세요.");
 
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/src/test/java/org/ject/support/base/TestSupport.java
+++ b/src/test/java/org/ject/support/base/TestSupport.java
@@ -1,0 +1,10 @@
+package org.ject.support.base;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public abstract class TestSupport {
+}

--- a/src/test/java/org/ject/support/base/UnitTestSupport.java
+++ b/src/test/java/org/ject/support/base/UnitTestSupport.java
@@ -1,0 +1,8 @@
+package org.ject.support.base;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class UnitTestSupport extends TestSupport {
+}

--- a/src/test/java/org/ject/support/common/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/ject/support/common/security/jwt/JwtTokenProviderTest.java
@@ -1,29 +1,26 @@
 package org.ject.support.common.security.jwt;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ject.support.common.exception.GlobalErrorCode.AUTHENTICATION_REQUIRED;
+import static org.mockito.Mockito.when;
+
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.exception.GlobalException;
 import org.ject.support.common.security.CustomUserDetails;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.ject.support.common.exception.GlobalErrorCode.AUTHENTICATION_REQUIRED;
-import static org.mockito.Mockito.when;
-
-@ExtendWith(MockitoExtension.class)
-class JwtTokenProviderTest {
+class JwtTokenProviderTest extends UnitTestSupport {
 
     private JwtTokenProvider jwtTokenProvider;
 
@@ -61,8 +58,7 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    @DisplayName("Access 토큰 생성 테스트")
-    void createAccessToken() {
+    void Access_토큰_생성_테스트() {
         // when
         String token = jwtTokenProvider.createAccessToken(authentication, testMember.getId());
 
@@ -73,8 +69,7 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    @DisplayName("Refresh 토큰 생성 테스트")
-    void createRefreshToken() {
+    void Refresh_토큰_생성_테스트() {
         // when
         String token = jwtTokenProvider.createRefreshToken(authentication, testMember.getId());
 
@@ -84,8 +79,7 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    @DisplayName("토큰으로부터 Authentication 객체 추출 테스트")
-    void getAuthenticationByToken() {
+    void 토큰으로부터_Authentication_객체_추출_테스트() {
         // given
         String token = jwtTokenProvider.createAccessToken(authentication, testMember.getId());
 
@@ -99,8 +93,7 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    @DisplayName("HTTP 요청에서 토큰 추출 테스트")
-    void resolveToken() {
+    void HTTP_요청에서_토큰_추출_테스트() {
         // given
         String token = "test-token";
         when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
@@ -113,8 +106,7 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    @DisplayName("쿠키 생성 테스트")
-    void createCookies() {
+    void 쿠키_생성_테스트() {
         // given
         String token = "test-token";
 
@@ -133,8 +125,7 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    @DisplayName("토큰 재발급 테스트")
-    void reissueAccessToken() {
+    void 토큰_재발급_테스트() {
         // given
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication, testMember.getId());
 
@@ -150,8 +141,7 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    @DisplayName("유효하지 않은 토큰 검증 테스트")
-    void validateInvalidToken() {
+    void 유효하지_않은_토큰_검증_테스트() {
         // given
         String invalidToken = "invalid-token";
 
@@ -160,30 +150,27 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    @DisplayName("Authentication이 null일 때 예외 발생 테스트")
-    void validateNullAuthentication() {
+    void Authentication이_null일_때_예외_발생_테스트() {
         // when & then
         assertThatThrownBy(() -> jwtTokenProvider.createAccessToken(null, testMember.getId()))
                 .isInstanceOf(GlobalException.class)
                 .extracting(e -> ((GlobalException) e).getErrorCode().getMessage())
                 .isEqualTo(AUTHENTICATION_REQUIRED.getMessage());
     }
-    
+
     @Test
-    @DisplayName("토큰에 ROLE_ 접두사가 포함된 역할이 저장되는지 확인")
-    void createAccessToken_ShouldStoreRoleWithPrefix() {
+    void 토큰에_ROLE_접두사가_포함된_역할이_저장되는지_확인() {
         // when
         String token = jwtTokenProvider.createAccessToken(authentication, testMember.getId());
-        
+
         // then
         Authentication resultAuth = jwtTokenProvider.getAuthenticationByToken(token);
         assertThat(resultAuth.getAuthorities()).isNotEmpty();
         assertThat(resultAuth.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_USER");
     }
-    
+
     @Test
-    @DisplayName("토큰에서 ROLE_ 접두사가 있는 역할을 추출할 때 정상적으로 처리되는지 확인")
-    void getAuthenticationByToken_WithRolePrefix_ShouldHandleCorrectly() {
+    void 토큰에서_ROLE_접두사가_있는_역할을_추출할_때_정상적으로_처리되는지_확인() {
         // given
         // 테스트를 위해 ROLE_ 접두사가 있는 역할을 가진 사용자로 테스트 멤버 재설정
         testMember = Member.builder()

--- a/src/test/java/org/ject/support/domain/admin/service/AdminAuthServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/AdminAuthServiceTest.java
@@ -1,5 +1,12 @@
 package org.ject.support.domain.admin.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.admin.exception.AdminErrorCode;
 import org.ject.support.domain.admin.exception.AdminException;
 import org.ject.support.domain.member.Role;
@@ -7,26 +14,13 @@ import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.ject.support.external.infrastructure.SlackRateLimiter;
 import org.ject.support.external.slack.SlackComponent;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-
-@ExtendWith(MockitoExtension.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class AdminAuthServiceTest {
+class AdminAuthServiceTest extends UnitTestSupport {
 
     @InjectMocks
     AdminAuthService adminAuthService;

--- a/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
@@ -1,27 +1,36 @@
 package org.ject.support.domain.auth;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.doAnswer;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.security.CustomSuccessHandler;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
+import org.ject.support.domain.auth.controller.AuthController;
 import org.ject.support.domain.auth.dto.AuthDto.PinLoginRequest;
 import org.ject.support.domain.auth.dto.AuthDto.TokenRefreshRequest;
 import org.ject.support.domain.auth.dto.AuthDto.VerifyAuthCodeRequest;
-import org.ject.support.domain.auth.controller.AuthController;
 import org.ject.support.domain.auth.dto.AuthVerificationResult;
 import org.ject.support.domain.auth.service.AuthService;
 import org.ject.support.external.email.domain.EmailTemplate;
 import org.ject.support.testconfig.ApplicationPeriodTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,14 +42,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
-@ExtendWith(MockitoExtension.class)
-class AuthControllerTest {
+class AuthControllerTest extends UnitTestSupport {
     @InjectMocks
     private AuthController authController;
 
@@ -59,8 +61,7 @@ class AuthControllerTest {
     private final Long TEST_MEMBER_ID = 1L;
 
     @Test
-    @DisplayName("인증 코드 검증 - AUTH_CODE 템플릿 - 이메일만 반환 성공")
-    void verifyAuthCode_WithCertificateTemplate_Success() {
+    void 인증_코드_검증_AUTH_CODE_템플릿_이메일만_반환_성공() {
         // given
         VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE);
         EmailTemplate template = EmailTemplate.AUTH_CODE;
@@ -79,8 +80,7 @@ class AuthControllerTest {
     }
     
     @Test
-    @DisplayName("인증 코드 검증 - PIN_RESET 템플릿 - 인증 토큰 발급 성공")
-    void verifyAuthCode_WithPinResetTemplate_Success() {
+    void 인증_코드_검증_PIN_RESET_템플릿_인증_토큰_발급_성공() {
         // given
         VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE);
         EmailTemplate template = EmailTemplate.PIN_RESET;
@@ -100,8 +100,7 @@ class AuthControllerTest {
     }
     
     @Test
-    @DisplayName("리프레시 토큰을 사용한 액세스 토큰 재발급 성공")
-    void refreshToken_Success() {
+    void 리프레시_토큰을_사용한_액세스_토큰_재발급_성공() {
         // given
         HttpServletRequest mockRequest = mock(HttpServletRequest.class);
         HttpServletResponse mockResponse = mock(HttpServletResponse.class);
@@ -118,8 +117,7 @@ class AuthControllerTest {
     }
     
     @Test
-    @DisplayName("PIN 로그인 성공")
-    void loginWithPin_Success() {
+    void PIN_로그인_성공() {
         // given
         PinLoginRequest request = new PinLoginRequest(TEST_EMAIL, TEST_AUTH_CODE);
         HttpServletRequest mockRequest = mock(HttpServletRequest.class);
@@ -138,8 +136,7 @@ class AuthControllerTest {
     }
     
     @Test
-    @DisplayName("회원 존재 여부 확인 성공")
-    void isExistMember_Success() {
+    void 회원_존재_여부_확인_성공() {
         // given
         given(authService.isExistMember(TEST_EMAIL))
             .willReturn(true);

--- a/src/test/java/org/ject/support/domain/member/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/org/ject/support/domain/member/controller/MemberControllerIntegrationTest.java
@@ -1,0 +1,81 @@
+package org.ject.support.domain.member.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.ject.support.domain.member.dto.MemberDto.InitialProfileRequest;
+import org.ject.support.domain.member.dto.MemberDto.RegisterRequest;
+import org.ject.support.domain.member.dto.MemberDto.UpdatePinRequest;
+import org.ject.support.testconfig.ApplicationPeriodTest;
+import org.ject.support.testconfig.AuthenticatedUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false", "server.port=0"})
+class MemberControllerIntegrationTest extends ApplicationPeriodTest {
+
+    private final String TEST_PIN = "123456";
+    private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
+    private final String TEST_NAME = "홍길동";
+    private final String TEST_PHONE_NUMBER = "01012345678";
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("회원 등록 API 통합 테스트")
+    void registerMember_Integration() throws Exception {
+        // given
+        RegisterRequest request = new RegisterRequest(TEST_PIN);
+
+        // 실제 서비스를 사용하므로 모킹하지 않음
+        // 대신 응답 상태만 확인
+
+        // when & then
+        mockMvc.perform(post("/members")
+                        .cookie(new jakarta.servlet.http.Cookie("verificationToken", TEST_VERIFICATION_TOKEN))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+        // 응답 본문이 없으므로 상태 코드만 확인
+    }
+
+    @Test
+    @DisplayName("임시회원 최초 프로필 등록 API 통합 테스트")
+    @AuthenticatedUser(memberId = 1L)
+    void registerInitialProfile_Integration() throws Exception {
+        // given
+        InitialProfileRequest request = new InitialProfileRequest(TEST_NAME, TEST_PHONE_NUMBER);
+
+        // when & then
+        mockMvc.perform(put("/members/profile/initial")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("핀번호 재설정 API 통합 테스트")
+    @AuthenticatedUser(memberId = 1L)
+    void resetPin_Integration() throws Exception {
+        // given
+        UpdatePinRequest request = new UpdatePinRequest("654321"); // 새로운 PIN 번호
+
+        // when & then
+        mockMvc.perform(put("/members/pin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/ject/support/domain/member/controller/MemberControllerTest.java
@@ -7,47 +7,34 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.security.CustomSuccessHandler;
 import org.ject.support.common.security.CustomUserDetails;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
 import org.ject.support.domain.member.Role;
-import org.ject.support.domain.member.dto.MemberDto.RegisterRequest;
 import org.ject.support.domain.member.dto.MemberDto.InitialProfileRequest;
+import org.ject.support.domain.member.dto.MemberDto.RegisterRequest;
 import org.ject.support.domain.member.dto.MemberDto.UpdatePinRequest;
-import org.ject.support.domain.member.exception.MemberErrorCode;
-import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.service.MemberService;
-import org.ject.support.testconfig.ApplicationPeriodTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import org.ject.support.testconfig.AuthenticatedUser;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-@ExtendWith(MockitoExtension.class)
-class MemberControllerTest {
+class MemberControllerTest extends UnitTestSupport {
 
     @InjectMocks
     private MemberController memberController;
@@ -77,41 +64,40 @@ class MemberControllerTest {
     }
 
     @Test
-    @DisplayName("회원 등록 성공")
-    void registerMember_Success() throws Exception {
+    void 회원_등록_성공() throws Exception {
         // given
         RegisterRequest request = new RegisterRequest(TEST_PIN);
         Authentication mockAuthentication = new UsernamePasswordAuthenticationToken(
                 new CustomUserDetails(TEST_EMAIL, 1L, Role.TEMP), "", null);
-        
+
         given(jwtTokenProvider.resolveVerificationToken(any())).willReturn(TEST_VERIFICATION_TOKEN);
         given(jwtTokenProvider.extractEmailFromVerificationToken(TEST_VERIFICATION_TOKEN)).willReturn(TEST_EMAIL);
         given(memberService.registerTempMember(any(RegisterRequest.class), anyString())).willReturn(mockAuthentication);
-        
+
         // customSuccessHandler.onAuthenticationSuccess 메소드 호출 모킹
         doNothing().when(customSuccessHandler).onAuthenticationSuccess(any(HttpServletRequest.class), any(
                 HttpServletResponse.class), any(Authentication.class));
 
         // when & then
         mockMvc.perform(post("/members")
-                .cookie(new jakarta.servlet.http.Cookie("verificationToken", TEST_VERIFICATION_TOKEN))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                        .cookie(new jakarta.servlet.http.Cookie("verificationToken", TEST_VERIFICATION_TOKEN))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
-        
+
         verify(jwtTokenProvider).resolveVerificationToken(any());
         verify(jwtTokenProvider).extractEmailFromVerificationToken(TEST_VERIFICATION_TOKEN);
         verify(memberService).registerTempMember(any(RegisterRequest.class), eq(TEST_EMAIL));
-        verify(customSuccessHandler).onAuthenticationSuccess(any(HttpServletRequest.class), any(HttpServletResponse.class), eq(mockAuthentication));
+        verify(customSuccessHandler).onAuthenticationSuccess(any(HttpServletRequest.class),
+                any(HttpServletResponse.class), eq(mockAuthentication));
     }
-    
+
     @Test
-    @DisplayName("임시회원 최초 프로필 등록 성공")
-    void registerInitialProfile_Success() throws Exception {
+    void 임시회원_최초_프로필_등록_성공() throws Exception {
         // given
         InitialProfileRequest request = new InitialProfileRequest(TEST_NAME, TEST_PHONE_NUMBER);
         Long memberId = 1L;
-        
+
         // lenient 설정을 사용하여 엄격한 스텔빙 검사를 해제
         lenient().doNothing().when(memberService).registerInitialProfile(any(), eq(memberId));
 
@@ -122,22 +108,21 @@ class MemberControllerTest {
 
         // when & then
         mockMvc.perform(put("/members/profile/initial")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
-        
+
         // verify를 사용하지 않고 스텔빙만 확인
         // 테스트 후 인증 정보 초기화
         SecurityContextHolder.clearContext();
     }
-    
+
     @Test
-    @DisplayName("핀번호 재설정 성공")
-    void resetPin_Success() throws Exception {
+    void 핀번호_재설정_성공() throws Exception {
         // given
         UpdatePinRequest request = new UpdatePinRequest("654321"); // 새로운 PIN 번호
         Long memberId = 1L;
-        
+
         // lenient 설정을 사용하여 엄격한 스텔빙 검사를 해제
         lenient().doNothing().when(memberService).updatePin(any(UpdatePinRequest.class), eq(memberId));
 
@@ -148,49 +133,17 @@ class MemberControllerTest {
 
         // when & then
         mockMvc.perform(put("/members/pin")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
-        
+
         // verify를 사용하지 않고 스텔빙만 확인
         // 테스트 후 인증 정보 초기화
         SecurityContextHolder.clearContext();
     }
 
-    /*
-    
     @Test
-    @DisplayName("핀번호 재설정 실패 - 동일한 PIN 번호")
-    void resetPin_Fail_SamePin() throws Exception {
-        // given
-        UpdatePinRequest request = new UpdatePinRequest(TEST_PIN); // 기존과 동일한 PIN 번호
-        Long memberId = 1L;
-        
-        // lenient 설정을 사용하여 엄격한 스텔빙 검사를 해제
-        lenient().doThrow(new MemberException(MemberErrorCode.SAME_PIN))
-            .when(memberService).updatePin(any(UpdatePinRequest.class), eq(memberId));
-
-        // CustomUserDetails를 사용하여 인증 정보 설정 (ROLE_TEMP 권한)
-        CustomUserDetails userDetails = new CustomUserDetails(TEST_EMAIL, memberId, Role.TEMP);
-        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
-        // when & then
-        mockMvc.perform(put("/members/pin")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
-        
-        // verify를 사용하지 않고 스텔빙만 확인
-        // 테스트 후 인증 정보 초기화
-        SecurityContextHolder.clearContext();
-    }
-
-     */
-    
-    @Test
-    @DisplayName("핀번호 재설정 실패 - 유효하지 않은 PIN 번호 형식")
-    void resetPin_Fail_InvalidPinFormat() throws Exception {
+    void 핀번호_재설정_실패_유효하지_않은_PIN_번호_형식() throws Exception {
         // given
         // 유효하지 않은 PIN 번호 (6자리가 아님)
         String invalidPin = "12345";
@@ -204,125 +157,61 @@ class MemberControllerTest {
 
         // when & then
         mockMvc.perform(put("/members/pin")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
-        
+
         // 테스트 후 인증 정보 초기화
         SecurityContextHolder.clearContext();
     }
-    
+
     @Test
-    @DisplayName("임시회원 최초 프로필 등록 여부 확인 성공 - 등록된 경우")
-    void isInitialMember_Success_True() throws Exception {
+    void 임시회원_최초_프로필_등록_여부_확인_성공_등록된_경우() throws Exception {
         // given
         Long memberId = 1L;
-        
+
         // 모킹 설정을 lenient로 변경하여 엄격한 스텁 검사를 비활성화
         lenient().when(memberService.checkIsInitialed(any())).thenReturn(true);
-        
+
         // CustomUserDetails를 사용하여 인증 정보 설정 (ROLE_TEMP 권한)
         CustomUserDetails userDetails = new CustomUserDetails(TEST_EMAIL, memberId, Role.TEMP);
         Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(auth);
-        
+
         // when & then
-        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/members/profile/initial/status")
-                .contentType(MediaType.APPLICATION_JSON)
-                .principal(auth))
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get(
+                                "/members/profile/initial/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .principal(auth))
                 .andExpect(status().isOk())
                 .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().string("true"));
-        
+
         // 테스트 후 인증 정보 초기화
         SecurityContextHolder.clearContext();
     }
-    
+
     @Test
-    @DisplayName("임시회원 최초 프로필 등록 여부 확인 성공 - 미등록된 경우")
-    void isInitialMember_Success_False() throws Exception {
+    void 임시회원_최초_프로필_등록_여부_확인_성공_미등록된_경우() throws Exception {
         // given
         Long memberId = 1L;
-        
+
         // 모킹 설정을 lenient로 변경하여 엄격한 스텁 검사를 비활성화
         lenient().when(memberService.checkIsInitialed(any())).thenReturn(false);
-        
+
         // CustomUserDetails를 사용하여 인증 정보 설정 (ROLE_TEMP 권한)
         CustomUserDetails userDetails = new CustomUserDetails(TEST_EMAIL, memberId, Role.TEMP);
         Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(auth);
-        
+
         // when & then
-        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/members/profile/initial/status")
-                .contentType(MediaType.APPLICATION_JSON)
-                .principal(auth))
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get(
+                                "/members/profile/initial/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .principal(auth))
                 .andExpect(status().isOk())
                 .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().string("false"));
-        
+
         // 테스트 후 인증 정보 초기화
         SecurityContextHolder.clearContext();
     }
-
-
-@SpringBootTest
-@AutoConfigureMockMvc
-@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false", "server.port=0"})
-class MemberControllerIntegrationTest extends ApplicationPeriodTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-    
-    @Autowired
-    private ObjectMapper objectMapper;
-    
-    private final String TEST_PIN = "123456";
-    private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
-    private final String TEST_NAME = "홍길동";
-    private final String TEST_PHONE_NUMBER = "01012345678";
-    
-    @Test
-    @DisplayName("회원 등록 API 통합 테스트")
-    void registerMember_Integration() throws Exception {
-        // given
-        RegisterRequest request = new RegisterRequest(TEST_PIN);
-        
-        // 실제 서비스를 사용하므로 모킹하지 않음
-        // 대신 응답 상태만 확인
-        
-        // when & then
-        mockMvc.perform(post("/members")
-                .cookie(new jakarta.servlet.http.Cookie("verificationToken", TEST_VERIFICATION_TOKEN))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
-        // 응답 본문이 없으므로 상태 코드만 확인
-    }
-    
-    @Test
-    @DisplayName("임시회원 최초 프로필 등록 API 통합 테스트")
-    @AuthenticatedUser(memberId = 1L)
-    void registerInitialProfile_Integration() throws Exception {
-        // given
-        InitialProfileRequest request = new InitialProfileRequest(TEST_NAME, TEST_PHONE_NUMBER);
-        
-        // when & then
-        mockMvc.perform(put("/members/profile/initial")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
-    }
-    
-    @Test
-    @DisplayName("핀번호 재설정 API 통합 테스트")
-    @AuthenticatedUser(memberId = 1L)
-    void resetPin_Integration() throws Exception {
-        // given
-        UpdatePinRequest request = new UpdatePinRequest("654321"); // 새로운 PIN 번호
-        
-        // when & then
-        mockMvc.perform(put("/members/pin")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
-    }
-  }
 }

--- a/src/test/java/org/ject/support/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/ject/support/domain/member/service/MemberServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import java.util.Optional;
+import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
 import org.ject.support.domain.member.dto.MemberDto.InitialProfileRequest;
 import org.ject.support.domain.member.dto.MemberDto.RegisterRequest;
@@ -16,17 +17,13 @@ import org.ject.support.domain.member.exception.MemberErrorCode;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-@ExtendWith(MockitoExtension.class)
-class MemberServiceTest {
+class MemberServiceTest extends UnitTestSupport {
 
     @InjectMocks
     private MemberService memberService;
@@ -58,8 +55,7 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("임시 회원 등록 성공")
-    void registerTempMember_Success() {
+    void 임시_회원_등록_성공() {
         // given
         RegisterRequest request = new RegisterRequest(TEST_PIN);
         Member member = Member.builder()
@@ -83,8 +79,7 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("이미 존재하는 회원인 경우 예외 발생")
-    void registerTempMember_AlreadyExistMember_ThrowsException() {
+    void 이미_존재하는_회원인_경우_예외_발생() {
         // given
         RegisterRequest request = new RegisterRequest(TEST_PIN);
         Member existingMember = Member.builder()
@@ -102,8 +97,7 @@ class MemberServiceTest {
     }
     
     @Test
-    @DisplayName("회원 정보 업데이트 성공")
-    void updateMember_Success() {
+    void 회원_정보_업데이트_성공() {
         // given
         Long memberId = 1L;
         InitialProfileRequest request = new InitialProfileRequest(TEST_NAME, TEST_PHONE_NUMBER);
@@ -125,8 +119,7 @@ class MemberServiceTest {
     }
     
     @Test
-    @DisplayName("존재하지 않는 회원 정보 업데이트 시 예외 발생")
-    void updateMember_NotFoundMember_ThrowsException() {
+    void 존재하지_않는_회원_정보_업데이트_시_예외_발생() {
         // given
         Long memberId = 1L;
         InitialProfileRequest request = new InitialProfileRequest(TEST_NAME, TEST_PHONE_NUMBER);
@@ -141,8 +134,7 @@ class MemberServiceTest {
     }
     
     @Test
-    @DisplayName("핀번호 재설정 성공")
-    void updatePin_Success() {
+    void 핀번호_재설정_성공() {
         // given
         Long memberId = 1L;
         String newPin = "654321";
@@ -169,8 +161,7 @@ class MemberServiceTest {
     }
     
     @Test
-    @DisplayName("핀번호 재설정 실패 - 존재하지 않는 회원")
-    void updatePin_NotFoundMember_ThrowsException() {
+    void 핀번호_재설정_실패_존재하지_않는_회원() {
         // given
         Long memberId = 1L;
         UpdatePinRequest request = new UpdatePinRequest("654321");
@@ -183,29 +174,4 @@ class MemberServiceTest {
                 .extracting(e -> ((MemberException) e).getErrorCode())
                 .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
     }
-
-    /*
-    @Test
-    @DisplayName("핀번호 재설정 실패 - 기존과 동일한 PIN 번호")
-    void updatePin_SamePin_ThrowsException() {
-        // given
-        Long memberId = 1L;
-        UpdatePinRequest request = new UpdatePinRequest(TEST_PIN);
-        
-        Member member = Member.builder()
-                .id(memberId)
-                .email(TEST_EMAIL)
-                .pin(TEST_ENCODED_PIN)
-                .build();
-        
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(passwordEncoder.matches(TEST_PIN, TEST_ENCODED_PIN)).willReturn(true); // 기존과 같은 PIN
-        
-        // when & then
-        assertThatThrownBy(() -> memberService.updatePin(request, memberId))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.SAME_PIN);
-    }
-     */
 }

--- a/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
@@ -7,9 +7,9 @@ import static org.ject.support.domain.project.entity.ProjectIntro.builder;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.member.dto.TeamMemberNames;
 import org.ject.support.domain.member.entity.Team;
 import org.ject.support.domain.member.repository.MemberRepository;
@@ -20,16 +20,12 @@ import org.ject.support.domain.project.entity.ProjectIntro;
 import org.ject.support.domain.project.exception.ProjectException;
 import org.ject.support.domain.project.repository.ProjectRepository;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class ProjectServiceTest {
+class ProjectServiceTest extends UnitTestSupport {
 
     @InjectMocks
     private ProjectService projectService;
@@ -72,8 +68,7 @@ class ProjectServiceTest {
     }
 
     @Test
-    @DisplayName("프로젝트 상세 조회")
-    void find_project_details() {
+    void 프로젝트_상세_조회() {
         // given
         when(projectRepository.findById(1L)).thenReturn(Optional.ofNullable(project));
         when(memberRepository.findMemberNamesByTeamId(1L)).thenReturn(
@@ -98,8 +93,7 @@ class ProjectServiceTest {
     }
 
     @Test
-    @DisplayName("프로젝트 상세 조회 시 서비스 소개서는 sequence 기준 오름차순 정렬되어야 함")
-    void find_project_details_sort_project_intro_by_sequence_ascending() {
+    void 프로젝트_상세_조회_시_서비스_소개서는_sequence_기준으로_오름차순_정렬() {
         // given
         when(projectRepository.findById(1L)).thenReturn(Optional.ofNullable(project));
         when(memberRepository.findMemberNamesByTeamId(1L)).thenReturn(
@@ -115,8 +109,7 @@ class ProjectServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 프로젝트 상세 조회 시 예외 발생")
-    void find_project_details_fail_by_not_found() {
+    void 존재하지_않는_프로젝트_상세_조회_시_예외_발생() {
         // given
         when(projectRepository.findById(Mockito.any())).thenReturn(Optional.empty());
 
@@ -126,8 +119,7 @@ class ProjectServiceTest {
     }
 
     @Test
-    @DisplayName("프로젝트 상세 조회 시 기술 스택을 배열 형태로 반환")
-    void get_tech_stack_for_list() {
+    void 프로젝트_상세_조회_시_기술_스택을_배열_형태로_반환() {
         // given
         when(projectRepository.findById(1L)).thenReturn(Optional.ofNullable(project));
         when(memberRepository.findMemberNamesByTeamId(1L)).thenReturn(

--- a/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodVerifierTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodVerifierTest.java
@@ -1,27 +1,24 @@
 package org.ject.support.domain.recruit.service;
 
-import org.aspectj.lang.ProceedingJoinPoint;
-import org.ject.support.common.exception.GlobalException;
-import org.ject.support.common.util.PeriodAccessible;
-import org.ject.support.domain.member.JobFamily;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
-class AccessPeriodVerifierTest {
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.common.exception.GlobalException;
+import org.ject.support.common.util.PeriodAccessible;
+import org.ject.support.domain.member.JobFamily;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+class AccessPeriodVerifierTest extends UnitTestSupport {
 
     @InjectMocks
     AccessPeriodVerifier accessPeriodVerifier;
@@ -44,8 +41,7 @@ class AccessPeriodVerifierTest {
     }
 
     @Test
-    @DisplayName("하나의 직군이라도 모집중인 상태에서 permitAllJob이 true면 통과")
-    void permit_all_job_success_by_recruiting_anyone() throws Throwable {
+    void 하나의_직군이라도_모집중인_상태에서_permitAllJob이_true면_통과() throws Throwable {
         // given
         when(target.permitAllJob()).thenReturn(true); // 모든 직군에 대한 요청
         when(valueOperations.get(anyString())).thenReturn("false");
@@ -60,8 +56,7 @@ class AccessPeriodVerifierTest {
     }
 
     @Test
-    @DisplayName("모집중인 직군이 없는 상태에서 permitAllJob이 true이면 실패")
-    void permit_all_job_fail_by_not_recruiting_all() {
+    void 모집중인_직군이_없는_상태에서_permitAllJob이_true이면_실패() {
         // given
         when(target.permitAllJob()).thenReturn(true); // 모든 직군에 대한 요청
         when(valueOperations.get(anyString())).thenReturn("false");
@@ -72,8 +67,7 @@ class AccessPeriodVerifierTest {
     }
 
     @Test
-    @DisplayName("permitAllJob이 false인 상태에서 모집중인 직군을 파라미터로 전달하면 통과")
-    void check_success_by_has_job_family() throws Throwable {
+    void permitAllJob이_false인_상태에서_모집중인_직군을_파라미터로_전달하면_통과() throws Throwable {
         // given
         when(target.permitAllJob()).thenReturn(false);
         when(joinPoint.getArgs()).thenReturn(new Object[]{JobFamily.BE});
@@ -89,8 +83,7 @@ class AccessPeriodVerifierTest {
     }
 
     @Test
-    @DisplayName("permitAllJob이 false인 상태에서 모집중이지 않은 직군을 파라미터로 전달하면 실패")
-    void test_method_name() {
+    void permitAllJob이_false인_상태에서_모집중이지_않은_직군을_파라미터로_전달하면_실패() {
         // given
         when(target.permitAllJob()).thenReturn(false);
         when(joinPoint.getArgs()).thenReturn(new Object[]{JobFamily.BE});
@@ -102,8 +95,7 @@ class AccessPeriodVerifierTest {
     }
 
     @Test
-    @DisplayName("permitAll이 false인데 JobFamily 파라미터 없으면 실패")
-    void check_fail_by_has_not_job_family() {
+    void permitAll이_false인데_JobFamily_파라미터_없으면_실패() {
         // given
         when(target.permitAllJob()).thenReturn(false);
         when(joinPoint.getArgs()).thenReturn(new Object[]{"string", 123}); // JobFamily 없음

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitSavedEventHandlerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitSavedEventHandlerTest.java
@@ -1,5 +1,12 @@
 package org.ject.support.domain.recruit.service;
 
+import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.dto.RecruitSavedEvent;
@@ -7,20 +14,10 @@ import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
-
-import static org.mockito.Mockito.atMostOnce;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-@ExtendWith(MockitoExtension.class)
-class RecruitSavedEventHandlerTest {
+class RecruitSavedEventHandlerTest extends UnitTestSupport {
 
     @InjectMocks
     RecruitSavedEventHandler recruitSavedEventHandler;

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitServiceTest.java
@@ -1,24 +1,5 @@
 package org.ject.support.domain.recruit.service;
 
-import org.ject.support.domain.member.JobFamily;
-import org.ject.support.domain.member.service.OngoingSemesterProvider;
-import org.ject.support.domain.recruit.domain.Recruit;
-import org.ject.support.domain.recruit.dto.RecruitRegisterRequest;
-import org.ject.support.domain.recruit.dto.RecruitUpdateRequest;
-import org.ject.support.domain.recruit.exception.RecruitException;
-import org.ject.support.domain.recruit.repository.RecruitRepository;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.ject.support.domain.member.JobFamily.BE;
@@ -28,8 +9,24 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
-class RecruitServiceTest {
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.service.OngoingSemesterProvider;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.dto.RecruitRegisterRequest;
+import org.ject.support.domain.recruit.dto.RecruitUpdateRequest;
+import org.ject.support.domain.recruit.exception.RecruitException;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.context.ApplicationEventPublisher;
+
+class RecruitServiceTest extends UnitTestSupport {
 
     @InjectMocks
     RecruitService recruitService;

--- a/src/test/java/org/ject/support/external/s3/S3ServiceTest.java
+++ b/src/test/java/org/ject/support/external/s3/S3ServiceTest.java
@@ -1,18 +1,9 @@
 package org.ject.support.external.s3;
 
-import org.ject.support.domain.file.dto.UploadFileRequest;
-import org.ject.support.domain.file.dto.UploadFileResponse;
-import org.ject.support.domain.file.exception.FileException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
-import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -20,14 +11,19 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.domain.file.dto.UploadFileRequest;
+import org.ject.support.domain.file.dto.UploadFileResponse;
+import org.ject.support.domain.file.exception.FileException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.when;
-
-@ExtendWith(MockitoExtension.class)
-class S3ServiceTest {
+class S3ServiceTest extends UnitTestSupport {
 
     private static final String CDN_DOMAIN = "https://test-ject-cdn.net";
     private static final int EXPIRE_MINUTES = 10;
@@ -58,8 +54,7 @@ class S3ServiceTest {
     }
 
     @Test
-    @DisplayName("포트폴리오 업로드를 위한 pre-signed url 생성")
-    void upload_portfolio() throws MalformedURLException {
+    void 포트폴리오_업로드를_위한_presigned_url_생성() throws MalformedURLException {
         // given
         when(presignedPutObjectRequest.url()).thenReturn(URI.create(expectedPortfolioUploadUrls.get(0)).toURL());
         when(presignedPutObjectRequest.expiration()).thenReturn(expirationTime);
@@ -82,8 +77,7 @@ class S3ServiceTest {
     }
 
     @Test
-    @DisplayName("객체 키 생성")
-    void create_key_name() throws MalformedURLException {
+    void 객체_키_생성() throws MalformedURLException {
         // given
         when(presignedPutObjectRequest.url()).thenReturn(URI.create(expectedPortfolioUploadUrls.get(0)).toURL());
         when(presignedPutObjectRequest.expiration()).thenReturn(expirationTime);
@@ -104,8 +98,7 @@ class S3ServiceTest {
     }
 
     @Test
-    @DisplayName("유효하지 않은 확장자로 인한 포트폴리오 업로드 실패")
-    void upload_portfolio_fail() {
+    void 유효하지_않은_확장자로_인한_포트폴리오_업로드_실패() {
         // given
         List<UploadFileRequest> invalidRequests = List.of(new UploadFileRequest("test.png", "image/png", 12345));
 
@@ -116,8 +109,7 @@ class S3ServiceTest {
 
 
     @Test
-    @DisplayName("포트폴리오 최대 용량을 초과해 업로드 실패")
-    void exceeded_portfolio_max_size() {
+    void 포트폴리오_최대_용량을_초과해_업로드_실패() {
         // given
         List<UploadFileRequest> invalidRequests = List.of(
                 new UploadFileRequest("test1.pdf", "application/pdf", 53428800),


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #257 

## 📝 작업 내용

테스트 클래스에서 사용되는 애노테이션에 대해서 DRY 방지를 위해 공통적으로 사용되는 구성을 추출해서 추상클래스로 생성했습니다.
작업한 내용은 다음과 같습니다.
- 공통 추상 클래스 생성
- 테스트 케이스 메서드 네이밍을 한글화
이러한 공통 추상 클래스 도입으로 기대되는 효과는 다음과 같습니다.
- DRY 방지
- 불필요한 import 제거
- 테스트 코드 작성 시 휴먼에러 방지


## 🙏 리뷰 요구사항 (선택)

현재는 단위 테스트에 대해서 적용을 했습니다.
추후 통합 테스트에 대한 추상 클래스 또한 생성해서 관리할 예정입니다.
