### PR TITLE
[FEAT] 서포터즈용 토큰 발급 API 추가

### DIFF
--- a/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.ject.support.common.security.jwt.JwtExceptionHandlerFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -70,6 +71,10 @@ public class SecurityConfig {
                 })
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(request -> request
+                        .requestMatchers("/admin-auth/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/admin/**")
+                            .hasAnyRole("ADMIN", "SUPPORTER")
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
@@ -1,19 +1,15 @@
 package org.ject.support.common.security.jwt;
 
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
+import org.ject.support.common.exception.GlobalErrorCode;
+import org.ject.support.common.exception.GlobalException;
 import org.ject.support.common.security.CustomUserDetails;
+import org.ject.support.domain.auth.exception.AuthErrorCode;
+import org.ject.support.domain.auth.exception.AuthException;
 import org.ject.support.domain.member.Role;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -22,6 +18,9 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * JWT 토큰 기반의 인증을 처리하는 필터
@@ -39,38 +38,42 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
-            throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) {
 
         String accessToken = jwtTokenProvider.resolveAccessToken(request);
 
-        if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
-            try {
+        try {
+            if (accessToken != null) {
+                if (!jwtTokenProvider.validateToken(accessToken)) {
+                    throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+                }
                 Authentication auth = jwtTokenProvider.getAuthenticationByToken(accessToken);
                 SecurityContextHolder.getContext().setAuthentication(auth);
                 chain.doFilter(request, response);
                 return;
-            } catch (Exception e) {
-                log.error("엑세스 토큰 인증 실패: {}", e.getMessage());
             }
-        }
 
-        String verificationToken = jwtTokenProvider.resolveVerificationToken(request);
-        if (verificationToken != null && jwtTokenProvider.validateToken(verificationToken)) {
-            try {
+            String verificationToken = jwtTokenProvider.resolveVerificationToken(request);
+            if (verificationToken != null) {
+                if (!jwtTokenProvider.validateToken(verificationToken)) {
+                    throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+                }
                 // verification 토큰에서 이메일 추출
                 String email = jwtTokenProvider.extractEmailFromVerificationToken(verificationToken);
                 Authentication auth = createVerificationAuthentication(email);
                 SecurityContextHolder.getContext().setAuthentication(auth);
                 chain.doFilter(request, response);
                 return;
-            } catch (Exception e) {
-                log.error("검증 토큰 인증 실패: {}", e.getMessage());
             }
-        }
 
-        // 두 토큰 모두 없거나 유효하지 않으면, 인증 없이 진행
-        chain.doFilter(request, response);
+            // 두 토큰 모두 없으면 인증 없이 진행 (익명 요청)
+            chain.doFilter(request, response);
+
+        } catch (Exception e) {
+            log.error("JWT 인증 처리 중 에러 발생", e);
+            SecurityContextHolder.clearContext();
+            throw new GlobalException(GlobalErrorCode.INVALID_ACCESS_TOKEN);
+        }
     }
     
     private Authentication createVerificationAuthentication(String email) {

--- a/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
@@ -64,6 +64,12 @@ public class JwtTokenProvider {
     }
 
     public String createToken(Claims claims, long expirationMillis) {
+        if (claims == null) {
+            throw new IllegalArgumentException("Claims cannot be null");
+        }
+        if (expirationMillis <= 0) {
+            throw new IllegalArgumentException("Expiration time must be positive");
+        }
         Date now = new Date();
         Date expireDate = new Date(now.getTime() + expirationMillis);
 

--- a/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
@@ -10,8 +10,6 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import java.security.Key;
-import java.util.Date;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.exception.GlobalException;
@@ -22,6 +20,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
 
 import static org.ject.support.common.exception.GlobalErrorCode.AUTHENTICATION_REQUIRED;
 
@@ -53,6 +54,18 @@ public class JwtTokenProvider {
         claims.setSubject(authentication.getName());
         Date now = new Date();
         Date expireDate = new Date(now.getTime() + accessExpirationTime);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expireDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String createToken(Claims claims, long expirationMillis) {
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + expirationMillis);
 
         return Jwts.builder()
                 .setClaims(claims)

--- a/src/main/java/org/ject/support/common/springdoc/SpringdocConfig.java
+++ b/src/main/java/org/ject/support/common/springdoc/SpringdocConfig.java
@@ -48,7 +48,10 @@ public class SpringdocConfig {
     public GroupedOpenApi coreApi() {
         return GroupedOpenApi.builder()
                 .group("Core API")
-                .pathsToExclude("/admin/**")
+                .pathsToExclude(
+                        "/admin/**",
+                        "/admin-auth/**"
+                )
                 .build();
     }
 
@@ -56,7 +59,10 @@ public class SpringdocConfig {
     public GroupedOpenApi adminApi() {
         return GroupedOpenApi.builder()
                 .group("Admin API")
-                .pathsToMatch("/admin/**")
+                .pathsToMatch(
+                        "/admin/**",
+                        "/admin-auth/**"
+                )
                 .build();
     }
 }

--- a/src/main/java/org/ject/support/domain/admin/controller/AdminAuthController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/AdminAuthController.java
@@ -17,13 +17,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin")
+@RequestMapping("/admin-auth")
 public class AdminAuthController implements AdminAuthApiSpec {
 
     private final AdminAuthService adminAuthService;
     private final CustomSuccessHandler customSuccessHandler;
 
-    @PostMapping("/auth/codes")
+    @PostMapping("/code")
     public AdminAuthSendResponse sendAdminAuthCode(@RequestBody @Valid AdminAuthSendRequest request) {
         String email = adminAuthService.sendAdminAuthCode(request.email());
         return AdminAuthSendResponse.builder()
@@ -31,7 +31,7 @@ public class AdminAuthController implements AdminAuthApiSpec {
                 .build();
     }
 
-    @PostMapping("/auth/codes/verify")
+    @PostMapping("/verify-code")
     public boolean verifyAdminAuthCode(
             @RequestBody @Valid AdminVerifyRequest request,
             HttpServletRequest httpRequest,

--- a/src/main/java/org/ject/support/domain/admin/controller/AdminTempApplyController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/AdminTempApplyController.java
@@ -9,7 +9,6 @@ import org.ject.support.domain.member.JobFamily;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,25 +24,21 @@ public class AdminTempApplyController implements AdminTempApplyApiSpec {
     private final AdminTempApplyService adminTempApplyService;
 
     @GetMapping("/{tempApplyId}")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public TempApplyDetailResponse getTempApplyDetail(@PathVariable("tempApplyId") Long tempApplyId) {
         return adminTempApplyService.getTempApplyDetail(tempApplyId);
     }
 
     @GetMapping("/count")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public TempSavedApplyCountResponse getTempSavedApplyCount() {
         return adminTempApplyService.getTempSavedApplyCount();
     }
 
     @DeleteMapping("/{tempApplyId}")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void deleteTempApply(@PathVariable final Long tempApplyId) {
         adminTempApplyService.deleteTempApply(tempApplyId);
     }
 
     @GetMapping()
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public Page<TempSavedApplyResponse> getTempApplies(@RequestParam(required = false) JobFamily jobFamily,
                                                        @PageableDefault(size = 15) Pageable pageable) {
         return adminTempApplyService.getTempApplies(jobFamily, pageable);

--- a/src/main/java/org/ject/support/domain/admin/controller/ApplyPassController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/ApplyPassController.java
@@ -3,7 +3,6 @@ package org.ject.support.domain.admin.controller;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.admin.dto.ApplyPassRequest;
 import org.ject.support.domain.admin.service.ApplyPassService;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +17,6 @@ public class ApplyPassController implements ApplyPassApiSpec {
 
     @Override
     @PostMapping
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public int passApply(@RequestBody ApplyPassRequest request) {
         return applyPassService.passApply(request.applyIds());
     }

--- a/src/main/java/org/ject/support/domain/admin/controller/MemberManagementController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/MemberManagementController.java
@@ -2,18 +2,17 @@ package org.ject.support.domain.admin.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.ject.support.domain.admin.service.MemberManagementService;
-import org.ject.support.domain.member.JobFamily;
-import org.ject.support.domain.member.Role;
 import org.ject.support.domain.admin.dto.MemberBulkDeleteRequest;
 import org.ject.support.domain.admin.dto.MemberDetailResponse;
 import org.ject.support.domain.admin.dto.MemberEditRequest;
 import org.ject.support.domain.admin.dto.MemberRegisterRequest;
 import org.ject.support.domain.admin.dto.MemberResponse;
+import org.ject.support.domain.admin.service.MemberManagementService;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Role;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,7 +32,6 @@ public class MemberManagementController implements MemberManagementApiSpec {
 
     @Override
     @GetMapping
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public Page<MemberResponse> findMembers(@RequestParam final Role role,
                                             @RequestParam(required = false) final JobFamily jobFamily,
                                             @RequestParam(required = false) final Long semesterId,
@@ -43,21 +41,18 @@ public class MemberManagementController implements MemberManagementApiSpec {
 
     @Override
     @GetMapping("/{memberId}")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public MemberDetailResponse findMemberDetail(@PathVariable("memberId") final Long memberId) {
         return memberManagementService.findMemberDetail(memberId);
     }
 
     @Override
     @PostMapping
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void registerMember(@RequestBody @Valid final MemberRegisterRequest request) {
         memberManagementService.registerMember(request);
     }
 
     @Override
     @PutMapping("/{memberId}")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void editMember(@PathVariable("memberId") final Long memberId,
                              @RequestBody @Valid final MemberEditRequest request) {
         memberManagementService.editMember(memberId, request);
@@ -65,14 +60,12 @@ public class MemberManagementController implements MemberManagementApiSpec {
 
     @Override
     @DeleteMapping("/{memberId}")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void deleteMember(@PathVariable("memberId") final Long memberId) {
         memberManagementService.deleteMember(memberId);
     }
 
     @Override
     @DeleteMapping
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public int deleteMembers(@RequestBody @Valid final MemberBulkDeleteRequest request) {
         return memberManagementService.deleteMembers(request.memberIds());
     }

--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
@@ -12,7 +12,6 @@ import org.ject.support.domain.member.JobFamily;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,14 +30,12 @@ public class SubmittedApplyController implements SubmittedApplyApiSpec {
 
     @Override
     @GetMapping("/count")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public SubmittedApplyCountResponse getSubmittedApplyCount() {
         return submittedApplyService.countSubmittedApply();
     }
 
     @Override
     @GetMapping
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public Page<SubmittedApplyResponse> findSubmittedApplies(@RequestParam(required = false) final JobFamily jobFamily,
                                                              @PageableDefault(size = 15) final Pageable pageable) {
         return submittedApplyService.findSubmittedApplies(jobFamily, pageable);
@@ -46,14 +43,12 @@ public class SubmittedApplyController implements SubmittedApplyApiSpec {
 
     @Override
     @GetMapping("/{applyId}")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public SubmittedApplyDetailResponse findSubmittedApplyDetail(@PathVariable("applyId") final Long applyId) {
         return submittedApplyService.findSubmittedApplyDetail(applyId);
     }
 
     @Override
     @PutMapping("/{applyId}")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void editSubmittedApply(@PathVariable("applyId") final Long applyId,
                                    @RequestBody @Valid final SubmittedApplyEditRequest request) {
         submittedApplyService.updateSubmittedApply(applyId, request);
@@ -61,14 +56,12 @@ public class SubmittedApplyController implements SubmittedApplyApiSpec {
 
     @Override
     @DeleteMapping("/{applyId}")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void deleteSubmittedApply(@PathVariable("applyId") final Long applyId) {
         submittedApplyService.deleteSubmittedApply(applyId);
     }
 
     @Override
     @DeleteMapping
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public int deleteSubmittedApplies(@RequestBody @Valid final SubmittedApplyBulkDeleteRequest request) {
         return submittedApplyService.deleteSubmittedApplies(request.applyIds());
     }

--- a/src/main/java/org/ject/support/domain/admin/service/AdminAuthService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/AdminAuthService.java
@@ -46,7 +46,7 @@ public class AdminAuthService {
 
         if (discordRateLimiter.tryConsume(1)) {
             redisTemplate.opsForValue().set(key, authCode, Duration.ofSeconds(ADMIN_LOGIN_AUTH_CODE_EXPIRATION));
-            discordComponent.sendAdminLoginMessage(makeAdminLoginMessage(member.getEmail(), authCode))
+            discordComponent.sendAdminLoginMessage(member.getEmail(), authCode)
                     .doOnError(e -> log.error("Discord 전송 실패: {}", member.getEmail(), e))
                     .subscribe();
         } else {
@@ -108,13 +108,5 @@ public class AdminAuthService {
     private int getFailCount(String failCountKey) {
         String failCountStr = redisTemplate.opsForValue().get(failCountKey);
         return failCountStr == null ? 0 : Integer.parseInt(failCountStr);
-    }
-
-    private String makeAdminLoginMessage(String email, String code) {
-        return """
-               관리자 로그인 인증 코드 요청
-               관리자 이메일: %s
-               인증 코드 : %s
-               """.formatted(email, code);
     }
 }

--- a/src/main/java/org/ject/support/domain/auth/controller/AuthSupporterTokenController.java
+++ b/src/main/java/org/ject/support/domain/auth/controller/AuthSupporterTokenController.java
@@ -1,0 +1,30 @@
+package org.ject.support.domain.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.ject.support.domain.auth.dto.AuthDto;
+import org.ject.support.domain.auth.service.AuthSupporterTokenService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+@Tag(name = "Supporter", description = "서포터 API")
+public class AuthSupporterTokenController {
+
+    private final AuthSupporterTokenService authSupporterTokenService;
+
+    @Operation(
+            summary = "서포터 토큰 발급",
+            description = "서포터 전용 토큰을 발급합니다."
+    )
+    @PostMapping("/supporter/token")
+    @PreAuthorize("permitAll()")
+    public void generateSupporterToken(@RequestBody @Valid AuthDto.PinLoginRequest request) {
+        authSupporterTokenService.issueReadOnlyToken(request.email(), request.pin());
+    }
+}

--- a/src/main/java/org/ject/support/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/org/ject/support/domain/auth/exception/AuthErrorCode.java
@@ -14,7 +14,9 @@ public enum AuthErrorCode implements ErrorCode {
     NOT_FOUND_AUTH_CODE(UNAUTHORIZED, "AUTH-2", "인증 번호를 찾을 수 없습니다."),
     INVALID_REFRESH_TOKEN(UNAUTHORIZED, "AUTH-3", "유효하지 않은 리프레시 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(UNAUTHORIZED, "AUTH-4", "만료된 리프레시 토큰입니다."),
-    INVALID_CREDENTIALS(UNAUTHORIZED, "AUTH-5", "PIN 번호가 올바르지 않습니다.");
+    INVALID_CREDENTIALS(UNAUTHORIZED, "AUTH-5", "PIN 번호가 올바르지 않습니다."),
+    EXPIRED_TOKEN(UNAUTHORIZED, "AUTH-6", "만료된 토큰입니다."),
+    INVALID_TOKEN(UNAUTHORIZED, "AUTH-7", "유효하지 않은 토큰입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/ject/support/domain/auth/service/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/service/AuthService.java
@@ -1,12 +1,12 @@
 package org.ject.support.domain.auth.service;
 
 
-import static org.ject.support.domain.auth.exception.AuthErrorCode.*;
-import static org.ject.support.domain.member.exception.MemberErrorCode.*;
-
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
-import org.ject.support.domain.auth.exception.AuthException;
 import org.ject.support.domain.auth.dto.AuthVerificationResult;
+import org.ject.support.domain.auth.exception.AuthException;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberRepository;
@@ -19,9 +19,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
-import lombok.RequiredArgsConstructor;
+import static org.ject.support.domain.auth.exception.AuthErrorCode.EXPIRED_REFRESH_TOKEN;
+import static org.ject.support.domain.auth.exception.AuthErrorCode.INVALID_AUTH_CODE;
+import static org.ject.support.domain.auth.exception.AuthErrorCode.INVALID_CREDENTIALS;
+import static org.ject.support.domain.auth.exception.AuthErrorCode.INVALID_REFRESH_TOKEN;
+import static org.ject.support.domain.auth.exception.AuthErrorCode.NOT_FOUND_AUTH_CODE;
+import static org.ject.support.domain.member.exception.MemberErrorCode.NOT_FOUND_MEMBER;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/ject/support/domain/auth/service/AuthSupporterTokenService.java
+++ b/src/main/java/org/ject/support/domain/auth/service/AuthSupporterTokenService.java
@@ -26,7 +26,7 @@ import static org.ject.support.domain.auth.exception.AuthErrorCode.INVALID_CREDE
 @Transactional(readOnly = true)
 public class AuthSupporterTokenService {
 
-    private final long TOKEN_EXPIRATION_MILLIS = 10 * 60 * 1000; // 10분
+    private final long TOKEN_EXPIRATION_MILLIS = 24 * 60 * 60 * 1000; // 1일
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;

--- a/src/main/java/org/ject/support/domain/auth/service/AuthSupporterTokenService.java
+++ b/src/main/java/org/ject/support/domain/auth/service/AuthSupporterTokenService.java
@@ -1,0 +1,60 @@
+package org.ject.support.domain.auth.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ject.support.common.security.jwt.JwtTokenProvider;
+import org.ject.support.domain.admin.exception.AdminErrorCode;
+import org.ject.support.domain.admin.exception.AdminException;
+import org.ject.support.domain.auth.exception.AuthException;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.external.discord.DiscordComponent;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.ject.support.domain.auth.exception.AuthErrorCode.INVALID_CREDENTIALS;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthSupporterTokenService {
+
+    private final long TOKEN_EXPIRATION_MILLIS = 10 * 60 * 1000; // 10분
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final DiscordComponent discordComponent;
+
+    public void issueReadOnlyToken(String email, String pin) {
+        Member member = memberRepository.findByEmailAndRole(email, Role.ADMIN)
+                .orElseThrow(() -> new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
+
+        if (!passwordEncoder.matches(pin, member.getPin())) {
+            throw new AuthException(INVALID_CREDENTIALS);
+        }
+
+        Claims claims = Jwts.claims();
+        claims.put("memberId", member.getId());
+        claims.put("role", "ROLE_ADMIN");
+        claims.put("tokenType", "TEMP");
+        claims.put("purpose", "SUPPORTER_DATA_VIEW");
+        claims.put("scopes", List.of("ADMIN_READ"));
+        claims.setSubject("SYSTEM_SUPPORTER");
+
+        String token = jwtTokenProvider.createToken(claims, TOKEN_EXPIRATION_MILLIS);
+
+        discordComponent.sendSupporterTokenIssueMessage(email, token)
+                .doOnError(e -> {
+                    log.error("지원자 토큰 전송 실패: {}", email, e);
+                })
+                .subscribe();
+    }
+}

--- a/src/main/java/org/ject/support/domain/auth/service/AuthSupporterTokenService.java
+++ b/src/main/java/org/ject/support/domain/auth/service/AuthSupporterTokenService.java
@@ -43,8 +43,7 @@ public class AuthSupporterTokenService {
 
         Claims claims = Jwts.claims();
         claims.put("memberId", member.getId());
-        claims.put("role", "ROLE_ADMIN");
-        claims.put("tokenType", "TEMP");
+        claims.put("role", "ROLE_SUPPORTER");
         claims.put("purpose", "SUPPORTER_DATA_VIEW");
         claims.put("scopes", List.of("ADMIN_READ"));
         claims.setSubject("SYSTEM_SUPPORTER");

--- a/src/main/java/org/ject/support/domain/member/Role.java
+++ b/src/main/java/org/ject/support/domain/member/Role.java
@@ -4,5 +4,6 @@ public enum Role {
     ADMIN,          // 관리자
     SEMESTER,       // 동아리 원
     APPLY,          // 지원자
-    VERIFICATION;   // 임시
+    VERIFICATION,   // 임시
+    SUPPORTER       // 서포터즈 토큰 발급용 (임시)
 }

--- a/src/main/java/org/ject/support/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/RecruitController.java
@@ -25,21 +25,18 @@ public class RecruitController implements RecruitApiSpec {
 
     @Override
     @PostMapping
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void registerRecruit(@RequestBody @Valid List<RecruitRegisterRequest> requests) {
         recruitUsecase.registerRecruits(requests);
     }
 
     @Override
     @PutMapping("/{recruitId}")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void updateRecruit(@PathVariable Long recruitId, @RequestBody @Valid RecruitUpdateRequest request) {
         recruitUsecase.updateRecruit(recruitId, request);
     }
 
     @Override
     @DeleteMapping("/{recruitId}")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void cancelRecruit(@PathVariable Long recruitId) {
         recruitUsecase.cancelRecruit(recruitId);
     }

--- a/src/main/java/org/ject/support/domain/recruit/controller/SemesterRegisterController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/SemesterRegisterController.java
@@ -3,7 +3,6 @@ package org.ject.support.domain.recruit.controller;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.recruit.dto.SemesterRegisterRequest;
 import org.ject.support.domain.recruit.service.SemesterRegisterUsecase;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +17,6 @@ public class SemesterRegisterController implements SemesterRegisterApiSpec {
 
     @Override
     @PostMapping
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void register(@RequestBody SemesterRegisterRequest request) {
         semesterRegisterUsecase.registerSemester(request);
     }

--- a/src/main/java/org/ject/support/external/discord/DiscordComponent.java
+++ b/src/main/java/org/ject/support/external/discord/DiscordComponent.java
@@ -1,6 +1,7 @@
 package org.ject.support.external.discord;
 
 import lombok.extern.slf4j.Slf4j;
+import org.ject.support.external.notification.NotificationMessageFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
@@ -15,24 +16,47 @@ import reactor.core.publisher.Mono;
 public class DiscordComponent {
 
     private final WebClient webClient;
-    private final Environment environment;
     private final String prefix;
+    private final NotificationMessageFactory messageFactory;
 
     @Value("${notification.discord.webhook.admin-login}")
     private String adminLoginWebhook;
 
-    public DiscordComponent(WebClient webClient, Environment environment) {
+    @Value("${notification.discord.webhook.supporter-token-issue}")
+    private String supporterTokenIssueWebhook;
+
+    public DiscordComponent(
+            WebClient webClient,
+            Environment environment,
+            NotificationMessageFactory messageFactory
+    ) {
         this.webClient = webClient;
-        this.environment = environment;
         this.prefix = resolvePrefix(environment);
+        this.messageFactory = messageFactory;
     }
 
-    public Mono<Void> sendAdminLoginMessage(String description) {
-        DiscordWebhookPayload.Embed content = new DiscordWebhookPayload.Embed("로그인 인증 요청", description);
+    public Mono<Void> sendAdminLoginMessage(String email, String code) {
+        String description = messageFactory.adminLoginCode(email, code);
+
+        DiscordWebhookPayload.Embed embed =
+                new DiscordWebhookPayload.Embed("로그인 인증 요청", description);
+
         DiscordWebhookPayload payload = new DiscordWebhookPayload();
         payload.setContent("[관리자 로그인]");
-        payload.getEmbeds().add(content);
+        payload.getEmbeds().add(embed);
         return sendMessage(adminLoginWebhook, payload);
+    }
+
+    public Mono<Void> sendSupporterTokenIssueMessage(String email, String accessToken) {
+        String description = messageFactory.supporterAccessTokenIssued(email, accessToken);
+
+        DiscordWebhookPayload.Embed embed =
+                new DiscordWebhookPayload.Embed("서포터즈 엑세스 토큰 발급 요청", description);
+
+        DiscordWebhookPayload payload = new DiscordWebhookPayload();
+        payload.setContent("[서포터즈 엑세스 토큰 발급]");
+        payload.getEmbeds().add(embed);
+        return sendMessage(supporterTokenIssueWebhook, payload);
     }
 
     /**

--- a/src/main/java/org/ject/support/external/email/controller/ManualEmailSendController.java
+++ b/src/main/java/org/ject/support/external/email/controller/ManualEmailSendController.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.ject.support.external.email.dto.SendManualBulkTemplatedEmailRequest;
 import org.ject.support.external.email.dto.SendManualTemplatedEmailRequest;
 import org.ject.support.external.email.service.SesEmailSendService;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,14 +18,12 @@ public class ManualEmailSendController implements ManualEmailSendApiSpec {
 
     @Override
     @PostMapping
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void sendManualTemplatedEmail(@RequestBody SendManualTemplatedEmailRequest request) {
         emailSendService.sendTemplatedEmail(request.sendGroupCode(), request.to(), request.content());
     }
 
     @Override
     @PostMapping("/bulk")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void sendManualBulkTemplatedEmail(@RequestBody SendManualBulkTemplatedEmailRequest request) {
         emailSendService.sendBulkTemplatedEmail(request.sendGroupCode(), request.toList(), request.content());
     }

--- a/src/main/java/org/ject/support/external/notification/DiscordNotificationMessageFactory.java
+++ b/src/main/java/org/ject/support/external/notification/DiscordNotificationMessageFactory.java
@@ -1,0 +1,27 @@
+package org.ject.support.external.notification;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Primary
+@Component
+public class DiscordNotificationMessageFactory implements NotificationMessageFactory {
+
+    @Override
+    public String adminLoginCode(String email, String code) {
+        return """
+               관리자 로그인 인증 코드 요청
+               관리자 이메일: %s
+               인증 코드 : ||%s||
+               """.formatted(email, code);
+    }
+
+    @Override
+    public String supporterAccessTokenIssued(String email, String accessToken) {
+        return """
+               서포터즈 엑세스 토큰 요청
+               요청 이메일 : %s
+               토큰 : ||%s||
+               """.formatted(email, accessToken);
+    }
+}

--- a/src/main/java/org/ject/support/external/notification/NotificationMessageFactory.java
+++ b/src/main/java/org/ject/support/external/notification/NotificationMessageFactory.java
@@ -1,0 +1,6 @@
+package org.ject.support.external.notification;
+
+public interface NotificationMessageFactory {
+    String adminLoginCode(String email, String code);
+    String supporterAccessTokenIssued(String email, String accessToken);
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -68,3 +68,4 @@ notification:
   discord:
     webhook:
       admin-login: dummy-url-for-test
+      supporter-token-issue: dummy-url-for-test

--- a/src/test/java/org/ject/support/domain/admin/service/AdminAuthServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/AdminAuthServiceTest.java
@@ -110,7 +110,7 @@ class AdminAuthServiceTest extends UnitTestSupport {
         given(adminMemberComponent.getMemberAdminByEmail(email)).willReturn(adminMember);
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(discordRateLimiter.tryConsume(1)).willReturn(true);
-        given(discordComponent.sendAdminLoginMessage(anyString())).willReturn(Mono.empty());
+        given(discordComponent.sendAdminLoginMessage(anyString(), anyString())).willReturn(Mono.empty());
 
         // when
         String result = adminAuthService.sendAdminAuthCode(email);


### PR DESCRIPTION
## #️⃣연관된 이슈

close #395

## 📝 작업 내용

### 1. 서포터즈용 accessToken 발급 API 추가
 - email, pin 필요
 - Member 테이블의 Role 은 ADMIN만 가능
 - accessToken의 Role은 'SUPPORTER' 로 기록해둠 (추후 프론트 ADMIN 페이지 연동시 해당 Role 삭제)
 - accessToken의 만료기간을 1일로 설정
 
### 2. OpenAPI 그룹 규칙 수정
 - AS-IS : /admin/** -> Swagger ADMIN API Group
 - TO-BE : /admin/**, /admin-auth/** -> Swagger ADMIN API Group

### 3. Spring Security Config authorizeHttpRequests 규칙 수정
 - 기존에 모든 API에 대해 permitAll() 권한이였던 부분중 Admin 권한이 필요한 부분만 따로 규칙을 추가해주었습니다.
 - /admin/** -> Role이 ADMIN 일 경우에 대해서만 접근 가능
 - 단 [GET] /admin/** 일 경우에 대해서는 SUPPORTER Role도 접근 가능
 - /admin-auth/** -> permitAll()
 - 위 규칙을 적용하기 위해 admin 로그인 인증하는 API의 uri의 prefix를 /admin-auth 로 변경해 주었습니다.
 - Security Filter에 규칙을 적용함에 따라 Admin Controller에 있는 @PreAuthorize("hasRole('ROLE_ADMIN')") 를 삭제해주었습니다.
 
 ## Description
  - 디스코드에 토큰을 받아볼 수 있는 Private 채널의 webhook url을 추가했습니다.
  - application-local 파일에 추가 부탁드립니다. (S3 dev, prod 반영 완료)
```
notification:
  discord:
    webhook:
      supporter-token-issue: {{url}}
```
 - 작업하다보니 Jwt관련 Filter, Provider 부분에 예외 처리가 잘 안되어있더라구요 전부 작업하기엔 작업의 단위가 많아질꺼 같아 일부만 수정해 두었습니다. ex) accessToken이 만료됬을때 만료 Exception을 내려줘야 하는데 이런 처리가 안되어있음
 
 
 
 ## Discord 수신 이미지

<img width="559" height="240" alt="image" src="https://github.com/user-attachments/assets/89739be2-21fe-44ae-8b2f-c4fb591c6850" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 지지자용 토큰 발급 기능 추가
  * 토큰 검증 강화 및 명확한 오류 코드 제공

* **버그 수정**
  * JWT 인증 필터의 예외 처리 및 오류 관리 개선

* **리팩토링**
  * 관리자 인증 관련 엔드포인트 경로 재정렬
  * 다수의 관리자 기능 엔드포인트에 대한 권한 검증 요구사항 조정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->