### PR TITLE
feat: 임시저장 지원서 조회 시 직군(JobFamily) 정보 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/admin/dto/TempApplyDetailResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/TempApplyDetailResponse.java
@@ -37,7 +37,7 @@ public record TempApplyDetailResponse(
             DateTimeUtil.formatWithDayOfWeek(apply.getCreatedAt()),
             DateTimeUtil.formatWithDayOfWeek(apply.getUpdatedAt()),
             apply.getRecruit().getJobFamily(),
-            TempApplicationFormResponse.from(answers, portfolios)
+            TempApplicationFormResponse.from(apply.getRecruit().getJobFamily(), answers, portfolios)
         );
     }
 }

--- a/src/main/java/org/ject/support/domain/apply/dto/TempApplicationFormResponse.java
+++ b/src/main/java/org/ject/support/domain/apply/dto/TempApplicationFormResponse.java
@@ -1,12 +1,17 @@
 package org.ject.support.domain.apply.dto;
 
+import org.ject.support.domain.member.JobFamily;
+
 import java.util.List;
 import java.util.Map;
 
-public record TempApplicationFormResponse(Map<String, String> answers,
+public record TempApplicationFormResponse(JobFamily jobFamily,
+                                          Map<String, String> answers,
                                           List<ApplyPortfolioDto> portfolios) {
 
-    public static TempApplicationFormResponse from(Map<String, String> answers, List<ApplyPortfolioDto> portfolios) {
-        return new TempApplicationFormResponse(answers, portfolios);
+    public static TempApplicationFormResponse from(JobFamily jobFamily,
+                                                   Map<String, String> answers,
+                                                   List<ApplyPortfolioDto> portfolios) {
+        return new TempApplicationFormResponse( jobFamily, answers, portfolios);
     }
 }

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -66,6 +66,7 @@ public class ApplyService implements ApplyUsecase {
 
         ApplicationForm tempApplicationForm = apply.getApplicationForm();
         return TempApplicationFormResponse.from(
+                apply.getRecruit().getJobFamily(),
                 string2MapSerializer.serializeAsMap(tempApplicationForm.getContent()),
                 tempApplicationForm.getPortfolios()
                         .stream()

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -476,6 +476,7 @@ class ApplyServiceTest extends UnitTestSupport {
         // then
         assertThat(result.answers()).isEqualTo(answers);
         assertThat(result.portfolios()).isEmpty();
+        assertThat(result.jobFamily()).isEqualTo(BE);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

close #378

## 📝 작업 내용

- TempApplicationFormResponse DTO에 jobFamily 필드를 추가했습니다.
- ApplyService의 findTempApplicationForm 메서드에서 임시 저장된 지원서의 jobFamily를 조회하여 응답에 포함하도록 수정했습니다.
- ApplyServiceTest에 변경된 응답 DTO를 검증하는 테스트 코드를 추가했습니다.


## 🙏 리뷰 요구사항 (선택)

- 프론트엔드에서 GET /apply/temp API 응답의 jobFamily 값을 확인하여, 현재 지원하려는 직군과 다를 경우 이전 지원서를 삭제하는 로직을 구현해야 합니다. (DELETE /apply/temp API 호출)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 임시 저장된 지원서 조회 시 응답에 직무군 정보가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->