### PR TITLE
refactor: 지원 상태 조회 API email 기반 로직으로 변경

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.apply.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Email;
 import org.ject.support.common.security.AuthPrincipal;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
 import org.ject.support.domain.apply.dto.ApplyStatusResponse;
@@ -46,7 +47,7 @@ public interface ApplyApiSpec {
                     - SUBMITTED: 이미 지원서를 제출한 경우
                     - JOINED: 합격하여 팀에 합류한 경우
                     """)
-    ApplyStatusResponse checkApplyStatus(@AuthPrincipal Long memberId);
+    ApplyStatusResponse checkApplyStatus(@RequestParam @Email String email);
 
     @Operation(
             summary = "프로필 작성(저장)",

--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.apply.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.security.AuthPrincipal;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
@@ -58,9 +59,9 @@ public class ApplyController implements ApplyApiSpec {
 
     @Override
     @GetMapping("/status")
-    @PreAuthorize("hasRole('ROLE_APPLY')")
-    public ApplyStatusResponse checkApplyStatus(@AuthPrincipal Long memberId) {
-        return applyUsecase.checkApplyStatus(memberId);
+    @PreAuthorize("permitAll()")
+    public ApplyStatusResponse checkApplyStatus(@RequestParam @Email String email) {
+        return applyUsecase.checkApplyStatus(email);
     }
 
     @Override

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -170,8 +170,8 @@ public class ApplyService implements ApplyUsecase {
 
     @Override
     @PeriodAccessible(permitAllJob = true)
-    public ApplyStatusResponse checkApplyStatus(Long memberId) {
-        Member member = memberRepository.findById(memberId)
+    public ApplyStatusResponse checkApplyStatus(String email) {
+        Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
 
         if (!member.isProfileComplete()) {
@@ -180,7 +180,7 @@ public class ApplyService implements ApplyUsecase {
         // 3. 지원 내역 조회
         //    - 없으면: 임시 저장 지원 상태 반환
         //    - 있으면: 상태 값에 따라 분기
-        Optional<Apply> optionalApply = applyRepository.findByMemberId(memberId);
+        Optional<Apply> optionalApply = applyRepository.findByMemberId(member.getId());
 
         if (optionalApply.isEmpty()) {
             return ApplyStatusResponse.tempSavedApply();

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
@@ -24,7 +24,7 @@ public interface ApplyUsecase {
                            Map<String, String> answers,
                            List<ApplyPortfolioDto> portfolios);
 
-    ApplyStatusResponse checkApplyStatus(Long memberId);
+    ApplyStatusResponse checkApplyStatus(String email);
 
     void saveProfile(Long memberId, ApplyProfileRequest request);
 }

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -194,14 +194,14 @@ class ApplyServiceTest extends UnitTestSupport {
     @Test
     void 지원단계중_프로필작성을_하지_않았을_경우_STEP을_PROFILE로_STATUS를_TEMP_SAVED_반환() {
         // given
-        Long memberId = 1L;
+        String email = "test@example.com";
         Member member = Member.builder()
                 .build();
-        given(memberRepository.findById(memberId))
+        given(memberRepository.findByEmail(email))
                 .willReturn(Optional.of(member));
 
         // when
-        ApplyStatusResponse result = applyService.checkApplyStatus(1L);
+        ApplyStatusResponse result = applyService.checkApplyStatus(email);
 
         // then
         assertThat(result).isEqualTo(ApplyStatusResponse.tempSavedProfile());
@@ -210,23 +210,24 @@ class ApplyServiceTest extends UnitTestSupport {
     @Test
     void 작성_중인_지원서가_있는_경우_TEMP_SAVED_반환() {
         // given
-        Long memberId = 1L;
+        String email = "test@example.com";
         Member member = Member.builder()
+                .id(1L)
                 .name("지원자명")
                 .phoneNumber("01012345678")
                 .build();
-        given(memberRepository.findById(memberId))
+        given(memberRepository.findByEmail(email))
                 .willReturn(Optional.of(member));
-        given(applyRepository.findByMemberId(any()))
+        given(applyRepository.findByMemberId(member.getId()))
                 .willReturn(Optional.of(
                         Apply.builder()
-                                .id(memberId)
+                                .id(1L)
                                 .status(TEMP_SAVED)
                                 .build()
                 ));
 
         // when
-        ApplyStatusResponse result = applyService.checkApplyStatus(1L);
+        ApplyStatusResponse result = applyService.checkApplyStatus(email);
 
         // then
         assertThat(result).isEqualTo(ApplyStatusResponse.tempSavedApply());
@@ -235,23 +236,24 @@ class ApplyServiceTest extends UnitTestSupport {
     @Test
     void 지원서를_제출한_지원자에_대한_제출_상태_확인_시_SUBMITTED_반환() {
         // given
-        Long memberId = 1L;
+        String email = "test@example.com";
         Member member = Member.builder()
+                        .id(1L)
                         .name("지원자명")
                         .phoneNumber("01012345678")
                         .build();
-        given(memberRepository.findById(memberId))
+        given(memberRepository.findByEmail(email))
                 .willReturn(Optional.of(member));
-        given(applyRepository.findByMemberId(any()))
+        given(applyRepository.findByMemberId(member.getId()))
                 .willReturn(Optional.of(
                         Apply.builder()
-                                .id(memberId)
+                                .id(1L)
                                 .status(SUBMITTED)
                                 .build()
                 ));
 
         // when
-        ApplyStatusResponse result = applyService.checkApplyStatus(memberId);
+        ApplyStatusResponse result = applyService.checkApplyStatus(email);
 
         // then
         assertThat(result).isEqualTo(ApplyStatusResponse.of(SUBMITTED));


### PR DESCRIPTION
## #️⃣연관된 이슈

close #358 

## 📝 작업 내용

지원 상태 조회 API (GET /apply/status) 로직 변경
- 기존에는 토큰을 통해 인증된 사용자만 지원 상태를 확인할 수 있었으나, 기기 변경이나 토큰 유실 시에도 상태 확인이 가능하도록 이메일 기반 조회로 변경하였습니다.
- checkApplyStatus 메서드의 파라미터를 `@AuthPrincipal Long memberId`에서 `@RequestParam String email`로 변경
- `@PreAuthorize("permitAll()")`을 적용하여 비로그인 상태에서도 접근 가능하도록 보안 설정 완화
- 식별된 회원의 ID로 기존 지원 상태 조회 로직 수행

## 🙏 리뷰 요구사항 (선택)

- 보안 관련: 토큰 없이 이메일만으로 조회가 가능해졌으나, 반환되는 정보가 민감 정보 없는 단순 상태값(TEMP_SAVED, SUBMITTED 등)이므로 보안상 허용 가능한 범위로 판단하여 진행했습니다.

- 참고 사항: 현재 조회를 사용하는 로직 특성상, 재지원(다기수) 시나리오에서 이전 기수 지원서가 조회될 수 있는 잠재적 문제가 확인되었습니다. 해당 문제는 이번 PR 범위에서 제외하고, 추후 별도 이슈로 분리하여 수정할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 신청 상태 확인 기능을 이메일 기반으로 업데이트했습니다.

* **Bug Fixes**
  * 프로필 미완성 상태 처리를 개선했습니다.

* **Refactor**
  * 신청 상태 조회 API의 접근 방식을 변경하여 인증 없이 이메일로 상태를 확인할 수 있도록 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->