### PR TITLE
임시 저장한 지원서 수 조회 기능 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/admin/controller/AdminTempApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/AdminTempApplyApiSpec.java
@@ -2,10 +2,11 @@ package org.ject.support.domain.admin.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.ject.support.domain.admin.dto.TempSavedApplyCountResponse;
 import org.ject.support.domain.apply.dto.TempApplyDetailResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@Tag(name = "Admin", description = "임시 저장된 지원서 관리")
+@Tag(name = "Temporary Apply", description = "임시 저장된 지원서 관리")
 public interface AdminTempApplyApiSpec {
 
     @Operation(
@@ -13,4 +14,9 @@ public interface AdminTempApplyApiSpec {
             description = "관리자가 지원자의 임시 저장된 지원서의 정보를 조회합니다."
     )
     TempApplyDetailResponse getTempApplyDetail(@PathVariable("tempApplyId") Long tempApplyId);
+
+    @Operation(
+            summary = "임시 저장한 지원서 수 조회",
+            description = "임시 저장한 지원서 총 개수를 조회합니다.")
+    TempSavedApplyCountResponse getTempSavedApplyCount();
 }

--- a/src/main/java/org/ject/support/domain/admin/controller/AdminTempApplyController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/AdminTempApplyController.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.admin.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.admin.dto.TempSavedApplyCountResponse;
 import org.ject.support.domain.admin.service.AdminTempApplyService;
 import org.ject.support.domain.apply.dto.TempApplyDetailResponse;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -20,5 +21,11 @@ public class AdminTempApplyController implements AdminTempApplyApiSpec {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public TempApplyDetailResponse getTempApplyDetail(@PathVariable("tempApplyId") Long tempApplyId) {
         return adminTempApplyService.getTempApplyDetail(tempApplyId);
+    }
+
+    @GetMapping("/count")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public TempSavedApplyCountResponse getTempSavedApplyCount() {
+        return adminTempApplyService.getTempSavedApplyCount();
     }
 }

--- a/src/main/java/org/ject/support/domain/admin/dto/TempSavedApplyCountResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/TempSavedApplyCountResponse.java
@@ -1,0 +1,11 @@
+package org.ject.support.domain.admin.dto;
+
+public record TempSavedApplyCountResponse(
+        Long count
+) {
+    public TempSavedApplyCountResponse {
+        if (count == null) {
+            count = 0L;
+        }
+    }
+}

--- a/src/main/java/org/ject/support/domain/admin/service/AdminTempApplyService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/AdminTempApplyService.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.admin.service;
 
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.util.String2MapSerializer;
+import org.ject.support.domain.admin.dto.TempSavedApplyCountResponse;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
@@ -33,5 +34,10 @@ public class AdminTempApplyService {
                         .stream()
                         .map(ApplyPortfolioDto::from)
                         .toList());
+    }
+
+    public TempSavedApplyCountResponse getTempSavedApplyCount() {
+        Long count = applyRepository.countByStatus(Apply.Status.TEMP_SAVED);
+        return new TempSavedApplyCountResponse(count);
     }
 }

--- a/src/test/java/org/ject/support/domain/admin/service/AdminTempApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/AdminTempApplyServiceTest.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.admin.service;
 
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.util.String2MapSerializer;
+import org.ject.support.domain.admin.dto.TempSavedApplyCountResponse;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.dto.TempApplyDetailResponse;
@@ -73,5 +74,37 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
         // then
         verify(applyRepository).findByIdAndStatusWithMember(tempApplyId, Apply.Status.TEMP_SAVED);
         assertThat(result.applyId()).isEqualTo(tempApplyId);
+    }
+
+    @Test
+    void 임시_저장된_지원서의_총_개수를_조회한다() {
+        // given
+        Apply.Status targetStatus = Apply.Status.TEMP_SAVED;
+        Long tempSavedCount = 5L;
+        given(applyRepository.countByStatus(targetStatus))
+                .willReturn(tempSavedCount);
+
+        // when
+        TempSavedApplyCountResponse result = adminTempApplyService.getTempSavedApplyCount();
+
+        // then
+        verify(applyRepository).countByStatus(targetStatus);
+        assertThat(result).isEqualTo(new TempSavedApplyCountResponse(tempSavedCount));
+    }
+
+    @Test
+    void 임시_저장된_지원서의_총_개수가_0개일_경우_0을_조회한다() {
+        // given
+        Apply.Status targetStatus = Apply.Status.TEMP_SAVED;
+        Long tempSavedCount = 0L;
+        given(applyRepository.countByStatus(targetStatus))
+                .willReturn(tempSavedCount);
+
+        // when
+        TempSavedApplyCountResponse result = adminTempApplyService.getTempSavedApplyCount();
+
+        // then
+        verify(applyRepository).countByStatus(targetStatus);
+        assertThat(result).isEqualTo(new TempSavedApplyCountResponse(tempSavedCount));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #291 

## 📝 작업 내용

### 임시 저장한 지원서 수 추가하기 API 개발
 - @023-dev 님이 개발해주신 [[FEAT] 제출 완료된 지원서 수 조회 #307](https://github.com/JECT-Study/JECT-Official-WebSite-Server/pull/307)를 참고해서 개발했습니다. 🙇‍♂️
 - 임시 저장된 지원서 관리 Swagger Group 을 변경해 주었습니다.
     - AS-IS : ADMIN
     - TO-BE : Temporary Apply
 
 ### SWAGGER UI
<img width="824" height="786" alt="image" src="https://github.com/user-attachments/assets/505c0674-bb90-47fb-af3b-67b9fad2d671" />

## Description
 - 코드를 작성하다 보니 어드민 > 지원서 관리 > **제출된 지원서**, **임시 저장된 지원서 관리** 2개의 파트가 비슷한 부분이 많아 추후 통합할 부분은 통합하면 좋을꺼 같아요!
   - API Endpoint 규칙 통합
   - 코드 재사용 ex)Response, Request Class


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
- 임시 저장된 신청의 총 건수를 조회하는 기능이 추가되었습니다. 관리자는 이 기능을 활용하여 시스템 내 임시 저장 상태의 신청이 정확히 몇 건인지 한눈에 파악할 수 있으며, 신청 현황을 보다 효율적으로 관리하고 실시간으로 모니터링할 수 있게 되었습니다.

## 테스트
- 새로 추가된 기능의 정확성과 안정성을 확보하기 위해 여러 시나리오를 포함한 단위 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->