### PR TITLE
[FIX] Swagger UI Authorization Token 적용 안되는 이슈 수정

### DIFF
--- a/src/main/java/org/ject/support/common/springdoc/SpringdocConfig.java
+++ b/src/main/java/org/ject/support/common/springdoc/SpringdocConfig.java
@@ -3,8 +3,8 @@ package org.ject.support.common.springdoc;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
@@ -21,21 +21,27 @@ public class SpringdocConfig {
 
     @Bean
     public OpenAPI openAPI() {
-        Info info = new Info()
-                .title("JECT Makers API Document")
-                .version("v0.0.1")
-                .description("JECT 메이커스 팀 API 명세서입니다.");
-
-        SecurityScheme securityScheme = new SecurityScheme()
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("JWT");
+        String securitySchemeName = "bearerAuth";
 
         return new OpenAPI()
+                // API 기본 정보
+                .info(new Info()
+                        .title("JECT Makers API Document")
+                        .version("v0.0.1")
+                        .description("JECT 메이커스 팀 API 명세서입니다."))
+
+                // Security 스키마 정의
                 .components(new Components()
-                        .addSecuritySchemes("Bearer Token", securityScheme))
-                .addServersItem(new Server().url("/"))
-                .info(info);
+                        .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .description("JWT 토큰을 입력하세요 (Bearer prefix 제외)")))
+
+                // 전역으로 Security 적용
+                .addSecurityItem(new SecurityRequirement()
+                        .addList(securitySchemeName));
     }
 
     @Bean


### PR DESCRIPTION
## #️⃣연관된 이슈

close #315 

## 📝 작업 내용

### Swagger UI 에서 Authorize로 Token 입력시 Token이 서버에 정상적으로 전달되지 않는 이슈 수정
<img width="1291" height="267" alt="image" src="https://github.com/user-attachments/assets/14b98a19-55ee-4f4a-bccb-9ba34956ac14" />
 - 기존에는 Authorize를 통해 Token을 입력해도 값이 정상적으로 Server에 전달되지 않아 항상 "Invalid access token" 예외를 던지고 있었습니다.

### Description
- Request Header에 authorization 으로 Token이 정상적으로 Server에 전송 되는걸 볼 수 있습니다.
<img width="1894" height="598" alt="image" src="https://github.com/user-attachments/assets/02c7e1af-8b9a-4b59-8037-a63415ed3511" />

- Local, Dev 환경에서 Swagger를 통한 개발 테스트를 편하게 하기 위해 Token 만들수 있는 API가 필요합니다.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * HTTP Bearer JWT 기반의 보안 인증이 명시적으로 설정되었습니다.
  * API 문서 보안 설정이 간소화되고 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->