### PR TITLE
feat: 지원서 프로필 작성 단계에서 거주지역 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/admin/dto/MemberDetailResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/MemberDetailResponse.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.admin.dto;
 
 import lombok.Builder;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.recruit.domain.Semester;
@@ -14,6 +15,7 @@ public record MemberDetailResponse(
         String phoneNumber,
         String email,
         JobFamily jobFamily,
+        Region region,
         String semesterName
 ) {
     public static MemberDetailResponse toResponse(
@@ -27,6 +29,7 @@ public record MemberDetailResponse(
                 .phoneNumber(member.getPhoneNumber())
                 .email(member.getEmail())
                 .jobFamily(member.getJobFamily())
+                .region(member.getRegion())
                 .semesterName(semester.getName().replaceAll("\\D", ""))
                 .build();
     }

--- a/src/main/java/org/ject/support/domain/admin/dto/MemberEditRequest.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/MemberEditRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 
 @Builder
@@ -21,6 +22,8 @@ public record MemberEditRequest(
         String email,
         @NotNull(message = "포지션은 필수입니다.")
         JobFamily jobFamily,
+        @NotNull(message = "거주 지역을 선택해주세요")
+        Region region,
         @Schema(description = "기수 이름", example = "1기")
         @Pattern(regexp = "^\\d+기$", message = "숫자+'기' 형식으로 입력해주세요", flags = Pattern.Flag.CANON_EQ)
         String semesterName

--- a/src/main/java/org/ject/support/domain/admin/dto/MemberRegisterRequest.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/MemberRegisterRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Pattern.Flag;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.recruit.domain.Semester;
@@ -22,6 +23,9 @@ public record MemberRegisterRequest(
         String email,
         @NotNull(message = "포지션은 필수입니다.")
         JobFamily jobFamily,
+
+        @NotNull(message = "거주 지역을 선택해주세요")
+        Region region,
         @NotNull(message = "기수는 필수입니다.")
         @Schema(description = "기수 이름", example = "1기")
         @Pattern(regexp = "^\\d+기$", message = "숫자+'기' 형식으로 입력해주세요", flags = Flag.CANON_EQ)
@@ -34,6 +38,7 @@ public record MemberRegisterRequest(
                 .phoneNumber(this.phoneNumber)
                 .email(this.email)
                 .jobFamily(this.jobFamily)
+                .region(this.region)
                 .semesterId(semester.getId())
                 .build();
     }

--- a/src/main/java/org/ject/support/domain/admin/service/MemberManagementService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/MemberManagementService.java
@@ -84,6 +84,7 @@ public class MemberManagementService {
                 .phoneNumber(request.phoneNumber())
                 .email(request.email())
                 .jobFamily(request.jobFamily())
+                .region(request.region())
                 .role(request.role())
                 .build();
 

--- a/src/main/java/org/ject/support/domain/apply/dto/ApplyProfileRequest.java
+++ b/src/main/java/org/ject/support/domain/apply/dto/ApplyProfileRequest.java
@@ -10,6 +10,7 @@ import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
 
 import java.util.List;
+import org.ject.support.domain.member.Region;
 
 public record ApplyProfileRequest(
         @NotBlank(message = "이름을 입력해주세요")
@@ -21,6 +22,9 @@ public record ApplyProfileRequest(
 
         @NotNull(message = "포지션을 선택해주세요")
         JobFamily jobFamily,
+
+        @NotNull(message = "거주 지역을 선택해주세요")
+        Region region,
 
         @NotNull(message = "지원자 신분을 선택해주세요")
         CareerDetails careerDetails,

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface ApplyRepository extends JpaRepository<Apply, Long>, ApplyQueryRepository {
 
+    boolean existsByMemberId(Long memberId);
+
     @Query("select a from Apply a where a.member.id = :memberId")
     Optional<Apply> findByMemberId(Long memberId);
 

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -36,6 +36,7 @@ import org.ject.support.domain.recruit.exception.QuestionException;
 import org.ject.support.domain.recruit.exception.RecruitErrorCode;
 import org.ject.support.domain.recruit.exception.RecruitException;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -200,11 +201,15 @@ public class ApplyService implements ApplyUsecase {
     }
 
     private void createApplyIfNotExists(Member member, JobFamily jobFamily) {
-        applyRepository.findByMemberId(member.getId()).orElseGet(() -> {
-            var recruit = getPeriodRecruit(jobFamily);
-            var newApply = Apply.createApply(member, recruit);
-            return applyRepository.save(newApply);
-        });
+        if (!applyRepository.existsByMemberId(member.getId())) {
+            try {
+                var recruit = getPeriodRecruit(jobFamily);
+                var newApply = Apply.createApply(member, recruit);
+                applyRepository.save(newApply);
+            } catch (DataIntegrityViolationException e) {
+                log.warn("지원서 생성 중 레이스 컨디션 발생. memberId: {}. 이미 지원서가 존재합니다.", member.getId());
+            }
+        }
     }
 
     private void validateQuestions(final Map<String, String> answers, final Recruit recruit) {

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -200,11 +200,11 @@ public class ApplyService implements ApplyUsecase {
     }
 
     private void createApplyIfNotExists(Member member, JobFamily jobFamily) {
-        if (!applyRepository.existsByMemberId(member.getId())) {
+        applyRepository.findByMemberId(member.getId()).orElseGet(() -> {
             var recruit = getPeriodRecruit(jobFamily);
             var newApply = Apply.createApply(member, recruit);
-            applyRepository.save(newApply);
-        }
+            return applyRepository.save(newApply);
+        });
     }
 
     private void validateQuestions(final Map<String, String> answers, final Recruit recruit) {

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -190,6 +190,7 @@ public class ApplyService implements ApplyUsecase {
                 .name(request.name())
                 .phoneNumber(request.phoneNumber())
                 .jobFamily(request.jobFamily())
+                .region(request.region())
                 .careerDetails(request.careerDetails())
                 .experiencePeriod(request.experiencePeriod())
                 .interestedDomains(request.interestedDomains())
@@ -199,11 +200,11 @@ public class ApplyService implements ApplyUsecase {
     }
 
     private void createApplyIfNotExists(Member member, JobFamily jobFamily) {
-        applyRepository.findByMemberId(member.getId()).orElseGet(() -> {
+        if (!applyRepository.existsByMemberId(member.getId())) {
             var recruit = getPeriodRecruit(jobFamily);
             var newApply = Apply.createApply(member, recruit);
-            return applyRepository.save(newApply);
-        });
+            applyRepository.save(newApply);
+        }
     }
 
     private void validateQuestions(final Map<String, String> answers, final Recruit recruit) {

--- a/src/main/java/org/ject/support/domain/member/Region.java
+++ b/src/main/java/org/ject/support/domain/member/Region.java
@@ -1,0 +1,29 @@
+package org.ject.support.domain.member;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Region {
+    SEOUL("서울"),
+    GYEONGGI("경기"),
+    INCHEON("인천"),
+    BUSAN("부산"),
+    DAEGU("대구"),
+    DAEJEON("대전"),
+    GWANGJU("광주"),
+    ULSAN("울산"),
+    SEJONG("세종"),
+    GANGWON("강원"),
+    CHUNGBUK("충북"),
+    CHUNGNAM("충남"),
+    JEONBUK("전북"),
+    JEONNAM("전남"),
+    GYEONGBUK("경북"),
+    GYEONGNAM("경남"),
+    JEJU("제주"),
+    OVERSEAS("해외");
+
+    private final String description;
+}

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -25,6 +25,7 @@ import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 
 import java.util.ArrayList;
@@ -57,6 +58,10 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(45)")
     private JobFamily jobFamily;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30)
+    private Region region;
 
     @Enumerated(EnumType.STRING)
     @Column(length = 30)
@@ -115,6 +120,7 @@ public class Member extends BaseTimeEntity {
                 .email(this.email)
                 .semesterId(this.semesterId)
                 .jobFamily(this.jobFamily)
+                .region(this.region)
                 .experiencePeriod(this.experiencePeriod)
                 .careerDetails(this.careerDetails)
                 .interestedDomains(this.interestedDomains)
@@ -127,6 +133,7 @@ public class Member extends BaseTimeEntity {
         this.email = editor.email();
         this.semesterId = editor.semesterId();
         this.jobFamily = editor.jobFamily();
+        this.region = editor.region();
         this.experiencePeriod = editor.experiencePeriod();
         this.careerDetails = editor.careerDetails();
         this.interestedDomains = editor.interestedDomains();
@@ -137,6 +144,7 @@ public class Member extends BaseTimeEntity {
         this.name = null;
         this.phoneNumber = null;
         this.jobFamily = null;
+        this.region = null;
         this.careerDetails = null;
         this.experiencePeriod = null;
         this.interestedDomains.clear();

--- a/src/main/java/org/ject/support/domain/member/entity/MemberEditor.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberEditor.java
@@ -1,22 +1,25 @@
 package org.ject.support.domain.member.entity;
 
-import java.util.List;
 import lombok.Builder;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 
+import java.util.List;
+
 @Builder
-public record MemberEditor (
-        String name,
-        String phoneNumber,
-        String email,
-        Long semesterId,
-        JobFamily jobFamily,
-        ExperiencePeriod experiencePeriod,
-        CareerDetails careerDetails,
-        List<String> interestedDomains,
-        Role role
+public record MemberEditor(
+    String name,
+    String phoneNumber,
+    String email,
+    Long semesterId,
+    JobFamily jobFamily,
+    Region region,
+    ExperiencePeriod experiencePeriod,
+    CareerDetails careerDetails,
+    List<String> interestedDomains,
+    Role role
 ) {
 }

--- a/src/main/resources/db/migration/V10__add_region_column_to_member.sql
+++ b/src/main/resources/db/migration/V10__add_region_column_to_member.sql
@@ -1,0 +1,2 @@
+ALTER TABLE member
+    ADD COLUMN region VARCHAR(30);

--- a/src/main/resources/db/migration/V11__add_unique_constraint_to_apply.sql
+++ b/src/main/resources/db/migration/V11__add_unique_constraint_to_apply.sql
@@ -1,0 +1,2 @@
+ALTER TABLE apply
+ADD CONSTRAINT uk_apply_member_recruit UNIQUE (member_id, recruit_id);

--- a/src/test/java/org/ject/support/domain/admin/controller/MemberManagementControllerTest.java
+++ b/src/test/java/org/ject/support/domain/admin/controller/MemberManagementControllerTest.java
@@ -349,6 +349,7 @@ class MemberManagementControllerTest extends UnitTestSupport {
                 .phoneNumber("01087654321")
                 .email("updated@example.com")
                 .jobFamily(JobFamily.FE)
+                .region(Region.SEOUL)
                 .semesterName("1기")
                 .build();
 
@@ -374,6 +375,7 @@ class MemberManagementControllerTest extends UnitTestSupport {
                 .phoneNumber("01087654321")
                 .email("updated@example.com")
                 .jobFamily(JobFamily.FE)
+                .region(Region.SEOUL)
                 .semesterName("1기")
                 .build();
 

--- a/src/test/java/org/ject/support/domain/admin/controller/MemberManagementControllerTest.java
+++ b/src/test/java/org/ject/support/domain/admin/controller/MemberManagementControllerTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.admin.service.MemberManagementService;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.admin.dto.MemberBulkDeleteRequest;
 import org.ject.support.domain.admin.dto.MemberDetailResponse;
@@ -228,6 +229,7 @@ class MemberManagementControllerTest extends UnitTestSupport {
                 TEST_PHONE_NUMBER,
                 TEST_EMAIL,
                 JobFamily.BE,
+                Region.SEOUL,
                 "1기"
         );
 
@@ -252,6 +254,7 @@ class MemberManagementControllerTest extends UnitTestSupport {
                 "123456789", // 유효하지 않은 전화번호
                 TEST_EMAIL,
                 JobFamily.BE,
+                Region.SEOUL,
                 "1"
         );
 
@@ -272,6 +275,7 @@ class MemberManagementControllerTest extends UnitTestSupport {
                 TEST_PHONE_NUMBER,
                 "invalid-email", // 유효하지 않은 이메일
                 JobFamily.BE,
+                Region.SEOUL,
                 "1"
         );
 
@@ -292,6 +296,7 @@ class MemberManagementControllerTest extends UnitTestSupport {
                 TEST_PHONE_NUMBER,
                 TEST_EMAIL,
                 JobFamily.BE,
+                Region.SEOUL,
                 "1"
         );
 
@@ -312,6 +317,7 @@ class MemberManagementControllerTest extends UnitTestSupport {
                 TEST_PHONE_NUMBER,
                 TEST_EMAIL,
                 JobFamily.BE,
+                Region.SEOUL,
                 "1기"
         );
 

--- a/src/test/java/org/ject/support/domain/admin/service/MemberManagementServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/MemberManagementServiceTest.java
@@ -14,6 +14,7 @@ import org.ject.support.domain.admin.dto.MemberEditRequest;
 import org.ject.support.domain.admin.dto.MemberRegisterRequest;
 import org.ject.support.domain.admin.dto.MemberResponse;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.exception.MemberErrorCode;
@@ -203,6 +204,7 @@ class MemberManagementServiceTest extends UnitTestSupport {
                 TEST_PHONE_NUMBER,
                 TEST_EMAIL,
                 JobFamily.BE,
+                Region.SEOUL,
                 "1기"
         );
 
@@ -233,6 +235,7 @@ class MemberManagementServiceTest extends UnitTestSupport {
                 TEST_PHONE_NUMBER,
                 TEST_EMAIL,
                 JobFamily.BE,
+                Region.SEOUL,
                 "1"
         );
 

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -33,6 +33,7 @@ import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.InterestedDomain;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.repository.MemberRepository;
@@ -246,14 +247,13 @@ class ApplyServiceTest extends UnitTestSupport {
 
     @Test
     void 프로필_저장_전에_임시저장_시도_시_실패() {
-        // given: Member는 있지만 Apply는 없는 상황
+        // given
         long memberId = 1L;
         Map<String, String> answers = Map.of("1", "답변1");
 
-        // applyRepository.findByMemberId()가 Optional.empty()를 반환하도록 설정
         given(applyRepository.findByMemberId(memberId)).willReturn(Optional.empty());
 
-        // when & then: saveApplicationTemporarily를 호출하면 NOT_FOUND_APPLY 에러가 발생해야 함
+        // expected
         assertThatThrownBy(() -> applyService.saveApplicationTemporarily(memberId, answers, List.of()))
                 .isInstanceOf(ApplyException.class)
                 .extracting("errorCode")
@@ -417,6 +417,7 @@ class ApplyServiceTest extends UnitTestSupport {
             "New Name",
             "010-1234-5678",
             JobFamily.FE,
+            Region.SEOUL,
             CareerDetails.STUDENT,
             ExperiencePeriod.NONE,
             List.of(InterestedDomain.GAME.getDescription(), InterestedDomain.EDUCATION.getDescription())
@@ -453,6 +454,7 @@ class ApplyServiceTest extends UnitTestSupport {
                 "New Name",
                 "010-1234-5678",
                 JobFamily.FE,
+                Region.SEOUL,
                 CareerDetails.STUDENT,
                 ExperiencePeriod.NONE,
                 List.of(InterestedDomain.GAME.getDescription(), InterestedDomain.EDUCATION.getDescription())
@@ -465,10 +467,8 @@ class ApplyServiceTest extends UnitTestSupport {
         applyService.saveProfile(memberId, request);
 
         // then
-        // applyRepository.save()는 호출되지 않아야 함 (멱등성)
         verify(applyRepository, never()).save(any(Apply.class));
 
-        // Member의 프로필 정보는 업데이트되어야 함
         assertThat(member.getName()).isEqualTo(request.name());
         assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
         assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -425,6 +425,7 @@ class ApplyServiceTest extends UnitTestSupport {
         Recruit recruit = getActiveRecruit(request.jobFamily(), List.of());
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(applyRepository.existsByMemberId(memberId)).willReturn(false);
         given(recruitRepository.findActiveRecruits(any())).willReturn(List.of(recruit));
 
         // when
@@ -449,7 +450,6 @@ class ApplyServiceTest extends UnitTestSupport {
         // given
         long memberId = 1L;
         Member member = getApplicant(memberId, "test@example.com");
-        Apply existingApply = getApply(1L, null, member, null, JOINED);
         ApplyProfileRequest request = new ApplyProfileRequest(
                 "New Name",
                 "010-1234-5678",
@@ -461,7 +461,7 @@ class ApplyServiceTest extends UnitTestSupport {
         );
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(applyRepository.findByMemberId(memberId)).willReturn(Optional.of(existingApply));
+        given(applyRepository.existsByMemberId(memberId)).willReturn(true);
 
         // when
         applyService.saveProfile(memberId, request);

--- a/src/test/java/org/ject/support/domain/member/MemberTest.java
+++ b/src/test/java/org/ject/support/domain/member/MemberTest.java
@@ -17,6 +17,7 @@ class MemberTest {
         String email = "john@example.com";
         JobFamily jobFamily = JobFamily.BE;
         Role role = Role.SEMESTER;
+        Region region = Region.SEOUL;
 
         // when
         Member member = Member.builder()
@@ -25,6 +26,7 @@ class MemberTest {
                 .email(email)
                 .jobFamily(jobFamily)
                 .role(role)
+                .region(region)
                 .status(MemberStatus.ACTIVE)
                 .build();
 
@@ -34,6 +36,7 @@ class MemberTest {
         assertThat(member.getEmail()).isEqualTo(email);
         assertThat(member.getJobFamily()).isEqualTo(jobFamily);
         assertThat(member.getRole()).isEqualTo(role);
+        assertThat(member.getRegion()).isEqualTo(region);
     }
 
     @Test
@@ -44,6 +47,7 @@ class MemberTest {
         String phoneNumber = "01012345678";
         String email = "john@example.com";
         Role role = Role.SEMESTER;
+        Region region = Region.OVERSEAS;
 
         // when
         Member member = Member.builder()
@@ -51,6 +55,7 @@ class MemberTest {
                 .phoneNumber(phoneNumber)
                 .email(email)
                 .role(role)
+                .region(region)
                 .status(MemberStatus.ACTIVE)
                 .build();
 
@@ -59,6 +64,7 @@ class MemberTest {
         assertThat(member.getPhoneNumber()).isEqualTo(phoneNumber);
         assertThat(member.getEmail()).isEqualTo(email);
         assertThat(member.getRole()).isEqualTo(role);
+        assertThat(member.getRegion()).isEqualTo(region);
         assertThat(member.getJobFamily()).isNull();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #348 

## 📝 작업 내용

지원서 작성 단계에서 사용자의 거주 지역을 저장하고 관리하기 위한 데이터 구조를 정의했습니다. 
단순 문자열 저장이 아닌 Enum을 활용하여 데이터 무결성을 확보하고, Member 엔티티에 해당 필드를 적용했습니다.
- Region Enum 추가: 국내 주요 행정 구역 및 해외를 포함한 상수 정의
- Member 엔티티 수정: region 필드 추가 및 JPA 매핑 (@Enumerated(EnumType.STRING))


## 🙏 리뷰 요구사항 (선택)

- Enum 구조가 적절한지 검토 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원 가입·프로필 편집·지원서에 거주 지역 필드 추가(선택 불가, 필수 입력)
  * 회원 상세에 거주 지역 노출 및 편집/삭제 반영

* **버그 수정**
  * 지원서 중복 생성 경합 처리 개선(동시성 예외를 안전하게 처리)

* **Chores**
  * 회원 테이블에 거주 지역 컬럼 추가(마이그레이션)
  * 입력 검증 추가로 거주 지역 미입력 방지

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->