### PR TITLE
fix: Apply 상태값(JOINED) 의미 불일치 해결 및 checkApplyStatus 로직 개선

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
@@ -44,9 +44,9 @@ public interface ApplyApiSpec {
             summary = "지원 상태 확인",
             description = """
                     지원자의 지원서 제출 여부를 확인합니다.
+                    - JOINED: 프로필을 저장한 경우
                     - TEMP_SAVED: 작성 중인 지원서가 있는 경우
                     - SUBMITTED: 이미 지원서를 제출한 경우
-                    - JOINED: 합격하여 팀에 합류한 경우
                     """)
     ApplyStatusResponse checkApplyStatus(@RequestParam @Email String email);
 

--- a/src/main/java/org/ject/support/domain/apply/dto/ApplyStatusResponse.java
+++ b/src/main/java/org/ject/support/domain/apply/dto/ApplyStatusResponse.java
@@ -1,25 +1,12 @@
 package org.ject.support.domain.apply.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.Apply.Status;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ApplyStatusResponse(
-        Status status,
-        String step
+        Status status
 ) {
-
-    public static ApplyStatusResponse of(Status status) {
-        return new ApplyStatusResponse(status, null);
-    }
-
-    // 프로필 작성을 하지 않았을 경우
-    public static ApplyStatusResponse tempSavedProfile() {
-        return new ApplyStatusResponse(Status.TEMP_SAVED, "PROFILE");
-    }
-
-    // 프로필 작성 이후, 지원서 작성 중인 경우
-    public static ApplyStatusResponse tempSavedApply() {
-        return new ApplyStatusResponse(Status.TEMP_SAVED, "APPLY");
+    public static ApplyStatusResponse of(Apply apply) {
+        return new ApplyStatusResponse(apply.getStatus());
     }
 }

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -174,27 +174,9 @@ public class ApplyService implements ApplyUsecase {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-        if (!member.isProfileComplete()) {
-            return ApplyStatusResponse.tempSavedProfile();
-        }
-        // 3. 지원 내역 조회
-        //    - 없으면: 임시 저장 지원 상태 반환
-        //    - 있으면: 상태 값에 따라 분기
-        Optional<Apply> optionalApply = applyRepository.findByMemberIdInActiveRecruit(member.getId(), LocalDateTime.now());
-
-        if (optionalApply.isEmpty()) {
-            return ApplyStatusResponse.tempSavedApply();
-        }
-
-        Apply apply = optionalApply.get();
-
-        // 4. 지원서가 임시 저장 상태인 경우
-        if (apply.isTempSaved()) {
-            return ApplyStatusResponse.tempSavedApply();
-        }
-
-        // 5. 그 외에는 실제 지원 상태 반환
-        return ApplyStatusResponse.of(apply.getStatus());
+        return applyRepository.findByMemberIdInActiveRecruit(member.getId(), LocalDateTime.now())
+                .map(ApplyStatusResponse::of)
+                .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
     }
 
     @Override

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -191,19 +191,21 @@ class ApplyServiceTest extends UnitTestSupport {
     }
 
     @Test
-    void 지원단계중_프로필작성을_하지_않았을_경우_STEP을_PROFILE로_STATUS를_TEMP_SAVED_반환() {
+    void 지원상태_조회_시_프로필작성을_하지_않았을_경우_예외발생() {
         // given
         String email = "test@example.com";
         Member member = Member.builder()
                 .build();
         given(memberRepository.findByEmail(email))
                 .willReturn(Optional.of(member));
+        given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
+                .willReturn(Optional.empty());
 
-        // when
-        ApplyStatusResponse result = applyService.checkApplyStatus(email);
-
-        // then
-        assertThat(result).isEqualTo(ApplyStatusResponse.tempSavedProfile());
+        // expected
+        assertThatThrownBy(() -> applyService.checkApplyStatus(email))
+                .isInstanceOf(ApplyException.class)
+                .extracting("errorCode")
+                .isEqualTo(ApplyErrorCode.NOT_FOUND_APPLY);
     }
 
     @Test
@@ -229,7 +231,7 @@ class ApplyServiceTest extends UnitTestSupport {
         ApplyStatusResponse result = applyService.checkApplyStatus(email);
 
         // then
-        assertThat(result).isEqualTo(ApplyStatusResponse.tempSavedApply());
+        assertThat(result.status()).isEqualTo(TEMP_SAVED);
     }
 
     @Test
@@ -255,7 +257,7 @@ class ApplyServiceTest extends UnitTestSupport {
         ApplyStatusResponse result = applyService.checkApplyStatus(email);
 
         // then
-        assertThat(result).isEqualTo(ApplyStatusResponse.of(SUBMITTED));
+        assertThat(result.status()).isEqualTo(SUBMITTED);
     }
 
     @Test
@@ -560,23 +562,6 @@ class ApplyServiceTest extends UnitTestSupport {
         assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
         assertThat(member.getCareerDetails()).isEqualTo(request.careerDetails());
         assertThat(member.getExperiencePeriod()).isEqualTo(request.experiencePeriod());
-    }
-
-    @Test
-    void 지원상태확인_지원내역없음_신규지원가능() {
-        // given
-        String email = "re-apply@example.com";
-        Member member = getApplicant(1L, email);
-        member.edit(member.toEditor().name("Test").phoneNumber("010-0000-0000").build()); // 프로필 작성 완료 상태로
-
-        given(memberRepository.findByEmail(email)).willReturn(Optional.of(member));
-        given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any())).willReturn(Optional.empty());
-
-        // when
-        ApplyStatusResponse result = applyService.checkApplyStatus(email);
-
-        // then
-        assertThat(result).isEqualTo(ApplyStatusResponse.tempSavedApply());
     }
 
     private Recruit getActiveRecruit(JobFamily jobFamily, List<Question> questions) {


### PR DESCRIPTION
## #️⃣연관된 이슈

close #374 

## 📝 작업 내용


- Swagger 문서 수정 (ApplyApiSpec)
  - JOINED 상태값의 설명을 "합격하여 팀에 합류한 경우"에서 "프로필을 저장한 경우"로 수정하여 코드와 문서 간의 의미 불일치를 해결했습니다.
- 지원 상태 확인 로직 개선 (ApplyService)
  - checkApplyStatus 메서드의 불필요한 분기 처리를 제거했습니다.
  - Apply 엔티티가 존재하면 해당 상태(JOINED, TEMP_SAVED 등)를 그대로 반환하고, 존재하지 않으면 NOT_FOUND_APPLY 예외를 던지도록 변경했습니다.
- DTO 리팩토링 (ApplyStatusResponse)
  - 불필요해진 step 필드와 정적 팩토리 메서드(tempSavedProfile, tempSavedApply)를 제거했습니다.
  - Status 값만 반환하도록 구조를 단순화했습니다.
- 테스트 코드 수정 (ApplyServiceTest)
  - 변경된 로직과 DTO 구조에 맞춰 단위 테스트를 수정했습니다.

## 🙏 리뷰 요구사항 (선택)
- 프론트엔드 연동 확인 필요: 
  - checkApplyStatus API가 이제 초기 상태인 JOINED를 그대로 반환합니다. 프론트엔드에서 JOINED 응답을 받으면 지원서 작성 페이지로 진입하도록 로직 수정이 필요합니다.
  - 지원 내역이 없을 경우 404 Not Found (NOT_FOUND_APPLY) 예외가 발생합니다. 프론트엔드에서 예외가 발생하면 프로필 작성 페이지로 진입하도록 로직 수정이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Clarified JOINED status description to accurately reflect when a profile has been saved.

* **Refactor**
  * Simplified application status retrieval logic with improved error handling for cases where no active application exists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->