### PR TITLE
fix: @Valid 어노테이션 Validation 설정 불일치 수정

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.apply.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import org.ject.support.common.security.AuthPrincipal;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
@@ -54,5 +55,5 @@ public interface ApplyApiSpec {
             description = "지원자의 프로필을 작성(저장)합니다."
     )
     void saveProfile(@AuthPrincipal Long memberId,
-                     @RequestBody ApplyProfileRequest request);
+                     @RequestBody @Valid ApplyProfileRequest request);
 }

--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
@@ -68,7 +68,7 @@ public class ApplyController implements ApplyApiSpec {
     @PostMapping("/profile")
     @PreAuthorize("hasRole('ROLE_APPLY')")
     public void saveProfile(@AuthPrincipal Long memberId,
-                            @Valid @RequestBody ApplyProfileRequest request
+                            @RequestBody @Valid ApplyProfileRequest request
     ) {
         applyUsecase.saveProfile(memberId, request);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #371 

## 📝 작업 내용

ApplyController의 saveProfile 메서드에는 @Valid가 적용되어 있으나, 인터페이스인 ApplyApiSpec에는 누락되어 있어 ConstraintDeclarationException이 발생하던 문제를 해결했습니다.

변경 사항: saveProfile 메서드의 ApplyProfileRequest 파라미터에 @Valid 어노테이션 추가


## 🙏 리뷰 요구사항 (선택)
- 간단한 어노테이션 추가 작업입니다.
- 이 변경으로 인해 애플리케이션 전역에서 발생하던 HV000151 에러가 사라지는지 확인요망.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 프로필 저장 시 입력 데이터 유효성 검증이 강화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->