### PR TITLE
feat: 프로젝트 테이블에 badges 컬럼 추가 및 ProjectDetailResponse에 badges 필드 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/project/dto/ProjectDetailResponse.java
+++ b/src/main/java/org/ject/support/domain/project/dto/ProjectDetailResponse.java
@@ -1,11 +1,12 @@
 package org.ject.support.domain.project.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
-import java.time.LocalDate;
-import java.util.List;
 import lombok.Builder;
 import org.ject.support.domain.member.dto.TeamMemberNames;
 import org.ject.support.domain.project.entity.Project;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Builder
 public record ProjectDetailResponse(
@@ -15,6 +16,7 @@ public record ProjectDetailResponse(
         LocalDate endDate,
         TeamMemberNames teamMemberNames,
         List<String> techStack,
+        List<String> badges,
         String description,
         String serviceUrl,
         List<ProjectIntroResponse> serviceIntros,
@@ -36,6 +38,7 @@ public record ProjectDetailResponse(
                 .endDate(project.getEndDate())
                 .teamMemberNames(teamMemberNames)
                 .techStack(project.getTechStack())
+                .badges(project.getBadges())
                 .description(project.getDescription())
                 .serviceUrl(project.getServiceUrl())
                 .serviceIntros(serviceIntros)

--- a/src/main/java/org/ject/support/domain/project/entity/Project.java
+++ b/src/main/java/org/ject/support/domain/project/entity/Project.java
@@ -55,6 +55,11 @@ public class Project extends BaseTimeEntity {
     @Column(length = 2083)
     private String serviceUrl;
 
+    @Column
+    @Convert(converter = StringListConverter.class)
+    @Builder.Default
+    private List<String> badges = new ArrayList<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)
     private Team team;

--- a/src/main/resources/db/migration/V12__alter_project_add_badges_column.sql
+++ b/src/main/resources/db/migration/V12__alter_project_add_badges_column.sql
@@ -1,0 +1,4 @@
+-- project 테이블에 badges 컬럼 추가
+ALTER TABLE project
+    ADD COLUMN badges VARCHAR(255) NULL COMMENT '프로젝트 뱃지/태그 (콤마 구분)';
+


### PR DESCRIPTION
## #️⃣연관된 이슈

close #359

## 📝 작업 내용

### 프로젝트 상세조회하기 API에 badges를 추가
 - project 테이블에 badges 컬럼을 추가했습니다.
 - /project/{projectId} [GET] Method에 badges를 추가
 
### 요청
<img width="899" height="272" alt="image" src="https://github.com/user-attachments/assets/607864f5-9181-4912-8dd7-6db1ad4bec17" />

## Description
 - 노출할 Project의 정보는 한이님께 요청드린상태입니다 (2025 12 21 요청)
 - 현재 Admin을 통해 Project를 추가, 편집, 삭제 하는 기능은 따로 구현되어 있지 않아 DB를 수동으로 밀어 넣어야 됩니다.
     - 썸네일, 추가 이미지, 뱃지, 기술 스택 등등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로젝트에 배지/태그 기능이 추가되었습니다. 이제 각 프로젝트는 여러 개의 배지를 포함할 수 있으며, 프로젝트 상세 정보 페이지에서 이러한 배지들을 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->