### PR TITLE
feat: 이전 기수 지원 이력이 있으면 신규 지원이 불가능한 오류

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -5,6 +5,7 @@ import org.ject.support.domain.recruit.domain.Recruit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +16,12 @@ public interface ApplyRepository extends JpaRepository<Apply, Long>, ApplyQueryR
 
     @Query("select a from Apply a where a.member.id = :memberId")
     Optional<Apply> findByMemberId(Long memberId);
+
+    @Query("select a from Apply a join a.recruit r where a.member.id = :memberId and r.startDate <= :now and r.endDate >= :now")
+    Optional<Apply> findByMemberIdInActiveRecruit(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
+
+    @Query("select count(a) > 0 from Apply a join a.recruit r where a.member.id = :memberId and r.startDate <= :now and r.endDate >= :now")
+    boolean existsByMemberIdInActiveRecruit(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
 
     List<Apply> findByRecruitAndStatus(Recruit recruit, Apply.Status status);
 

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -57,7 +57,7 @@ public class ApplyService implements ApplyUsecase {
     @PeriodAccessible(permitAllJob = true)
     @Transactional(readOnly = true)
     public TempApplicationFormResponse findTempApplicationForm(final Long memberId) {
-        Apply apply = applyRepository.findByMemberId(memberId)
+        Apply apply = applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
 
         if (apply.isNotTempSaved()) {
@@ -80,7 +80,7 @@ public class ApplyService implements ApplyUsecase {
                                            Map<String, String> answers,
                                            List<ApplyPortfolioDto> portfolios) {
         // 1. memberId를 바탕으로 apply 조회
-        Apply apply = applyRepository.findByMemberId(memberId)
+        Apply apply = applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
 
         Apply.Status applyStatus = apply.getStatus();
@@ -117,7 +117,7 @@ public class ApplyService implements ApplyUsecase {
     @Transactional
     public void deleteProfileAndTempApplicationForm(Long memberId) {
         // 지원 정보 조회
-        Apply apply = applyRepository.findByMemberId(memberId)
+        Apply apply = applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
 
         // 지원서를 임시 저장하지 않은 경우 실패
@@ -148,7 +148,7 @@ public class ApplyService implements ApplyUsecase {
         validateQuestions(answers, recruit);
 
         // 3. 지원 정보 조회
-        Apply apply = applyRepository.findByMemberId(memberId)
+        Apply apply = applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
 
         String content = map2JsonSerializer.serializeAsString(answers);
@@ -180,7 +180,7 @@ public class ApplyService implements ApplyUsecase {
         // 3. 지원 내역 조회
         //    - 없으면: 임시 저장 지원 상태 반환
         //    - 있으면: 상태 값에 따라 분기
-        Optional<Apply> optionalApply = applyRepository.findByMemberId(member.getId());
+        Optional<Apply> optionalApply = applyRepository.findByMemberIdInActiveRecruit(member.getId(), LocalDateTime.now());
 
         if (optionalApply.isEmpty()) {
             return ApplyStatusResponse.tempSavedApply();
@@ -221,7 +221,7 @@ public class ApplyService implements ApplyUsecase {
     }
 
     private void createApplyIfNotExists(Member member, JobFamily jobFamily) {
-        if (!applyRepository.existsByMemberId(member.getId())) {
+        if (!applyRepository.existsByMemberIdInActiveRecruit(member.getId(), LocalDateTime.now())) {
             try {
                 var recruit = getPeriodRecruit(jobFamily);
                 var newApply = Apply.createApply(member, recruit);

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -45,6 +45,8 @@ import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
 import static org.ject.support.domain.apply.domain.Apply.Status.TEMP_SAVED;
 import static org.ject.support.domain.member.JobFamily.BE;
 import static org.ject.support.domain.member.JobFamily.PD;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
@@ -98,7 +100,7 @@ class ApplyServiceTest extends UnitTestSupport {
         Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
 
         when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
-        when(applyRepository.findByMemberId(applicant.getId())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
         // when
@@ -129,7 +131,7 @@ class ApplyServiceTest extends UnitTestSupport {
         Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
 
         when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
-        when(applyRepository.findByMemberId(applicant.getId())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
         // expected
@@ -156,7 +158,7 @@ class ApplyServiceTest extends UnitTestSupport {
         );
 
         when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
-        when(applyRepository.findByMemberId(applicant.getId())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
         // when
@@ -218,7 +220,7 @@ class ApplyServiceTest extends UnitTestSupport {
                 .build();
         given(memberRepository.findByEmail(email))
                 .willReturn(Optional.of(member));
-        given(applyRepository.findByMemberId(member.getId()))
+        given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
                 .willReturn(Optional.of(
                         Apply.builder()
                                 .id(1L)
@@ -244,7 +246,7 @@ class ApplyServiceTest extends UnitTestSupport {
                         .build();
         given(memberRepository.findByEmail(email))
                 .willReturn(Optional.of(member));
-        given(applyRepository.findByMemberId(member.getId()))
+        given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
                 .willReturn(Optional.of(
                         Apply.builder()
                                 .id(1L)
@@ -284,7 +286,7 @@ class ApplyServiceTest extends UnitTestSupport {
 
         String content = "newContent";
 
-        when(applyRepository.findByMemberId(any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(content);
 
         // when
@@ -325,7 +327,7 @@ class ApplyServiceTest extends UnitTestSupport {
 
         Apply apply = getApply(1L, recruit, applicant, applicationForm, SUBMITTED);
 
-        when(applyRepository.findByMemberId(any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
 
         // when, then
         assertThatThrownBy(() -> applyService.saveApplicationTemporarily(1L, answers, List.of()))
@@ -338,7 +340,7 @@ class ApplyServiceTest extends UnitTestSupport {
         long memberId = 1L;
         Map<String, String> answers = Map.of("1", "답변1");
 
-        given(applyRepository.findByMemberId(memberId)).willReturn(Optional.empty());
+        given(applyRepository.findByMemberIdInActiveRecruit(eq(memberId), any())).willReturn(Optional.empty());
 
         // expected
         assertThatThrownBy(() -> applyService.saveApplicationTemporarily(memberId, answers, List.of()))
@@ -375,7 +377,7 @@ class ApplyServiceTest extends UnitTestSupport {
 
         String newContent = "newContent";
 
-        when(applyRepository.findByMemberId(any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(newContent);
 
         // when
@@ -405,7 +407,7 @@ class ApplyServiceTest extends UnitTestSupport {
 
         Apply apply = getApply(1L, recruit, getApplicant(1L, "email@test.com"), applicationForm, TEMP_SAVED);
 
-        when(applyRepository.findByMemberId(any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply));
 
         // when
         applyService.deleteProfileAndTempApplicationForm(1L);
@@ -440,8 +442,8 @@ class ApplyServiceTest extends UnitTestSupport {
                 .content("content")
                 .build(), SUBMITTED);
 
-        when(applyRepository.findByMemberId(1L)).thenReturn(Optional.of(apply1));
-        when(applyRepository.findByMemberId(2L)).thenReturn(Optional.of(apply2));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply1));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(2L), any())).thenReturn(Optional.of(apply2));
 
         // when, then
         assertThatThrownBy(() -> applyService.deleteProfileAndTempApplicationForm(1L))
@@ -466,7 +468,7 @@ class ApplyServiceTest extends UnitTestSupport {
 
         Apply apply = getApply(1L, recruit, getApplicant(1L, "email@test.com"), tempApplicationForm, TEMP_SAVED);
 
-        when(applyRepository.findByMemberId(any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply));
         when(string2MapSerializer.serializeAsMap(tempApplicationForm.getContent())).thenReturn(answers);
 
         // when
@@ -488,7 +490,7 @@ class ApplyServiceTest extends UnitTestSupport {
 
         Apply apply = getApply(1L, getActiveRecruit(BE, questions), getApplicant(1L, "email@test.com"), null, JOINED);
 
-        when(applyRepository.findByMemberId(any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply));
 
         // when, then
         assertThatThrownBy(() -> applyService.findTempApplicationForm(1L))
@@ -512,7 +514,7 @@ class ApplyServiceTest extends UnitTestSupport {
         Recruit recruit = getActiveRecruit(request.jobFamily(), List.of());
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(applyRepository.existsByMemberId(memberId)).willReturn(false);
+        given(applyRepository.existsByMemberIdInActiveRecruit(eq(memberId), any())).willReturn(false);
         given(recruitRepository.findActiveRecruits(any())).willReturn(List.of(recruit));
 
         // when
@@ -548,7 +550,7 @@ class ApplyServiceTest extends UnitTestSupport {
         );
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(applyRepository.existsByMemberId(memberId)).willReturn(true);
+        given(applyRepository.existsByMemberIdInActiveRecruit(eq(memberId), any())).willReturn(true);
 
         // when
         applyService.saveProfile(memberId, request);
@@ -561,6 +563,23 @@ class ApplyServiceTest extends UnitTestSupport {
         assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
         assertThat(member.getCareerDetails()).isEqualTo(request.careerDetails());
         assertThat(member.getExperiencePeriod()).isEqualTo(request.experiencePeriod());
+    }
+
+    @Test
+    void 지원상태확인_지원내역없음_신규지원가능() {
+        // given
+        String email = "re-apply@example.com";
+        Member member = getApplicant(1L, email);
+        member.edit(member.toEditor().name("Test").phoneNumber("010-0000-0000").build()); // 프로필 작성 완료 상태로
+
+        given(memberRepository.findByEmail(email)).willReturn(Optional.of(member));
+        given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any())).willReturn(Optional.empty());
+
+        // when
+        ApplyStatusResponse result = applyService.checkApplyStatus(email);
+
+        // then
+        assertThat(result).isEqualTo(ApplyStatusResponse.tempSavedApply());
     }
 
     private Recruit getActiveRecruit(JobFamily jobFamily, List<Question> questions) {

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -1,11 +1,28 @@
 package org.ject.support.domain.apply.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ject.support.domain.apply.domain.Apply.Status.JOINED;
+import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
+import static org.ject.support.domain.apply.domain.Apply.Status.TEMP_SAVED;
+import static org.ject.support.domain.member.JobFamily.BE;
+import static org.ject.support.domain.member.JobFamily.PD;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.util.Map2JsonSerializer;
 import org.ject.support.common.util.String2MapSerializer;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
-import org.ject.support.domain.apply.domain.Portfolio;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
 import org.ject.support.domain.apply.dto.ApplyStatusResponse;
@@ -32,26 +49,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.ject.support.domain.apply.domain.Apply.Status.JOINED;
-import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
-import static org.ject.support.domain.apply.domain.Apply.Status.TEMP_SAVED;
-import static org.ject.support.domain.member.JobFamily.BE;
-import static org.ject.support.domain.member.JobFamily.PD;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class ApplyServiceTest extends UnitTestSupport {
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #367 

## 📝 작업 내용

이전 기수 지원 이력이 있는 사용자가 신규 지원을 할 수 없었던 버그를 해결했습니다.
- 원인: 지원 내역 조회 시, 현재 모집 기수를 필터링하지 않아 과거 내역이 조회될 수 있음을 확인했습니다.
- 해결:
  - ApplyRepository에 findByMemberIdInActiveRecruit 등 현재 모집 기간 내의 데이터만 조회하는 메서드를 추가했습니다.
  - ApplyService의 모든 관련 로직(checkApplyStatus, saveProfile 등)이 새로운 Repository 메서드를 사용하도록 수정했습니다.
- 검증: 재지원_시나리오_정상_동작_확인 테스트 케이스를 추가하여 버그가 해결되었음을 확인했습니다.


## 🙏 리뷰 요구사항 (선택)

- 제가 확인한 바로는 모집 종료 후 지원 데이터를 정리하는 별도의 스케줄링이나 로직이 없는 것으로 파악되어 이 방식을 적용했습니다. 혹시 제가 놓친 데이터 정리 정책이나 관련 레거시 코드가 있다면 코멘트 부탁드립니다!

- ApplyRepository에 추가된 JPQL 쿼리가 현재 모집 기간(startDate <= now <= endDate)을 올바르게 필터링하는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 지원 조회 및 존재 확인 로직을 활성 모집 기간 기준으로 엄격히 필터링하도록 개선했습니다. (이로 인해 모집 기간 외의 기존 지원은 조회되지 않습니다.)

* **테스트**
  * 활성 모집 기간 필터링 관련 테스트를 추가 및 갱신하여 다양한 시점(활성/비활성) 상황을 검증하도록 보강했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->