### PR TITLE
[FEAT] 제출 완료된 지원서 목록 조회

### DIFF
--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyApiSpec.java
@@ -5,8 +5,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.ject.support.domain.admin.dto.SubmittedApplyBulkDeleteRequest;
 import org.ject.support.domain.admin.dto.SubmittedApplyCountResponse;
+import org.ject.support.domain.admin.dto.SubmittedApplyResponse;
+import org.ject.support.domain.member.JobFamily;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Submitted Apply", description = "제출된 지원서 관리 API")
 public interface SubmittedApplyApiSpec {
@@ -15,6 +21,12 @@ public interface SubmittedApplyApiSpec {
             summary = "제출된 지원서 수 조회",
             description = "제출된 상태의 지원서 총 개수를 조회합니다.")
     SubmittedApplyCountResponse getSubmittedApplyCount();
+
+    @Operation(
+            summary = "제출된 지원서 목록 조회",
+            description = "제출된 지원서들의 목록을 조회합니다.")
+    Page<SubmittedApplyResponse> findSubmittedApplies(@RequestParam(required = false) final JobFamily jobFamily,
+                                                      @PageableDefault(size = 15) final Pageable pageable);
 
     @Operation(
             summary = "제출된 지원서 삭제",

--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
@@ -4,13 +4,19 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.admin.dto.SubmittedApplyBulkDeleteRequest;
 import org.ject.support.domain.admin.dto.SubmittedApplyCountResponse;
+import org.ject.support.domain.admin.dto.SubmittedApplyResponse;
 import org.ject.support.domain.admin.service.SubmittedApplyService;
+import org.ject.support.domain.member.JobFamily;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,6 +31,14 @@ public class SubmittedApplyController implements SubmittedApplyApiSpec {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public SubmittedApplyCountResponse getSubmittedApplyCount() {
         return submittedApplyService.countSubmittedApply();
+    }
+
+    @Override
+    @GetMapping
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public Page<SubmittedApplyResponse> findSubmittedApplies(@RequestParam(required = false) final JobFamily jobFamily,
+                                                             @PageableDefault(size = 15) final Pageable pageable) {
+        return submittedApplyService.findSubmittedApplies(jobFamily, pageable);
     }
 
     @Override

--- a/src/main/java/org/ject/support/domain/admin/dto/ApplicationFormResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/ApplicationFormResponse.java
@@ -2,11 +2,21 @@ package org.ject.support.domain.admin.dto;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 
 public record ApplicationFormResponse(Map<String, String> answers,
                                       List<ApplyPortfolioDto> portfolios) {
-    public static ApplicationFormResponse from(Map<String, String> answers, List<ApplyPortfolioDto> portfolios) {
+    public ApplicationFormResponse {
+        answers = Map.copyOf(
+                Optional.ofNullable(answers)
+                        .orElse(Map.of()));
+        portfolios = List.copyOf(
+                Optional.ofNullable(portfolios)
+                        .orElse(List.of()));
+    }
+    public static ApplicationFormResponse from(final Map<String, String> answers,
+                                                        final List<ApplyPortfolioDto> portfolios) {
         return new ApplicationFormResponse(answers, portfolios);
     }
 }

--- a/src/main/java/org/ject/support/domain/admin/dto/ApplicationFormResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/ApplicationFormResponse.java
@@ -1,0 +1,12 @@
+package org.ject.support.domain.admin.dto;
+
+import java.util.List;
+import java.util.Map;
+import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
+
+public record ApplicationFormResponse(Map<String, String> answers,
+                                      List<ApplyPortfolioDto> portfolios) {
+    public static ApplicationFormResponse from(Map<String, String> answers, List<ApplyPortfolioDto> portfolios) {
+        return new ApplicationFormResponse(answers, portfolios);
+    }
+}

--- a/src/main/java/org/ject/support/domain/admin/dto/SubmittedApplyResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/SubmittedApplyResponse.java
@@ -2,6 +2,8 @@ package org.ject.support.domain.admin.dto;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.member.JobFamily;
@@ -24,7 +26,10 @@ public record SubmittedApplyResponse(
                 apply.getMember().getPhoneNumber(),
                 apply.getMember().getEmail(),
                 apply.getMember().getJobFamily(),
-                !apply.getApplicationForm().getPortfolios().isEmpty(),
+                Optional.ofNullable(apply.getApplicationForm())
+                        .map(ApplicationForm::getPortfolios)
+                        .map(portfolioList -> !portfolioList.isEmpty())
+                        .orElse(false),
                 ApplicationFormResponse.from(answers, portfolios)
         );
     }

--- a/src/main/java/org/ject/support/domain/admin/dto/SubmittedApplyResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/SubmittedApplyResponse.java
@@ -1,0 +1,31 @@
+package org.ject.support.domain.admin.dto;
+
+import java.util.List;
+import java.util.Map;
+import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
+import org.ject.support.domain.member.JobFamily;
+
+public record SubmittedApplyResponse(
+        Long applyId,
+        String name,
+        String phoneNumber,
+        String email,
+        JobFamily jobFamily,
+        boolean hasPortfolio,
+        ApplicationFormResponse applicationFormResponse
+) {
+    public static SubmittedApplyResponse from(Apply apply,
+                                                        Map<String, String> answers,
+                                                        List<ApplyPortfolioDto> portfolios) {
+        return new SubmittedApplyResponse(
+                apply.getId(),
+                apply.getMember().getName(),
+                apply.getMember().getPhoneNumber(),
+                apply.getMember().getEmail(),
+                apply.getMember().getJobFamily(),
+                !apply.getApplicationForm().getPortfolios().isEmpty(),
+                ApplicationFormResponse.from(answers, portfolios)
+        );
+    }
+}

--- a/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.admin.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.data.PageResponse;
 import org.ject.support.common.util.String2MapSerializer;
@@ -41,9 +42,14 @@ public class SubmittedApplyService {
     }
 
     private SubmittedApplyResponse toSubmittedApplyResponse(final Apply apply) {
-        ApplicationForm submittedApplicationForm = apply.getApplicationForm();
-        Map<String, String> content = string2MapSerializer.serializeAsMap(submittedApplicationForm.getContent());
-        List<ApplyPortfolioDto> portfolios = submittedApplicationForm.getPortfolios()
+        ApplicationForm applicationForm = apply.getApplicationForm();
+        Map<String, String> content = Optional.ofNullable(applicationForm)
+                .map(ApplicationForm::getContent)
+                .map(string2MapSerializer::serializeAsMap)
+                .orElse(Map.of());
+        List<ApplyPortfolioDto> portfolios = Optional.ofNullable(applicationForm)
+                .map(ApplicationForm::getPortfolios)
+                .orElse(List.of())
                 .stream()
                 .map(ApplyPortfolioDto::from)
                 .toList();

--- a/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
@@ -1,14 +1,23 @@
 package org.ject.support.domain.admin.service;
 
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.PageResponse;
+import org.ject.support.common.util.String2MapSerializer;
 import org.ject.support.domain.admin.dto.SubmittedApplyCountResponse;
+import org.ject.support.domain.admin.dto.SubmittedApplyResponse;
+import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.Apply.Status;
+import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.exception.ApplyErrorCode;
 import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.domain.apply.repository.ApplyRepository;
+import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +26,30 @@ import org.springframework.transaction.annotation.Transactional;
 public class SubmittedApplyService {
 
     private final ApplyRepository applyRepository;
+    private final String2MapSerializer string2MapSerializer;
+
+    @Transactional(readOnly = true)
+    public Page<SubmittedApplyResponse> findSubmittedApplies(final JobFamily jobFamily,
+                                                             final Pageable pageable) {
+        Page<Apply> applyPage = applyRepository.findSubmittedApplies(jobFamily, pageable);
+
+        List<SubmittedApplyResponse> content = applyPage.getContent().stream()
+                .map(this::toSubmittedApplyResponse)
+                .toList();
+
+        return PageResponse.from(content, pageable, applyPage.getTotalElements());
+    }
+
+    private SubmittedApplyResponse toSubmittedApplyResponse(final Apply apply) {
+        ApplicationForm submittedApplicationForm = apply.getApplicationForm();
+        Map<String, String> content = string2MapSerializer.serializeAsMap(submittedApplicationForm.getContent());
+        List<ApplyPortfolioDto> portfolios = submittedApplicationForm.getPortfolios()
+                .stream()
+                .map(ApplyPortfolioDto::from)
+                .toList();
+
+        return SubmittedApplyResponse.from(apply, content, portfolios);
+    }
 
     public SubmittedApplyCountResponse countSubmittedApply() {
         Long count = applyRepository.countByStatus(Status.SUBMITTED);

--- a/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
@@ -51,6 +51,7 @@ public class SubmittedApplyService {
         return SubmittedApplyResponse.from(apply, content, portfolios);
     }
 
+    @Transactional(readOnly = true)
     public SubmittedApplyCountResponse countSubmittedApply() {
         Long count = applyRepository.countByStatus(Status.SUBMITTED);
         return new SubmittedApplyCountResponse(count);

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepository.java
@@ -1,0 +1,11 @@
+package org.ject.support.domain.apply.repository;
+
+import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.member.JobFamily;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ApplyQueryRepository {
+    Page<Apply> findSubmittedApplies(final JobFamily jobFamily,
+                                     final Pageable pageable);
+}

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryImpl.java
@@ -1,0 +1,63 @@
+package org.ject.support.domain.apply.repository;
+
+import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
+import static org.ject.support.domain.apply.domain.QApplicationForm.applicationForm;
+import static org.ject.support.domain.apply.domain.QApply.apply;
+import static org.ject.support.domain.apply.domain.QPortfolio.portfolio;
+import static org.ject.support.domain.member.entity.QMember.member;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPQLQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.PageResponse;
+import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.member.JobFamily;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ApplyQueryRepositoryImpl implements ApplyQueryRepository {
+
+    private final JPQLQueryFactory queryFactory;
+
+    @Override
+    public Page<Apply> findSubmittedApplies(final JobFamily jobFamily,
+                                            final Pageable pageable) {
+        List<Apply> content = queryFactory
+                .selectFrom(apply)
+                .join(apply.member, member).fetchJoin()
+                .join(apply.applicationForm, applicationForm).fetchJoin()
+                .leftJoin(apply.applicationForm.portfolios, portfolio).fetchJoin()
+                .where(
+                        apply.member.isDeleted.eq(false),
+                        eqJobFamily(jobFamily),
+                        apply.status.eq(SUBMITTED)
+                )
+                .orderBy(apply.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(apply.count())
+                .from(apply)
+                .where(
+                        eqJobFamily(jobFamily),
+                        apply.member.isDeleted.eq(false),
+                        apply.status.eq(SUBMITTED)
+                ).fetchOne();
+
+
+        return PageResponse.from(content, pageable, total);
+    }
+
+    private BooleanExpression eqJobFamily(final JobFamily jobFamily) {
+        return Optional.ofNullable(jobFamily)
+                .map(apply.member.jobFamily::eq)
+                .orElse(null);
+    }
+}

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryImpl.java
@@ -45,9 +45,10 @@ public class ApplyQueryRepositoryImpl implements ApplyQueryRepository {
         Long total = queryFactory
                 .select(apply.count())
                 .from(apply)
+                .join(apply.member, member)
                 .where(
-                        eqJobFamily(jobFamily),
                         apply.member.isDeleted.eq(false),
+                        eqJobFamily(jobFamily),
                         apply.status.eq(SUBMITTED)
                 ).fetchOne();
 

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryImpl.java
@@ -7,7 +7,7 @@ import static org.ject.support.domain.apply.domain.QPortfolio.portfolio;
 import static org.ject.support.domain.member.entity.QMember.member;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.JPQLQueryFactory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -22,13 +22,14 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class ApplyQueryRepositoryImpl implements ApplyQueryRepository {
 
-    private final JPQLQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public Page<Apply> findSubmittedApplies(final JobFamily jobFamily,
                                             final Pageable pageable) {
         List<Apply> content = queryFactory
                 .selectFrom(apply)
+                .distinct()
                 .join(apply.member, member).fetchJoin()
                 .join(apply.applicationForm, applicationForm).fetchJoin()
                 .leftJoin(apply.applicationForm.portfolios, portfolio).fetchJoin()

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.query.Param;
 
-public interface ApplyRepository extends JpaRepository<Apply, Long> {
+public interface ApplyRepository extends JpaRepository<Apply, Long>, ApplyQueryRepository {
 
     @Query("select a from Apply a where a.member.id = :memberId")
     Optional<Apply> findByMemberId(Long memberId);

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -22,6 +22,6 @@ public interface ApplyRepository extends JpaRepository<Apply, Long>, ApplyQueryR
     @Query("select a from Apply a join fetch a.member m where a.id in :applyIds and a.status = :status")
     List<Apply> findAllByIdAndStatusWithMember(@Param("applyIds") List<Long> applyIds, @Param("status") Apply.Status status);
 
-    @Query("select COUNT(a) FROM Apply a WHERE a.status = :status")
+    @Query("select count(a) from Apply a where a.status = :status")
     Long countByStatus(@Param("status") Apply.Status status);
 }

--- a/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
@@ -9,6 +9,13 @@ import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.Optional;
+import org.ject.support.common.util.String2MapSerializer;
+import org.ject.support.domain.admin.dto.SubmittedApplyResponse;
+import org.ject.support.domain.member.JobFamily;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.admin.dto.SubmittedApplyCountResponse;
 import org.ject.support.domain.apply.domain.ApplicationForm;
@@ -32,6 +39,9 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
 
     @Mock
     private ApplyRepository applyRepository;
+
+    @Mock
+    private String2MapSerializer string2MapSerializer;
 
     private static Apply submittedApply;
 
@@ -182,4 +192,96 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         assertThat(response.count()).isZero();
         then(applyRepository).should(times(1)).countByStatus(Status.SUBMITTED);
     }
+
+    @Test
+    void 제출된_지원서_목록_조회_성공() {
+        // given
+        var pageable = PageRequest.of(0, 15);
+        var jobFamily = JobFamily.BE;
+
+        var applies = List.of(submittedApply);
+        var page = new PageImpl<>(applies, pageable, 1L);
+
+        given(applyRepository.findSubmittedApplies(jobFamily, pageable))
+                .willReturn(page);
+
+        // when
+        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        verify(applyRepository).findSubmittedApplies(jobFamily, pageable);
+    }
+
+    @Test
+    void 제출된_지원서_목록_조회시_JobFamily가_null이면_전체_조회() {
+        // given
+        var pageable = PageRequest.of(0, 15);
+        var applies = List.of(submittedApply);
+        var page = new PageImpl<>(applies, pageable, 1L);
+
+        given(applyRepository.findSubmittedApplies(null, pageable))
+                .willReturn(page);
+
+        // when
+        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(null, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        verify(applyRepository).findSubmittedApplies(null, pageable);
+    }
+
+    @Test
+    void 제출된_지원서_목록_조회시_결과가_없으면_빈_페이지_반환() {
+        // given
+        var pageable = PageRequest.of(0, 15);
+        var jobFamily = JobFamily.BE;
+        var page = new PageImpl<Apply>(List.of(), pageable, 0L);
+
+        given(applyRepository.findSubmittedApplies(jobFamily, pageable))
+                .willReturn(page);
+
+        // when
+        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, pageable);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        verify(applyRepository).findSubmittedApplies(jobFamily, pageable);
+    }
+
+    @Test
+    void 제출된_지원서_목록_조회시_페이징_정보_정확히_전달() {
+        // given
+        var pageable = PageRequest.of(1, 10, Sort.by("createdAt").descending());
+        var jobFamily = JobFamily.BE;
+
+        var member2 = Member.builder().name("김젝트2").build();
+        var apply2 = Apply.builder()
+                .id(2L)
+                .member(member2)
+                .recruit(submittedApply.getRecruit())
+                .status(Status.SUBMITTED)
+                .applicationForm(ApplicationForm.builder().build())
+                .build();
+
+        var applies = List.of(submittedApply, apply2);
+        var page = new PageImpl<>(applies, pageable, 25L);
+
+        given(applyRepository.findSubmittedApplies(jobFamily, pageable))
+                .willReturn(page);
+
+        // when
+        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(25L);
+        assertThat(result.getNumber()).isEqualTo(1);
+        assertThat(result.getSize()).isEqualTo(10);
+        verify(applyRepository).findSubmittedApplies(jobFamily, pageable);
+    }
+
 }

--- a/src/test/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryTest.java
@@ -132,7 +132,7 @@ class ApplyQueryRepositoryTest {
 
         // then
         assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getStatus()).isEqualTo(SUBMITTED);
+        assertThat(result.getContent().getFirst().getStatus()).isEqualTo(SUBMITTED);
     }
 
     @Test
@@ -154,7 +154,7 @@ class ApplyQueryRepositoryTest {
 
         // then
         assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getMember()).isEqualTo(activeMember);
+        assertThat(result.getContent().getFirst().getMember()).isEqualTo(activeMember);
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryTest.java
@@ -1,0 +1,259 @@
+package org.ject.support.domain.apply.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
+import static org.ject.support.domain.apply.domain.Apply.Status.TEMP_SAVED;
+import static org.ject.support.domain.member.JobFamily.BE;
+import static org.ject.support.domain.member.JobFamily.FE;
+import static org.ject.support.domain.member.JobFamily.PM;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.ject.support.domain.apply.domain.ApplicationForm;
+import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.Semester;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.ject.support.domain.recruit.repository.SemesterRepository;
+import org.ject.support.testconfig.QueryDslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@Import(QueryDslTestConfig.class)
+@DataJpaTest
+class ApplyQueryRepositoryTest {
+
+    @Autowired
+    ApplyRepository applyRepository;
+
+    @Autowired
+    SemesterRepository semesterRepository;
+
+    @Autowired
+    RecruitRepository recruitRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    Semester semester;
+    Recruit beRecruit;
+    Recruit feRecruit;
+    Recruit pmRecruit;
+
+    @BeforeEach
+    void setUp() {
+        semester = semesterRepository.save(Semester.builder()
+                .name("1기")
+                .isRecruiting(true)
+                .build());
+
+        beRecruit = getRecruit(BE);
+        feRecruit = getRecruit(FE);
+        pmRecruit = getRecruit(PM);
+        recruitRepository.saveAll(List.of(beRecruit, feRecruit, pmRecruit));
+    }
+
+    @Test
+    void JobFamily로_제출된_지원서_목록_조회_성공() {
+        // given
+        Member beMember1 = createMember("be1@test.com", BE);
+        Member beMember2 = createMember("be2@test.com", BE);
+        Member feMember = createMember("fe@test.com", FE);
+        memberRepository.saveAll(List.of(beMember1, beMember2, feMember));
+
+        Apply beApply1 = getApply(beMember1, beRecruit, SUBMITTED);
+        Apply beApply2 = getApply(beMember2, beRecruit, SUBMITTED);
+        Apply feApply = getApply(feMember, feRecruit, SUBMITTED);
+        applyRepository.saveAll(List.of(beApply1, beApply2, feApply));
+
+        Pageable pageable = PageRequest.of(0, 15);
+
+        // when
+        Page<Apply> result = applyRepository.findSubmittedApplies(BE, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent())
+                .extracting(Apply::getMember)
+                .containsExactlyInAnyOrder(beMember1, beMember2);
+    }
+
+    @Test
+    void JobFamily가_null이면_전체_제출된_지원서_조회() {
+        // given
+        Member beMember = createMember("be@test.com", BE);
+        Member feMember = createMember("fe@test.com", FE);
+        Member pmMember = createMember("pm@test.com", PM);
+        memberRepository.saveAll(List.of(beMember, feMember, pmMember));
+
+        Apply beApply = getApply(beMember, beRecruit, SUBMITTED);
+        Apply feApply = getApply(feMember, feRecruit, SUBMITTED);
+        Apply pmApply = getApply(pmMember, pmRecruit, SUBMITTED);
+        applyRepository.saveAll(List.of(beApply, feApply, pmApply));
+
+        Pageable pageable = PageRequest.of(0, 15);
+
+        // when
+        Page<Apply> result = applyRepository.findSubmittedApplies(null, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getTotalElements()).isEqualTo(3);
+    }
+
+    @Test
+    void 임시저장_상태는_조회되지_않음() {
+        // given
+        Member beMember1 = createMember("be1@test.com", BE);
+        Member beMember2 = createMember("be2@test.com", BE);
+        memberRepository.saveAll(List.of(beMember1, beMember2));
+
+        Apply submittedApply = getApply(beMember1, beRecruit, SUBMITTED);
+        Apply tempApply = getApply(beMember2, beRecruit, TEMP_SAVED);
+        applyRepository.saveAll(List.of(submittedApply, tempApply));
+
+        Pageable pageable = PageRequest.of(0, 15);
+
+        // when
+        Page<Apply> result = applyRepository.findSubmittedApplies(BE, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getStatus()).isEqualTo(SUBMITTED);
+    }
+
+    @Test
+    void 삭제된_회원의_지원서는_조회되지_않음() {
+        // given
+        Member activeMember = createMember("active@test.com", BE);
+        Member deletedMember = createMember("deleted@test.com", BE);
+        deletedMember.deleteProfile();
+        memberRepository.saveAll(List.of(activeMember, deletedMember));
+
+        Apply activeApply = getApply(activeMember, beRecruit, SUBMITTED);
+        Apply deletedApply = getApply(deletedMember, beRecruit, SUBMITTED);
+        applyRepository.saveAll(List.of(activeApply, deletedApply));
+
+        Pageable pageable = PageRequest.of(0, 15);
+
+        // when
+        Page<Apply> result = applyRepository.findSubmittedApplies(BE, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getMember()).isEqualTo(activeMember);
+    }
+
+    @Test
+    void 페이징_정상_작동() {
+        // given
+        for (int i = 1; i <= 25; i++) {
+            Member member = createMember("be" + i + "@test.com", BE);
+            memberRepository.save(member);
+            Apply apply = getApply(member, beRecruit, SUBMITTED);
+            applyRepository.save(apply);
+        }
+
+        Pageable pageable = PageRequest.of(1, 10);
+
+        // when
+        Page<Apply> result = applyRepository.findSubmittedApplies(BE, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(10);
+        assertThat(result.getTotalElements()).isEqualTo(25);
+        assertThat(result.getTotalPages()).isEqualTo(3);
+        assertThat(result.getNumber()).isEqualTo(1);
+    }
+
+    @Test
+    void 제출된_지원서가_없으면_빈_페이지_반환() {
+        // given
+        Pageable pageable = PageRequest.of(0, 15);
+
+        // when
+        Page<Apply> result = applyRepository.findSubmittedApplies(BE, pageable);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+    }
+
+    @Test
+    void createdAt_기준_내림차순_정렬()  {
+        // given
+        Member member1 = createMember("be1@test.com", BE);
+        Member member2 = createMember("be2@test.com", BE);
+        Member member3 = createMember("be3@test.com", BE);
+        memberRepository.saveAll(List.of(member1, member2, member3));
+
+        Apply apply1 = getApply(member1, beRecruit, SUBMITTED);
+        applyRepository.save(apply1);
+
+        Apply apply2 = getApply(member2, beRecruit, SUBMITTED);
+        applyRepository.save(apply2);
+
+        Apply apply3 = getApply(member3, beRecruit, SUBMITTED);
+        applyRepository.save(apply3);
+
+        Pageable pageable = PageRequest.of(0, 15);
+
+        // when
+        Page<Apply> result = applyRepository.findSubmittedApplies(BE, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getContent().get(0)).isEqualTo(apply3);
+        assertThat(result.getContent().get(1)).isEqualTo(apply2);
+        assertThat(result.getContent().get(2)).isEqualTo(apply1);
+    }
+
+    private Recruit getRecruit(JobFamily jobFamily) {
+        return Recruit.builder()
+                .semester(semester)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .jobFamily(jobFamily)
+                .build();
+    }
+
+    private Apply getApply(Member member, Recruit recruit, Apply.Status status) {
+        ApplicationForm applicationForm = ApplicationForm.builder()
+                .build();
+
+        Apply apply = Apply.builder()
+                .recruit(recruit)
+                .member(member)
+                .status(status)
+                .applicationForm(applicationForm)
+                .build();
+
+        setField(applicationForm, "apply", apply);
+
+        return apply;
+    }
+
+    private Member createMember(String email, JobFamily jobFamily) {
+        return Member.builder()
+                .email(email)
+                .jobFamily(jobFamily)
+                .semesterId(1L)
+                .role(Role.APPLY)
+                .pin("123456")
+                .status(MemberStatus.ACTIVE)
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #297

## 📝 작업 내용


### 제출 완료된 지원서 목록 조회를 구현했습니다.

- 상태가 SUBMITTED인 지원서만 조회되도록 구현했습니다.
- 정렬 기준: 기본 등록 순
- 페이징: 기본 size=15
- 직군에 대한 동적 쿼리

#### 응답값 예시

```
{
  "status": "SUCCESS",
  "data": {
    "totalElements": 0,
    "totalPages": 0,
    "size": 0,
    "content": [
      {
        "applyId": 0,
        "name": "string",
        "phoneNumber": "string",
        "email": "string",
        "jobFamily": "PM",
        "hasPortfolio": true,
        "applicationFormResponse": {
          "answers": {
            "additionalProp1": "string",
            "additionalProp2": "string",
            "additionalProp3": "string"
          },
          "portfolios": [
            {
              "fileUrl": "string",
              "fileName": "string",
              "fileSize": "string",
              "sequence": "string"
            }]}}]
  },
  "timestamp": "2025-08-08T14:10:32.123"
}
```

#### 실행 계획 (EXPLAIN ANALYZE 결과)

인덱스 기반 탐색(Index lookup)으로 잘 수행 되는 걸 확인했습니다!
- 풀 스캔이 발생하지 않았습니다.

```
-> Index lookup on af1_0 using idx_application_form_apply (apply_id = a1_0.id) (cost=0.35 rows=1) 
-> Index lookup on p1_0 using idx_portfolio_form_sequence (application_form_id = af1_0.id) (cost=0.35 rows=1) (never executed)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 제출 지원서 조회 API 추가: 직무별 필터 옵션과 기본 페이지 크기(15)를 갖춘 페이지네이션으로 지원자 정보, 포트폴리오, 응답 내용 포함한 페이징 응답 제공.
  * 제출 지원서 응답 구조 및 응용폼/포트폴리오 응답 타입 추가.
  * 제출 조회용 쿼리 및 구현체 추가로 효율적 필터링·정렬 지원.

* **테스트**
  * 서비스·쿼리 레이어 테스트 추가: 필터링, 페이징, 정렬, 비어있는 결과 등 다양한 시나리오 검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->