### PR TITLE
fix: 프로젝트 상세 조회 응답에서 썸네일 URL 필드 제거

### DIFF
--- a/src/main/java/org/ject/support/domain/project/dto/ProjectDetailResponse.java
+++ b/src/main/java/org/ject/support/domain/project/dto/ProjectDetailResponse.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 @Builder
 public record ProjectDetailResponse(
-        String thumbnailUrl,
         String name,
         LocalDate startDate,
         LocalDate endDate,
@@ -34,7 +33,6 @@ public record ProjectDetailResponse(
                                                    List<ProjectIntroResponse> sampleImageUrls,
                                                    List<ProjectIntroResponse> descriptionImageUrls) {
         return ProjectDetailResponse.builder()
-                .thumbnailUrl(project.getThumbnailUrl())
                 .name(project.getName())
                 .startDate(project.getStartDate())
                 .endDate(project.getEndDate())

--- a/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
@@ -78,7 +78,6 @@ class ProjectServiceTest extends UnitTestSupport {
         ProjectDetailResponse result = projectService.findProjectDetails(1L);
 
         // then
-        assertThat(result.thumbnailUrl()).isEqualTo(project.getThumbnailUrl());
         assertThat(result.name()).isEqualTo(project.getName());
         assertThat(result.startDate()).isEqualTo(project.getStartDate());
         assertThat(result.endDate()).isEqualTo(project.getEndDate());


### PR DESCRIPTION
## #️⃣연관된 이슈

close #368 

## 📝 작업 내용

### 프로젝트 상세조회 API 썸네일 필드 삭제
 - 프론트엔드 요청


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 프로젝트 상세 조회 응답에서 썸네일 URL 필드를 제거했습니다.

* **Tests**
  * 프로젝트 상세 조회 테스트에서 썸네일 URL 검증을 제거했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->