### PR TITLE
feat: JWT 인증 필터에서 액세스 토큰 및 검증 토큰 처리 로직 개선

### DIFF
--- a/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package org.ject.support.common.security.jwt;
 
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -40,33 +41,40 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) {
 
-        String accessToken = jwtTokenProvider.resolveAccessToken(request);
-
         try {
+            // =========================
+            // 1. Access Token 처리 (선택 인증)
+            // =========================
+            String accessToken = jwtTokenProvider.resolveAccessToken(request);
+
             if (accessToken != null) {
-                if (!jwtTokenProvider.validateToken(accessToken)) {
-                    throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+                if (jwtTokenProvider.validateToken(accessToken)) {
+                    Authentication auth = jwtTokenProvider.getAuthenticationByToken(accessToken);
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                } else {
+                    clearAuthCookie(response, "accessToken");
+                    SecurityContextHolder.clearContext();
                 }
-                Authentication auth = jwtTokenProvider.getAuthenticationByToken(accessToken);
-                SecurityContextHolder.getContext().setAuthentication(auth);
-                chain.doFilter(request, response);
-                return;
             }
 
-            String verificationToken = jwtTokenProvider.resolveVerificationToken(request);
+            // =========================
+            // 2. Verification Token 처리 (의도적 인증)
+            // =========================
+            String verificationToken =
+                    jwtTokenProvider.resolveVerificationToken(request);
+
             if (verificationToken != null) {
                 if (!jwtTokenProvider.validateToken(verificationToken)) {
+                    // verification token은 실패 시 에러가 맞음
                     throw new AuthException(AuthErrorCode.INVALID_TOKEN);
                 }
-                // verification 토큰에서 이메일 추출
+
                 String email = jwtTokenProvider.extractEmailFromVerificationToken(verificationToken);
+
                 Authentication auth = createVerificationAuthentication(email);
                 SecurityContextHolder.getContext().setAuthentication(auth);
-                chain.doFilter(request, response);
-                return;
             }
 
-            // 두 토큰 모두 없으면 인증 없이 진행 (익명 요청)
             chain.doFilter(request, response);
 
         } catch (Exception e) {
@@ -87,5 +95,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return new UsernamePasswordAuthenticationToken(
                 userDetails, "", authorities);
     }
-}
 
+    private void clearAuthCookie(HttpServletResponse response, String cookieName) {
+        Cookie cookie = new Cookie(cookieName, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        response.addCookie(cookie);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #343 

## 📝 작업 내용

임시 AccessToken 발급 작업의 연장선으로 Token 처리 방식을 개선했습니다.

### 1. accessToken 처리 방식 개선
 - accessToken은 선택 인증 토큰으로 처리
 - 유효한 경우에만 Authentication을 설정
 - 유효하지 않은 경우:
  - accessToken 쿠키 삭제
  - SecurityContext 정리
  - 요청은 계속 진행 (permitAll API 정상 동작)
  
### 2. verificationToken 처리 명확화 (의도적 인증) 
 - verificationToken은 반드시 유효해야 하는 토큰으로 유지
 - 유효하지 않은 경우 AuthException 발생
 - 이메일 인증 등 의도적인 인증 플로우에만 사용

### 3. 쿠키 삭제 로직 공통화
 - accessToken / verificationToken 삭제 로직의 중복을 제거
 - 쿠키 이름만 전달받는 공통 메서드로 분리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 토큰 검증 실패 시 불필요한 토큰을 자동으로 제거하여 로그인 상태 관리 개선
  * 잘못된 인증 토큰에 대한 명확한 오류 처리 추가

* **개선 사항**
  * 접근 토큰과 인증 토큰 처리 흐름을 분리하여 보안 강화
  * 세션 정보 관리의 안정성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->