### PR TITLE
[FEAT] 제출 완료된 지원서 수 조회

### DIFF
--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyApiSpec.java
@@ -4,11 +4,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.ject.support.domain.admin.dto.SubmittedApplyBulkDeleteRequest;
+import org.ject.support.domain.admin.dto.SubmittedApplyCountResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Submitted Apply", description = "제출된 지원서 관리 API")
 public interface SubmittedApplyApiSpec {
+
+    @Operation(
+            summary = "제출된 지원서 수 조회",
+            description = "제출된 상태의 지원서 총 개수를 조회합니다.")
+    SubmittedApplyCountResponse getSubmittedApplyCount();
 
     @Operation(
             summary = "제출된 지원서 삭제",

--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
@@ -3,9 +3,11 @@ package org.ject.support.domain.admin.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.admin.dto.SubmittedApplyBulkDeleteRequest;
+import org.ject.support.domain.admin.dto.SubmittedApplyCountResponse;
 import org.ject.support.domain.admin.service.SubmittedApplyService;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +19,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class SubmittedApplyController implements SubmittedApplyApiSpec {
 
     private final SubmittedApplyService submittedApplyService;
+
+    @Override
+    @GetMapping("/count")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public SubmittedApplyCountResponse getSubmittedApplyCount() {
+        return submittedApplyService.countSubmittedApply();
+    }
 
     @Override
     @DeleteMapping("/{applyId}")

--- a/src/main/java/org/ject/support/domain/admin/dto/SubmittedApplyCountResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/SubmittedApplyCountResponse.java
@@ -1,0 +1,11 @@
+package org.ject.support.domain.admin.dto;
+
+public record SubmittedApplyCountResponse(
+        Long count
+) {
+    public SubmittedApplyCountResponse {
+        if (count == null) {
+            count = 0L;
+        }
+    }
+}

--- a/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.admin.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.admin.dto.SubmittedApplyCountResponse;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.Apply.Status;
 import org.ject.support.domain.apply.exception.ApplyErrorCode;
@@ -16,6 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class SubmittedApplyService {
 
     private final ApplyRepository applyRepository;
+
+    public SubmittedApplyCountResponse countSubmittedApply() {
+        Long count = applyRepository.countByStatus(Status.SUBMITTED);
+        return new SubmittedApplyCountResponse(count);
+    }
 
     @Transactional
     public void deleteSubmittedApply(final Long applyId) {

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -21,4 +21,7 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
     @Query("select a from Apply a join fetch a.member m where a.id in :applyIds and a.status = :status")
     List<Apply> findAllByIdAndStatusWithMember(@Param("applyIds") List<Long> applyIds, @Param("status") Apply.Status status);
+
+    @Query("select COUNT(a) FROM Apply a WHERE a.status = :status")
+    Long countByStatus(@Param("status") Apply.Status status);
 }

--- a/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
@@ -3,11 +3,14 @@ package org.ject.support.domain.admin.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.Optional;
 import org.ject.support.base.UnitTestSupport;
+import org.ject.support.domain.admin.dto.SubmittedApplyCountResponse;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.Apply.Status;
@@ -148,5 +151,35 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         assertThatThrownBy(() -> submittedApplyService.deleteSubmittedApplies(applyIds))
                 .isInstanceOf(ApplyException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
+    }
+
+    @Test
+    void 제출된_지원서_수_조회_성공() {
+        // given
+        Long expectedCount = 10L;
+        given(applyRepository.countByStatus(Status.SUBMITTED))
+                .willReturn(expectedCount);
+
+        // when
+        SubmittedApplyCountResponse response = submittedApplyService.countSubmittedApply();
+
+        // then
+        assertThat(response.count()).isEqualTo(expectedCount);
+        then(applyRepository).should(times(1)).countByStatus(Status.SUBMITTED);
+    }
+
+    @Test
+    void 제출된_지원서가_없을_때_0_반환() {
+        // given
+        Long expectedCount = 0L;
+        given(applyRepository.countByStatus(Status.SUBMITTED))
+                .willReturn(expectedCount);
+
+        // when
+        SubmittedApplyCountResponse response = submittedApplyService.countSubmittedApply();
+
+        // then
+        assertThat(response.count()).isZero();
+        then(applyRepository).should(times(1)).countByStatus(Status.SUBMITTED);
     }
 }

--- a/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
@@ -82,9 +82,47 @@ class ApplyRepositoryTest {
         List<Apply> result = applyRepository.findByRecruitAndStatus(beRecruit, TEMP_SAVED);
 
         // then
-        assertThat(result).hasSize(2);
-        assertThat(result).containsExactlyInAnyOrder(be2TempApply, be3TempApply);
+        assertThat(result)
+                .hasSize(2)
+                .containsExactlyInAnyOrder(be2TempApply, be3TempApply);
     }
+
+    @Test
+    void 상태별_지원서_수_조회_성공() {
+        // given
+        Member feApplicant = createMember("emailFE@test.com", Role.APPLY);
+        Member beApplicant = createMember("emailBE@test.com", Role.APPLY);
+        memberRepository.saveAll(List.of(feApplicant, beApplicant));
+
+        Apply feTempApply = getApply(feApplicant, feRecruit, TEMP_SAVED);
+        Apply beSubmitApply = getApply(beApplicant, beRecruit, SUBMITTED);
+        applyRepository.saveAll(List.of(feTempApply, beSubmitApply));
+
+        // when
+        Long count = applyRepository.countByStatus(SUBMITTED);
+
+        // then
+        assertThat(count).isEqualTo(1L);
+    }
+
+    @Test
+    void 해당_상태의_지원서가_없을_때_0_반환() {
+        // given
+        Member feApplicant = createMember("emailFE@test.com", Role.APPLY);
+        Member beApplicant = createMember("emailBE@test.com", Role.APPLY);
+        memberRepository.saveAll(List.of(feApplicant, beApplicant));
+
+        Apply feTempApply = getApply(feApplicant, feRecruit, TEMP_SAVED);
+        Apply beSubmitApply = getApply(beApplicant, beRecruit, TEMP_SAVED);
+        applyRepository.saveAll(List.of(feTempApply, beSubmitApply));
+
+        // when
+        Long count = applyRepository.countByStatus(SUBMITTED);
+
+        // then
+        assertThat(count).isZero();
+    }
+
 
     private Recruit getRecruit(JobFamily jobFamily) {
         return Recruit.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈

close #296 

## 📝 작업 내용

### 제출 완료된 지원서 수를 조회하는 기능을 구현

아래는 응답 값 예시입니다.

```
{
  "status": "SUCCESS",
  "data": {
    "count": 0
  },
  "timestamp": "2025-08-08T14:10:32.123"
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 관리자 대시보드에 제출된 지원서 수 조회 기능 추가
* 제출 상태의 지원서 개수를 빠르게 확인할 수 있는 API 엔드포인트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->