### PR TITLE
개선된 지원 플로우에 따른 리팩토링 (추가 개선)

### DIFF
--- a/src/main/java/org/ject/support/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/ject/support/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.ject.support.common.response.ErrorResponse;
 import org.springframework.context.MessageSourceResolvable;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -89,8 +90,26 @@ public class GlobalExceptionHandler {
         return ErrorResponse.of(errorCode);
     }
 
+    /**
+     * 요청 파라미터에 대한 유효성 검증 실패 시 발생
+     */
     @ExceptionHandler(HandlerMethodValidationException.class)
     public ErrorResponse handleHandlerMethodValidationException(HandlerMethodValidationException e) {
+        GlobalErrorCode errorCode = GlobalErrorCode.METHOD_VALIDATION_FAILED;
+        logException(e, errorCode);
+
+        List<String> errorMessages = e.getAllErrors().stream()
+                .map(MessageSourceResolvable::getDefaultMessage)
+                .toList();
+
+        return ErrorResponse.of(errorCode, errorMessages);
+    }
+
+    /**
+     * RequestBody에 대한 유효성 검증 실패 시 발생
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         GlobalErrorCode errorCode = GlobalErrorCode.METHOD_VALIDATION_FAILED;
         logException(e, errorCode);
 

--- a/src/main/java/org/ject/support/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/ject/support/common/exception/GlobalExceptionHandler.java
@@ -3,11 +3,13 @@ package org.ject.support.common.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.ject.support.common.response.ErrorResponse;
 import org.springframework.context.MessageSourceResolvable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -108,6 +110,7 @@ public class GlobalExceptionHandler {
     /**
      * RequestBody에 대한 유효성 검증 실패 시 발생
      */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         GlobalErrorCode errorCode = GlobalErrorCode.METHOD_VALIDATION_FAILED;

--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
@@ -60,7 +60,7 @@ public class ApplyController implements ApplyApiSpec {
     @GetMapping("/status")
     @PreAuthorize("hasRole('ROLE_APPLY')")
     public ApplyStatusResponse checkApplyStatus(@AuthPrincipal Long memberId) {
-        return applyUsecase.checkApplySubmit(memberId);
+        return applyUsecase.checkApplyStatus(memberId);
     }
 
     @Override

--- a/src/main/java/org/ject/support/domain/apply/dto/ApplyProfileRequest.java
+++ b/src/main/java/org/ject/support/domain/apply/dto/ApplyProfileRequest.java
@@ -4,10 +4,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import java.util.List;
+import jakarta.validation.constraints.Size;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
+
+import java.util.List;
 
 public record ApplyProfileRequest(
         @NotBlank(message = "이름을 입력해주세요")
@@ -27,6 +29,7 @@ public record ApplyProfileRequest(
         ExperiencePeriod experiencePeriod,
 
         @NotEmpty(message = "관심 도메인을 최소 1개 이상 선택해주세요")
+        @Size(min = 1, max = 3, message = "관심 도메인은 최소 1개부터 최대 3개까지 선택 가능합니다.")
         List<String> interestedDomains
 ) {
 }

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -177,7 +177,7 @@ public class ApplyService implements ApplyUsecase {
     }
 
     @Override
-    @PeriodAccessible
+    @PeriodAccessible(permitAllJob = true)
     @Transactional
     public void saveProfile(Long memberId, ApplyProfileRequest request) {
         var member = memberRepository.findById(memberId)

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -170,7 +170,7 @@ public class ApplyService implements ApplyUsecase {
 
     @Override
     @PeriodAccessible(permitAllJob = true)
-    public ApplyStatusResponse checkApplySubmit(Long memberId) {
+    public ApplyStatusResponse checkApplyStatus(Long memberId) {
         return applyRepository.findByMemberId(memberId)
                 .map(ApplyStatusResponse::of)
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
@@ -24,7 +24,7 @@ public interface ApplyUsecase {
                            Map<String, String> answers,
                            List<ApplyPortfolioDto> portfolios);
 
-    ApplyStatusResponse checkApplySubmit(Long memberId);
+    ApplyStatusResponse checkApplyStatus(Long memberId);
 
     void saveProfile(Long memberId, ApplyProfileRequest request);
 }

--- a/src/main/java/org/ject/support/domain/member/controller/MemberApiSpec.java
+++ b/src/main/java/org/ject/support/domain/member/controller/MemberApiSpec.java
@@ -15,8 +15,8 @@ public interface MemberApiSpec {
     @Operation(
             summary = "회원 등록",
             description = "PIN 번호를 암호화하여 임시 회원을 생성합니다. 인증번호 검증 후 발급받은 토큰을 통해 인증된 사용자만 접근 가능합니다.")
-    boolean registerMember(HttpServletRequest request, HttpServletResponse response,
-                           @Valid @RequestBody MemberDto.RegisterRequest registerRequest);
+    boolean registerTempMember(HttpServletRequest request, HttpServletResponse response,
+                               @Valid @RequestBody MemberDto.RegisterRequest registerRequest);
 
     @Operation(
             summary = "임시회원의 최초 정보 등록",

--- a/src/main/java/org/ject/support/domain/member/controller/MemberController.java
+++ b/src/main/java/org/ject/support/domain/member/controller/MemberController.java
@@ -36,8 +36,8 @@ public class MemberController implements MemberApiSpec {
     @Override
     @PostMapping("/apply")
     @PreAuthorize("hasRole('ROLE_VERIFICATION')")
-    public boolean registerMember(HttpServletRequest request, HttpServletResponse response,
-                                  @Valid @RequestBody MemberDto.RegisterRequest registerRequest) {
+    public boolean registerTempMember(HttpServletRequest request, HttpServletResponse response,
+                                      @Valid @RequestBody MemberDto.RegisterRequest registerRequest) {
 
         // 쿠키에서 verification 토큰 추출
         String token = jwtTokenProvider.resolveVerificationToken(request);

--- a/src/main/java/org/ject/support/domain/member/event/TempMemberRegisteredEvent.java
+++ b/src/main/java/org/ject/support/domain/member/event/TempMemberRegisteredEvent.java
@@ -1,9 +1,0 @@
-package org.ject.support.domain.member.event;
-
-import org.ject.support.domain.member.entity.Member;
-
-public record TempMemberRegisteredEvent(Long memberId) {
-    public static TempMemberRegisteredEvent of(Member member) {
-        return new TempMemberRegisteredEvent(member.getId());
-    }
-}

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -147,7 +147,7 @@ class ApplyServiceTest extends UnitTestSupport {
                 ));
 
         // when
-        ApplyStatusResponse result = applyService.checkApplySubmit(1L);
+        ApplyStatusResponse result = applyService.checkApplyStatus(1L);
 
         // then
         assertThat(result).isEqualTo(new ApplyStatusResponse(TEMP_SAVED));
@@ -165,7 +165,7 @@ class ApplyServiceTest extends UnitTestSupport {
                 ));
 
         // when
-        ApplyStatusResponse result = applyService.checkApplySubmit(1L);
+        ApplyStatusResponse result = applyService.checkApplyStatus(1L);
 
         // then
         assertThat(result).isEqualTo(new ApplyStatusResponse(SUBMITTED));


### PR DESCRIPTION
## #️⃣연관된 이슈

close #302 

## 📝 작업 내용
#290 에서 아래 사항을 추가 개선했습니다.

- RequestBody에 대한 유효성 검증 실패 시 발생하는 예외 처리 코드 추가
- ApplyProfileRequest의 interestedDomains 필드에 최대 개수 검증 어노테이션 추가
- ApplyService의 checkApplySubmit 메서드 네이밍 개선
- MemberService의 registerMember 메서드 네이밍 개선
- TempMemberRegisteredEvent 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 요청 본문 검증 실패에 대한 상세한 오류 메시지 반환 기능 추가

* **버그 수정**
  * 지원 현황 조회 기능 개선

* **개선사항**
  * 관심 분야 입력 유효성 검사 추가
  * 프로필 저장 접근 제어 정책 업데이트
  * 멤버 등록 프로세스 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->