### PR TITLE
hotfix: 개발 서버 Logback 설정 오류로 인한 애플리케이션 실행 실패

### DIFF
--- a/src/main/resources/logs/logback-dev.xml
+++ b/src/main/resources/logs/logback-dev.xml
@@ -1,4 +1,8 @@
 <configuration>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="wEx" converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
+
     <springProperty name="ACCESS_KEY" source="aws.cloudwatch.access-key"/>
     <springProperty name="SECRET_KEY" source="aws.cloudwatch.secret-key"/>
     <springProperty name="LOG_REGION" source="aws.cloudwatch.region"/>
@@ -10,9 +14,6 @@
     </appender>
 
     <appender name="AWS_LOGS" class="ca.pjer.logback.AwsLogsAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>info</level>
-        </filter>
         <logGroupName>JECT-log</logGroupName>
         <logStreamUuidPrefix>JECT-log-dev-</logStreamUuidPrefix>
         <logRegion>${LOG_REGION}</logRegion>
@@ -23,6 +24,7 @@
     </appender>
 
     <logger name="org.ject.support" level="DEBUG" />
+
     <root level="INFO">
         <appender-ref ref="AWS_LOGS"/>
         <appender-ref ref="CONSOLE"/>


### PR DESCRIPTION
## #️⃣연관된 이슈

close #353 

## 📝 작업 내용

개발 서버(`dev`)의 로그 설정 파일(`logback-dev.xml`)을 서버가 아예 켜지지 않는 크리티컬한 이슈라 긴급 수정했습니다.
설정 파일(`xml`)만 변경되었으므로 비즈니스 로직에는 영향이 없습니다.

#### 서버 기동 실패 해결:
- **변경 전**: `%clr` 키워드를 인식하지 못해 `IllegalStateException` 발생하며 서버 다운.
- **변경 후**: `<conversionRule>` 태그를 추가하여 색상 변환기 정상 등록.

#### AWS CloudWatch 로그 수집 정책 변경:
- **변경 전**: `ThresholdFilter`로 인해 INFO 레벨 이상만 AWS로 전송됨 (내 코드의 DEBUG 로그 확인 불가).
- **변경 후**: 필터를 제거하고 `org.ject` 패키지의 DEBUG 로그가 정상적으로 AWS에 적재되도록 수정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * AWS 로그 필터 제거로 모든 수준의 로그가 AWS 로그 어댑터에서 캡처됩니다.
  * 로그 포매팅 향상: 색상 표시 및 스택 추적 변환 규칙이 전역적으로 사용 가능해졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->