### PR TITLE
feat: project 테이블의 semester_id 컬럼을 team 테이블로 마이그레이션 및 코드 수정

### DIFF
--- a/src/main/java/org/ject/support/domain/member/entity/Team.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Team.java
@@ -25,4 +25,7 @@ public class Team extends BaseTimeEntity {
 
     @Column(length = 30, nullable = false)
     private String name;
+
+    @Column(nullable = false)
+    private Long semesterId;
 }

--- a/src/main/java/org/ject/support/domain/project/entity/Project.java
+++ b/src/main/java/org/ject/support/domain/project/entity/Project.java
@@ -32,9 +32,6 @@ public class Project extends BaseTimeEntity {
     @Column(columnDefinition = "varchar(30)", nullable = false)
     private Project.Category category;
 
-    @Column(nullable = false)
-    private Long semesterId;
-
     @Column(length = 100, nullable = false)
     private String summary;
 

--- a/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryImpl.java
@@ -1,13 +1,9 @@
 package org.ject.support.domain.project.repository;
 
-import static org.ject.support.domain.project.entity.Project.Category;
-import static org.ject.support.domain.project.entity.QProject.project;
-
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.data.PageResponse;
 import org.ject.support.domain.project.dto.ProjectResponse;
@@ -15,6 +11,11 @@ import org.ject.support.domain.project.dto.QProjectResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static org.ject.support.domain.project.entity.Project.Category;
+import static org.ject.support.domain.project.entity.QProject.project;
 
 @Repository
 @RequiredArgsConstructor
@@ -51,6 +52,6 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
         if (semesterId == null) {
             return Expressions.TRUE;
         }
-        return project.semesterId.eq(semesterId);
+        return project.team.semesterId.eq(semesterId);
     }
 }

--- a/src/main/resources/db/migration/V4__alter_team_add_semester_id_column.sql
+++ b/src/main/resources/db/migration/V4__alter_team_add_semester_id_column.sql
@@ -1,0 +1,10 @@
+-- team 테이블에 semester_id 컬럼 추가
+ALTER TABLE team ADD COLUMN semester_id BIGINT NOT NULL;
+
+-- team 테이블의 semester_id 컬럼을 project 테이블의 semester_id 값으로 초기화
+UPDATE team
+    JOIN project ON team.id = project.team_id
+    SET team.semester_id = project.semester_id;
+
+-- project 테이블에 semester_id 컬럼 삭제
+ALTER TABLE project DROP COLUMN semester_id;

--- a/src/main/resources/db/migration/V4__alter_team_add_semester_id_column.sql
+++ b/src/main/resources/db/migration/V4__alter_team_add_semester_id_column.sql
@@ -1,5 +1,5 @@
 -- team 테이블에 semester_id 컬럼 추가
-ALTER TABLE team ADD COLUMN semester_id BIGINT NOT NULL;
+ALTER TABLE team ADD COLUMN semester_id BIGINT NOT NULL DEFAULT 1;
 
 -- team 테이블의 semester_id 컬럼을 project 테이블의 semester_id 값으로 초기화
 UPDATE team

--- a/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
@@ -118,6 +118,7 @@ class MemberQueryRepositoryTest {
     private Team createTeam(String name) {
         return Team.builder()
                 .name(name)
+                .semesterId(1L)
                 .build();
     }
 

--- a/src/test/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryTest.java
@@ -1,7 +1,5 @@
 package org.ject.support.domain.project.repository;
 
-import java.time.LocalDate;
-import java.util.List;
 import org.ject.support.domain.member.entity.Team;
 import org.ject.support.domain.member.repository.TeamRepository;
 import org.ject.support.domain.project.dto.ProjectResponse;
@@ -15,6 +13,9 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ject.support.domain.project.entity.Project.Category.HACKATHON;
@@ -34,9 +35,9 @@ class ProjectQueryRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        team1 = Team.builder().name("team1").build();
-        team2 = Team.builder().name("team2").build();
-        team3 = Team.builder().name("team3").build();
+        team1 = Team.builder().name("team1").semesterId(1L).build();
+        team2 = Team.builder().name("team2").semesterId(1L).build();
+        team3 = Team.builder().name("team3").semesterId(2L).build();
         teamRepository.saveAll(List.of(team1, team2, team3));
     }
 
@@ -44,9 +45,9 @@ class ProjectQueryRepositoryTest {
     @DisplayName("기수별 프로젝트 목록 조회")
     void find_projects_by_semester() {
         // given
-        Project project1 = createProject(MAIN, 1L, team1);
-        Project project2 = createProject(MAIN, 1L, team2);
-        Project project3 = createProject(MAIN, 2L, team3);
+        Project project1 = createProject(MAIN, team1);
+        Project project2 = createProject(MAIN, team2);
+        Project project3 = createProject(MAIN, team3);
         projectRepository.saveAll(List.of(project1, project2, project3));
 
         // when
@@ -71,15 +72,15 @@ class ProjectQueryRepositoryTest {
     @DisplayName("특정 년월에 진행한 해커톤 프로젝트 목록 조회")
     void find_hackathon_projects() {
         // given
-        Project project1 = createProject(MAIN, 1L, team1);
-        Project project2 = createProject(HACKATHON, 2L, team2);
-        Project project3 = createProject(HACKATHON, 2L, team3);
-        Project project4 = createProject(HACKATHON, 3L, team1);
+        Project project1 = createProject(MAIN, team1);
+        Project project2 = createProject(HACKATHON, team2);
+        Project project3 = createProject(HACKATHON, team3);
+        Project project4 = createProject(HACKATHON, team1);
         projectRepository.saveAll(List.of(project1, project2, project3, project4));
 
         // when
         Page<ProjectResponse> result =
-                projectRepository.findProjectsByCategoryAndSemester(HACKATHON, 2L, PageRequest.of(0, 30));
+                projectRepository.findProjectsByCategoryAndSemester(HACKATHON, 1L, PageRequest.of(0, 30));
 
         // then
         assertThat(result.getContent()).hasSize(2);
@@ -94,7 +95,6 @@ class ProjectQueryRepositoryTest {
         Project project = Project.builder()
                 .name("name")
                 .category(Project.Category.MAIN)
-                .semesterId(1L)
                 .summary("summary")
                 .techStack(techStack)
                 .startDate(LocalDate.of(2025, 3, 1))
@@ -114,10 +114,10 @@ class ProjectQueryRepositoryTest {
     @DisplayName("semesterId가 null이면 전체 조회")
     void find_all_projects_by_semester_id_null() {
         // given
-        Project project1 = createProject(MAIN, 1L, team1);
-        Project project2 = createProject(MAIN, 1L, team2);
-        Project project3 = createProject(MAIN, 2L, team3);
-        Project project4 = createProject(MAIN, 2L, team3);
+        Project project1 = createProject(MAIN, team1);
+        Project project2 = createProject(MAIN, team2);
+        Project project3 = createProject(MAIN, team3);
+        Project project4 = createProject(MAIN, team3);
         projectRepository.saveAll(List.of(project1, project2, project3, project4));
 
         // when
@@ -131,11 +131,10 @@ class ProjectQueryRepositoryTest {
         assertThat(responses).hasSize(4);
     }
 
-    private Project createProject(Project.Category category, Long semesterId, Team team) {
+    private Project createProject(Project.Category category, Team team) {
         return Project.builder()
                 .name("projectName")
                 .thumbnailUrl("https://test.net/thumbnail.png")
-                .semesterId(semesterId)
                 .summary("summary")
                 .description("description")
                 .startDate(LocalDate.of(2025, 3, 2))

--- a/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
@@ -1,14 +1,5 @@
 package org.ject.support.domain.project.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.ject.support.domain.project.entity.ProjectIntro.Category;
-import static org.ject.support.domain.project.entity.ProjectIntro.builder;
-import static org.mockito.Mockito.when;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.member.dto.TeamMemberNames;
 import org.ject.support.domain.member.entity.Team;
@@ -24,6 +15,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ject.support.domain.project.entity.ProjectIntro.Category;
+import static org.ject.support.domain.project.entity.ProjectIntro.builder;
+import static org.mockito.Mockito.when;
 
 class ProjectServiceTest extends UnitTestSupport {
 
@@ -54,7 +55,6 @@ class ProjectServiceTest extends UnitTestSupport {
         ProjectIntro devIntro1 = createProjectIntro(4L, "devImage1.png", Category.DEV, 1);
         project = Project.builder()
                 .id(1L)
-                .semesterId(1L)
                 .summary("summary")
                 .techStack(List.of("java", "Spring", "JPA", "QueryDSL", "MySQL", "AWS"))
                 .startDate(LocalDate.of(2025, 3, 2))
@@ -62,7 +62,7 @@ class ProjectServiceTest extends UnitTestSupport {
                 .description("description")
                 .thumbnailUrl("thumbnail.png")
                 .serviceUrl("service.com")
-                .team(Team.builder().id(1L).name("team").build())
+                .team(Team.builder().id(1L).name("team").semesterId(1L).build())
                 .projectIntros(List.of(serviceIntro1, serviceIntro2, serviceIntro3, devIntro1))
                 .build();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #278 

## 📝 작업 내용

### 1. project 테이블에 있는 semester_id(기수 ID) 컬럼을 team 테이블로 옮기기
 - entity 수정
 - 관련 code 수정
 - migration code 작성

## 🙏 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능: 없음
- 개선(Refactor)
  - 프로젝트의 기수 기준을 팀의 기수로 통합하여 조회 일관성을 개선했습니다.
- 버그 수정: 없음
- 테스트
  - 테스트 데이터와 케이스를 팀의 기수 기반으로 정비하고 관련 검증을 업데이트했습니다.
- 작업(Chores)
  - 데이터 마이그레이션 수행: 팀에 기수 컬럼을 추가하고 기존 프로젝트의 기수 데이터를 팀으로 이전했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->