### PR TITLE
[BUG] 에러 반환 시 200 응답 반환

### DIFF
--- a/src/main/java/org/ject/support/common/security/jwt/JwtExceptionHandlerFilter.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtExceptionHandlerFilter.java
@@ -66,6 +66,7 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
     ) throws IOException {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(errorCode.getHttpStatus().value());
 
         ApiResponse<String> errorResponse = new ApiResponse<>(
                 errorCode.getCode(),


### PR DESCRIPTION
## #️⃣연관된 이슈

close #334 

## 📝 작업 내용

- [FE 문의 사항](https://www.notion.so/cultured-phalange-7de/FE-BE-2bb62a893ac580eaa41fcb8526d4ad02?source=copy_link) 중 에러 발생 시, 200 응답이 반환되고 있습니다.

- 각 에러 코드에 설정한 HttpStatus가 함께 반환되어야 정상이지만, 그렇지 못하고 있는 상황입니다.

- `JwtExceptionHandlerFilter`에서 에러 발생 시 응답 값을 설정하는 `setErrorResponse` 메소드 내 `HttpStatus` 설정에 관한 코드가 누락되어 200 응답이 발생하는 것으로 보입니다.

- `setErrorResponse` 메소드에 `response.setStatus(errorCode.getHttpStatus().value());`를 추가했습니다.

- 적용 전
  <img width="1218" height="189" alt="Image" src="https://github.com/user-attachments/assets/ada0880f-0a32-4f6d-a32e-5a24048d8004" />

- 적용 후
  <img width="1214" height="211" alt="Image" src="https://github.com/user-attachments/assets/ffd239e3-c527-4992-8d27-3453c1179a99" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * API 오류 응답에서 적절한 HTTP 상태 코드가 올바르게 반환되도록 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->