### PR TITLE
refactor: 지원 상태 확인 API 파라미터 변경

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
@@ -3,7 +3,6 @@ package org.ject.support.domain.apply.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Email;
 import org.ject.support.common.security.AuthPrincipal;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
 import org.ject.support.domain.apply.dto.ApplyStatusResponse;
@@ -48,7 +47,7 @@ public interface ApplyApiSpec {
                     - TEMP_SAVED: 작성 중인 지원서가 있는 경우
                     - SUBMITTED: 이미 지원서를 제출한 경우
                     """)
-    ApplyStatusResponse checkApplyStatus(@RequestParam @Email String email);
+    ApplyStatusResponse checkApplyStatus(@AuthPrincipal Long memberId);
 
     @Operation(
             summary = "프로필 작성(저장)",

--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
@@ -1,7 +1,6 @@
 package org.ject.support.domain.apply.controller;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.security.AuthPrincipal;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
@@ -59,9 +58,9 @@ public class ApplyController implements ApplyApiSpec {
 
     @Override
     @GetMapping("/status")
-    @PreAuthorize("permitAll()")
-    public ApplyStatusResponse checkApplyStatus(@RequestParam @Email String email) {
-        return applyUsecase.checkApplyStatus(email);
+    @PreAuthorize("hasRole('ROLE_APPLY')")
+    public ApplyStatusResponse checkApplyStatus(@AuthPrincipal Long memberId) {
+        return applyUsecase.checkApplyStatus(memberId);
     }
 
     @Override

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -170,11 +170,11 @@ public class ApplyService implements ApplyUsecase {
 
     @Override
     @PeriodAccessible(permitAllJob = true)
-    public ApplyStatusResponse checkApplyStatus(String email) {
-        Member member = memberRepository.findByEmail(email)
+    public ApplyStatusResponse checkApplyStatus(Long memberId) {
+        memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-        return applyRepository.findByMemberIdInActiveRecruit(member.getId(), LocalDateTime.now())
+        return applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
                 .map(ApplyStatusResponse::of)
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
     }

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
@@ -24,7 +24,7 @@ public interface ApplyUsecase {
                            Map<String, String> answers,
                            List<ApplyPortfolioDto> portfolios);
 
-    ApplyStatusResponse checkApplyStatus(String email);
+    ApplyStatusResponse checkApplyStatus(Long memberId);
 
     void saveProfile(Long memberId, ApplyProfileRequest request);
 }

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -193,16 +193,18 @@ class ApplyServiceTest extends UnitTestSupport {
     @Test
     void 지원상태_조회_시_프로필작성을_하지_않았을_경우_예외발생() {
         // given
-        String email = "test@example.com";
         Member member = Member.builder()
+                .id(1L)
+                .name("지원자명")
+                .phoneNumber("01012345678")
                 .build();
-        given(memberRepository.findByEmail(email))
+        given(memberRepository.findById(member.getId()))
                 .willReturn(Optional.of(member));
         given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
                 .willReturn(Optional.empty());
 
         // expected
-        assertThatThrownBy(() -> applyService.checkApplyStatus(email))
+        assertThatThrownBy(() -> applyService.checkApplyStatus(member.getId()))
                 .isInstanceOf(ApplyException.class)
                 .extracting("errorCode")
                 .isEqualTo(ApplyErrorCode.NOT_FOUND_APPLY);
@@ -211,13 +213,12 @@ class ApplyServiceTest extends UnitTestSupport {
     @Test
     void 작성_중인_지원서가_있는_경우_TEMP_SAVED_반환() {
         // given
-        String email = "test@example.com";
         Member member = Member.builder()
                 .id(1L)
                 .name("지원자명")
                 .phoneNumber("01012345678")
                 .build();
-        given(memberRepository.findByEmail(email))
+        given(memberRepository.findById(member.getId()))
                 .willReturn(Optional.of(member));
         given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
                 .willReturn(Optional.of(
@@ -228,7 +229,7 @@ class ApplyServiceTest extends UnitTestSupport {
                 ));
 
         // when
-        ApplyStatusResponse result = applyService.checkApplyStatus(email);
+        ApplyStatusResponse result = applyService.checkApplyStatus(member.getId());
 
         // then
         assertThat(result.status()).isEqualTo(TEMP_SAVED);
@@ -237,13 +238,12 @@ class ApplyServiceTest extends UnitTestSupport {
     @Test
     void 지원서를_제출한_지원자에_대한_제출_상태_확인_시_SUBMITTED_반환() {
         // given
-        String email = "test@example.com";
         Member member = Member.builder()
-                        .id(1L)
-                        .name("지원자명")
-                        .phoneNumber("01012345678")
-                        .build();
-        given(memberRepository.findByEmail(email))
+                .id(1L)
+                .name("지원자명")
+                .phoneNumber("01012345678")
+                .build();
+        given(memberRepository.findById(member.getId()))
                 .willReturn(Optional.of(member));
         given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
                 .willReturn(Optional.of(
@@ -254,7 +254,7 @@ class ApplyServiceTest extends UnitTestSupport {
                 ));
 
         // when
-        ApplyStatusResponse result = applyService.checkApplyStatus(email);
+        ApplyStatusResponse result = applyService.checkApplyStatus(member.getId());
 
         // then
         assertThat(result.status()).isEqualTo(SUBMITTED);


### PR DESCRIPTION
## #️⃣연관된 이슈

close #376 

## 📝 작업 내용

- checkApplyStatus API 리팩토링
  - 권한 설정: 기존 `permitAll` 권한을 `hasRole('ROLE_APPLY')`로 변경하여 인증된 사용자만 접근 가능하도록 수정했습니다.
  - 파라미터 변경: `@RequestParam email을` 제거하고, `@AuthPrincipal`을 통해 토큰에서 추출한 `memberId`를 사용하도록 변경했습니다. 이를 통해 이메일만 알면 타인의 지원 상태를 조회할 수 있었던 보안 취약점을 제거했습니다.
- service 계층 수정
  - ApplyService 및 ApplyUsecase의 메서드 시그니처를 변경하고, 불필요한 이메일 기반 회원 조회 로직을 제거했습니다.

## 🙏 리뷰 요구사항 (선택)

- API 명세 변경: 프론트엔드에서 해당 API 호출 시 더 이상 email 파라미터를 보낼 필요가 없으며, Authorization 헤더(토큰)가 필수입니다. 프론트엔드 연동 시 이 점 유의 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 개선**
  * 지원 상태 확인 엔드포인트의 보안이 강화되었습니다. 이전의 이메일 기반 접근에서 인증된 사용자 기반 접근 제어로 변경되어, 해당 권한을 가진 사용자만 본인의 지원 상태를 조회할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->