### PR TITLE
[FEAT] DEV 환경용 AccessToken 발급 API 구현 및 Swagger 문서화

### DIFF
--- a/src/main/java/org/ject/support/domain/auth/controller/DevAuthController.java
+++ b/src/main/java/org/ject/support/domain/auth/controller/DevAuthController.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import org.ject.support.common.security.CustomUserDetails;
@@ -27,8 +28,9 @@ public class DevAuthController {
             description = "개발 편의를 위한 access token 발급 API"
     )
     @PostMapping("/access-token")
-    public String getToken(@RequestBody EmailRequest request) {
-        Member member = memberRepository.findByEmail(request.email).orElseThrow();
+    public String getToken(@Valid @RequestBody EmailRequest request) {
+        Member member = memberRepository.findByEmail(request.email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
         Authentication authentication = jwtTokenProvider.createAuthenticationByMember(member);
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
         return jwtTokenProvider.createAccessToken(authentication, customUserDetails.getMemberId());


### PR DESCRIPTION
## #️⃣연관된 이슈

close #324

## 📝 작업 내용

### Dev 환경용 AccessToken 발급 API 구현 및 Swagger 문서화
 - DevAuthController 클래스 생성하여 local 및 dev 프로파일에서만 활성화되도록 구현했습니다.
 - POST /access-token 엔드포인트 추가: 이메일 입력을 받아 회원 정보 조회 후 JWT Access Token 발급
 - 이메일을 입력받는 DTO를 EmailRequest Java record로 클래스 내부에 임시 선언 해두었습니다.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 개발 및 로컬 환경에서 이메일을 제출해 액세스 토큰을 발급받을 수 있는 POST 엔드포인트가 추가되었습니다. 빠른 테스트 및 개발 인증 발급에 유용합니다.
  * 요청 본문 이메일 입력에 대한 유효성 검사가 적용되며, API 문서화 정보(요청 예시 등)가 포함되어 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->