### PR TITLE
[FEAT] 개발 서버용 지원기간 설정 API 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/recruit/controller/DevRecruitController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/DevRecruitController.java
@@ -1,0 +1,51 @@
+package org.ject.support.domain.recruit.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.dto.RecruitUpdateRequest;
+import org.ject.support.domain.recruit.dto.RecruitUpdatedEvent;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Profile;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Dev Recruit", description = "개발용 모집 관리 API")
+@Slf4j
+@RestController
+@RequestMapping("/admin/recruits")
+@RequiredArgsConstructor
+@Profile({"dev", "local"})
+public class DevRecruitController {
+
+    private final RecruitRepository recruitRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Operation(summary = "모집 정보 강제 수정", description = "마감 여부와 관계없이 모집 정보를 강제로 수정합니다.")
+    @PutMapping("/{recruitId}/force-update")
+    @Transactional
+    public void updateRecruit(@PathVariable Long recruitId,
+                                   @RequestBody @Valid RecruitUpdateRequest request) {
+        log.info("force update recruitId: {}, request: {}", recruitId, request);
+
+        Recruit recruit = recruitRepository.findById(recruitId)
+                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
+        recruit.update(request.jobFamily(), request.startDate(), request.endDate());
+
+        eventPublisher.publishEvent(new RecruitUpdatedEvent(
+                recruit.getId(),
+                recruit.getJobFamily(),
+                recruit.getStartDate(),
+                recruit.getEndDate()));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #342

## 📝 작업 내용

개발 및 테스트 환경에서 마감된 모집 공고의 기간을 자유롭게 수정할 수 있는 기능을 추가했습니다.
- DevRecruitController 추가:
  - PUT /admin/recruits/{recruitId}/force-update API를 제공합니다.
  - dev, local 프로파일에서만 활성화됩니다.
  - RecruitService의 isClosed() 검증 로직을 우회하여, 마감된 공고도 수정할 수 있습니다.
  - 이 API는 운영 환경(prod)에는 배포되지 않습니다. (@Profile({"dev", "local"}))
- Swagger 문서화:
  - Dev Recruit 태그로 분리하여 API 문서를 제공합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개발/로컬 환경 업데이트**
  * 개발 및 로컬 환경 전용 관리 도구를 추가했습니다.

**참고:** 이 변경 사항은 개발 및 로컬 환경에만 적용되며, 프로덕션 환경의 최종 사용자에게는 영향을 미치지 않습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->