### PR TITLE
[FEAT] 제출 완료된 지원서 수정

### DIFF
--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyApiSpec.java
@@ -48,6 +48,6 @@ public interface SubmittedApplyApiSpec {
 
     @Operation(
             summary = "제출된 지원서 다수 삭제",
-            description = "선택한 다수의 제출된 지원서들을 삭제합니다.")
-    void deleteSubmittedApplies(@RequestBody @Valid final SubmittedApplyBulkDeleteRequest request);
+            description = "선택한 다수의 제출된 지원서들을 삭제합니다. 삭제한 수를 반환합니다.")
+    int deleteSubmittedApplies(@RequestBody @Valid final SubmittedApplyBulkDeleteRequest request);
 }

--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyApiSpec.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import org.ject.support.domain.admin.dto.SubmittedApplyBulkDeleteRequest;
 import org.ject.support.domain.admin.dto.SubmittedApplyCountResponse;
 import org.ject.support.domain.admin.dto.SubmittedApplyDetailResponse;
+import org.ject.support.domain.admin.dto.SubmittedApplyEditRequest;
 import org.ject.support.domain.admin.dto.SubmittedApplyResponse;
 import org.ject.support.domain.member.JobFamily;
 import org.springframework.data.domain.Page;
@@ -33,6 +34,12 @@ public interface SubmittedApplyApiSpec {
             summary = "제출된 지원서 상세 조회",
             description = "전달한 ID에 해당하는 제출된 지원서의 상세 정보를 조회합니다.")
     SubmittedApplyDetailResponse findSubmittedApplyDetail(@PathVariable("applyId") final Long applyId);
+
+    @Operation(
+            summary = "제출된 지원서 수정",
+            description = "전달한 ID에 해당하는 제출된 지원서의 정보를 수정 합니다.")
+    void editSubmittedApply(@PathVariable("applyId") final Long applyId,
+                            @RequestBody @Valid final SubmittedApplyEditRequest request);
 
     @Operation(
             summary = "제출된 지원서 삭제",

--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.admin.dto.SubmittedApplyBulkDeleteRequest;
 import org.ject.support.domain.admin.dto.SubmittedApplyCountResponse;
 import org.ject.support.domain.admin.dto.SubmittedApplyDetailResponse;
+import org.ject.support.domain.admin.dto.SubmittedApplyEditRequest;
 import org.ject.support.domain.admin.dto.SubmittedApplyResponse;
 import org.ject.support.domain.admin.service.SubmittedApplyService;
 import org.ject.support.domain.member.JobFamily;
@@ -15,6 +16,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -47,6 +49,13 @@ public class SubmittedApplyController implements SubmittedApplyApiSpec {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public SubmittedApplyDetailResponse findSubmittedApplyDetail(@PathVariable("applyId") final Long applyId) {
         return submittedApplyService.findSubmittedApplyDetail(applyId);
+    }
+
+    @Override
+    @PutMapping("{applyId}")
+    public void editSubmittedApply(@PathVariable("applyId") final Long applyId,
+                                   @RequestBody @Valid final SubmittedApplyEditRequest request) {
+        submittedApplyService.updateSubmittedApply(applyId, request);
     }
 
     @Override

--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
@@ -52,7 +52,7 @@ public class SubmittedApplyController implements SubmittedApplyApiSpec {
     }
 
     @Override
-    @PutMapping("{applyId}")
+    @PutMapping("/{applyId}")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void editSubmittedApply(@PathVariable("applyId") final Long applyId,
                                    @RequestBody @Valid final SubmittedApplyEditRequest request) {

--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
@@ -68,7 +68,7 @@ public class SubmittedApplyController implements SubmittedApplyApiSpec {
     @Override
     @DeleteMapping
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    public void deleteSubmittedApplies(@RequestBody @Valid final SubmittedApplyBulkDeleteRequest request) {
-        submittedApplyService.deleteSubmittedApplies(request.applyIds());
+    public int deleteSubmittedApplies(@RequestBody @Valid final SubmittedApplyBulkDeleteRequest request) {
+        return submittedApplyService.deleteSubmittedApplies(request.applyIds());
     }
 }

--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
@@ -53,6 +53,7 @@ public class SubmittedApplyController implements SubmittedApplyApiSpec {
 
     @Override
     @PutMapping("{applyId}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void editSubmittedApply(@PathVariable("applyId") final Long applyId,
                                    @RequestBody @Valid final SubmittedApplyEditRequest request) {
         submittedApplyService.updateSubmittedApply(applyId, request);

--- a/src/main/java/org/ject/support/domain/admin/dto/SubmittedApplyEditRequest.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/SubmittedApplyEditRequest.java
@@ -1,0 +1,25 @@
+package org.ject.support.domain.admin.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.util.List;
+import java.util.Map;
+import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
+import org.ject.support.domain.member.JobFamily;
+
+public record SubmittedApplyEditRequest(
+        @NotBlank @Pattern(regexp = "^[가-힣]{1,5}$", message = "한글 1~5글자만 입력 가능합니다.")
+        String name,
+        @NotBlank @Pattern(regexp = "^010\\d{8}$", message = "010으로 시작하는 11자리 숫자를 입력하세요.")
+        String phoneNumber,
+        @NotBlank @Email
+        String email,
+        @NotNull(message = "포지션은 필수입니다.")
+        JobFamily jobFamily,
+        @NotNull(message = "답변은 필수입니다.")
+        Map<String, String> answers,
+        List<ApplyPortfolioDto> portfolios
+) {
+}

--- a/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
@@ -92,15 +92,6 @@ public class SubmittedApplyService {
                 .updateContentAndPortfolios(newContent, newPortfolios);
     }
 
-    private void validateQuestions(final Map<String, String> answers, final Recruit recruit) {
-        answers.keySet().stream()
-                .map(Long::parseLong)
-                .filter(recruit::isInvalidQuestionId)
-                .forEach(key -> {
-                    throw new QuestionException(QuestionErrorCode.NOT_FOUND_QUESTION);
-                });
-    }
-
     @Transactional
     public void deleteSubmittedApply(final Long applyId) {
         Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED)
@@ -155,6 +146,15 @@ public class SubmittedApplyService {
         if (apply.isNotSubmitted()) {
             throw new ApplyException(ApplyErrorCode.NOT_FOUND_SUBMITTED_APPLICATION_FORM);
         }
+    }
+
+    private void validateQuestions(final Map<String, String> answers, final Recruit recruit) {
+        answers.keySet().stream()
+                .map(Long::parseLong)
+                .filter(recruit::isInvalidQuestionId)
+                .forEach(key -> {
+                    throw new QuestionException(QuestionErrorCode.NOT_FOUND_QUESTION);
+                });
     }
 
     private void deleteProfileAndApplicationForm(final Apply apply) {

--- a/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
@@ -101,7 +101,7 @@ public class SubmittedApplyService {
     }
 
     @Transactional
-    public void deleteSubmittedApplies(final List<Long> applyIds) {
+    public int deleteSubmittedApplies(final List<Long> applyIds) {
         final List<Long> distinctIds = applyIds.stream().distinct().toList();
         final List<Apply> applies = applyRepository.findAllByIdAndStatusWithMember(distinctIds, Status.SUBMITTED);
 
@@ -110,6 +110,7 @@ public class SubmittedApplyService {
         }
 
         applies.forEach(this::deleteProfileAndApplicationForm);
+        return applies.size();
     }
 
     private SubmittedApplyDetailResponse toSubmittedApplyDetailResponse(final Apply apply) {

--- a/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
@@ -5,19 +5,26 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.data.PageResponse;
+import org.ject.support.common.util.Map2JsonSerializer;
 import org.ject.support.common.util.String2MapSerializer;
 import org.ject.support.domain.admin.dto.SubmittedApplyCountResponse;
 import org.ject.support.domain.admin.dto.SubmittedApplyDetailResponse;
+import org.ject.support.domain.admin.dto.SubmittedApplyEditRequest;
 import org.ject.support.domain.admin.dto.SubmittedApplyResponse;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.Apply.Status;
+import org.ject.support.domain.apply.domain.Portfolio;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.exception.ApplyErrorCode;
 import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.domain.apply.repository.ApplyRepository;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.entity.MemberEditor;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.exception.QuestionErrorCode;
+import org.ject.support.domain.recruit.exception.QuestionException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -29,6 +36,7 @@ public class SubmittedApplyService {
 
     private final ApplyRepository applyRepository;
     private final String2MapSerializer string2MapSerializer;
+    private final Map2JsonSerializer map2JsonSerializer;
 
     @Transactional(readOnly = true)
     public Page<SubmittedApplyResponse> findSubmittedApplies(final JobFamily jobFamily,
@@ -53,6 +61,44 @@ public class SubmittedApplyService {
     public SubmittedApplyCountResponse countSubmittedApply() {
         Long count = applyRepository.countByStatus(Status.SUBMITTED);
         return new SubmittedApplyCountResponse(count);
+    }
+
+    @Transactional
+    public void updateSubmittedApply(final Long applyId,
+                                     final SubmittedApplyEditRequest request) {
+        Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED)
+                .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
+        ensureSubmitted(apply);
+
+        Member member = apply.getMember();
+        MemberEditor memberEditor = member.toEditor()
+                .name(request.name())
+                .phoneNumber(request.phoneNumber())
+                .email(request.email())
+                .jobFamily(request.jobFamily())
+                .build();
+        member.edit(memberEditor);
+
+        Map<String, String> answers = request.answers();
+        validateQuestions(answers, apply.getRecruit());
+        String newContent = map2JsonSerializer.serializeAsString(answers);
+
+        List<Portfolio> newPortfolios = request.portfolios()
+                .stream()
+                .map(ApplyPortfolioDto::toEntity)
+                .toList();
+
+        apply.getApplicationForm()
+                .updateContentAndPortfolios(newContent, newPortfolios);
+    }
+
+    private void validateQuestions(final Map<String, String> answers, final Recruit recruit) {
+        answers.keySet().stream()
+                .map(Long::parseLong)
+                .filter(recruit::isInvalidQuestionId)
+                .forEach(key -> {
+                    throw new QuestionException(QuestionErrorCode.NOT_FOUND_QUESTION);
+                });
     }
 
     @Transactional

--- a/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
@@ -8,10 +8,17 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import org.ject.support.common.util.Map2JsonSerializer;
 import org.ject.support.common.util.String2MapSerializer;
+import org.ject.support.domain.admin.dto.SubmittedApplyEditRequest;
 import org.ject.support.domain.admin.dto.SubmittedApplyResponse;
+import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.Question;
+import org.ject.support.domain.recruit.exception.QuestionErrorCode;
+import org.ject.support.domain.recruit.exception.QuestionException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -43,6 +50,9 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
     @Mock
     private String2MapSerializer string2MapSerializer;
 
+    @Mock
+    private Map2JsonSerializer map2JsonSerializer;
+
     private static Apply submittedApply;
 
     @BeforeEach
@@ -54,9 +64,19 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         var semester = Semester.builder()
                 .name("1")
                 .build();
+
+        var question1 = Question.builder()
+                .id(1L)
+                .build();
+        var question2 = Question.builder()
+                .id(2L)
+                .build();
+
         var recruit = Recruit.builder()
                 .semester(semester)
+                .questions(List.of(question1, question2))
                 .build();
+
         submittedApply = Apply.builder()
                 .id(applyId)
                 .member(member)
@@ -342,4 +362,125 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         assertThat(actual.applyId()).isEqualTo(submittedApply.getId());
     }
 
+    @Test
+    void 제출된_지원서_수정_성공() {
+        // given
+        var applyId = submittedApply.getId();
+        var newName = "수정된이름";
+        var newPhoneNumber = "010-1234-5678";
+        var newEmail = "updated@example.com";
+        var newJobFamily = JobFamily.FE;
+
+        var newAnswers = Map.of(
+                "1", "수정된 답변1",
+                "2", "수정된 답변2"
+        );
+
+        var newPortfolios = List.of(
+                new ApplyPortfolioDto("url1", "name1", "1", "1"),
+                new ApplyPortfolioDto("url2", "name2", "2", "2")
+        );
+
+        var request = new SubmittedApplyEditRequest(
+                newName,
+                newPhoneNumber,
+                newEmail,
+                newJobFamily,
+                newAnswers,
+                newPortfolios
+        );
+
+        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+                .willReturn(Optional.of(submittedApply));
+        given(map2JsonSerializer.serializeAsString(newAnswers))
+                .willReturn("{\"1\":\"수정된 답변1\",\"2\":\"수정된 답변2\"}");
+
+        // when
+        submittedApplyService.updateSubmittedApply(applyId, request);
+
+        // then
+        verify(applyRepository).findByIdAndStatusWithMember(applyId, Status.SUBMITTED);
+        verify(map2JsonSerializer).serializeAsString(newAnswers);
+
+        assertThat(submittedApply.getMember().getName()).isEqualTo(newName);
+        assertThat(submittedApply.getMember().getPhoneNumber()).isEqualTo(newPhoneNumber);
+        assertThat(submittedApply.getMember().getEmail()).isEqualTo(newEmail);
+        assertThat(submittedApply.getMember().getJobFamily()).isEqualTo(newJobFamily);
+    }
+
+    @Test
+    void 제출된_지원서_수정시_존재하지_않으면_예외_발생() {
+        // given
+        var applyId = 999L;
+        var request = new SubmittedApplyEditRequest(
+                "이름",
+                "010-1234-5678",
+                "test@example.com",
+                JobFamily.BE,
+                Map.of("1", "답변"),
+                List.of()
+        );
+
+        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+                .willReturn(Optional.empty());
+
+        // expected
+        assertThatThrownBy(() -> submittedApplyService.updateSubmittedApply(applyId, request))
+                .isInstanceOf(ApplyException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
+    }
+
+    @Test
+    void 제출된_지원서_수정시_유효하지_않은_질문ID면_예외_발생() {
+        // given
+        var applyId = submittedApply.getId();
+        var invalidQuestionId = "999";
+
+        var request = new SubmittedApplyEditRequest(
+                "이름",
+                "010-1234-5678",
+                "test@example.com",
+                JobFamily.BE,
+                Map.of(invalidQuestionId, "답변"),
+                List.of()
+        );
+
+        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+                .willReturn(Optional.of(submittedApply));
+
+        // expected
+        assertThatThrownBy(() -> submittedApplyService.updateSubmittedApply(applyId, request))
+                .isInstanceOf(QuestionException.class)
+                .hasFieldOrPropertyWithValue("errorCode", QuestionErrorCode.NOT_FOUND_QUESTION);
+    }
+
+    @Test
+    void 제출되지_않은_지원서_수정시_예외_발생() {
+        // given
+        var applyId = submittedApply.getId();
+        var tempSavedApply = Apply.builder()
+                .id(applyId)
+                .member(submittedApply.getMember())
+                .recruit(submittedApply.getRecruit())
+                .status(Status.TEMP_SAVED)
+                .applicationForm(ApplicationForm.builder().build())
+                .build();
+
+        var request = new SubmittedApplyEditRequest(
+                "이름",
+                "010-1234-5678",
+                "test@example.com",
+                JobFamily.BE,
+                Map.of("1", "답변"),
+                List.of()
+        );
+
+        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+                .willReturn(Optional.of(tempSavedApply));
+
+        // expected
+        assertThatThrownBy(() -> submittedApplyService.updateSubmittedApply(applyId, request))
+                .isInstanceOf(ApplyException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_SUBMITTED_APPLICATION_FORM);
+    }
 }

--- a/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
@@ -414,7 +414,7 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         var applyId = 999L;
         var request = new SubmittedApplyEditRequest(
                 "이름",
-                "010-1234-5678",
+                "01012345678",
                 "test@example.com",
                 JobFamily.BE,
                 Map.of("1", "답변"),

--- a/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
@@ -438,7 +438,7 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
 
         var request = new SubmittedApplyEditRequest(
                 "이름",
-                "010-1234-5678",
+                "01012345678",
                 "test@example.com",
                 JobFamily.BE,
                 Map.of(invalidQuestionId, "답변"),
@@ -468,7 +468,7 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
 
         var request = new SubmittedApplyEditRequest(
                 "이름",
-                "010-1234-5678",
+                "01012345678",
                 "test@example.com",
                 JobFamily.BE,
                 Map.of("1", "답변"),


### PR DESCRIPTION
## #️⃣연관된 이슈

close #299 

## 📝 작업 내용

- 제출 완료된 지원서 수정 기능
- 제출 완료된 지원서 다건 삭제 시 삭제한 지원서 수 반환



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 제출된 지원서를 수정할 수 있는 새 API 엔드포인트 추가
  * 수정 요청을 위한 입력 형식(이름, 연락처, 이메일, 직군, 답변, 포트폴리오) 도입

* **Improvements**
  * 지원서 일괄 삭제 API가 이제 삭제된 지원서 개수를 반환
  * 수정 시 답변 검증 및 직군/포트폴리오 정보 반영 강화

* **Tests**
  * 제출된 지원서 수정 관련 통합 및 예외 처리 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->