### PR TITLE
feat: JWT 인증 필터에서 검증 토큰 처리 로직 개선 및 쿠키 삭제 기능 추가

### DIFF
--- a/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
@@ -9,8 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.ject.support.common.exception.GlobalErrorCode;
 import org.ject.support.common.exception.GlobalException;
 import org.ject.support.common.security.CustomUserDetails;
-import org.ject.support.domain.auth.exception.AuthErrorCode;
-import org.ject.support.domain.auth.exception.AuthException;
 import org.ject.support.domain.member.Role;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -64,9 +62,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     jwtTokenProvider.resolveVerificationToken(request);
 
             if (verificationToken != null) {
-                if (!jwtTokenProvider.validateToken(verificationToken)) {
-                    // verification token은 실패 시 에러가 맞음
-                    throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+                if (jwtTokenProvider.validateToken(verificationToken)) {
+                    // 토큰이 유효한 경우, 인증 정보를 SecurityContext에 설정
+                    Authentication auth = jwtTokenProvider.getAuthenticationByToken(accessToken);
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                } else {
+                    clearAuthCookie(response, "Authentication auth = jwtTokenProvider.getAuthenticationByToken(accessToken);\n" +
+                            "                    SecurityContextHolder.getContext().setAuthentication(auth);");
+                    SecurityContextHolder.clearContext();
                 }
 
                 String email = jwtTokenProvider.extractEmailFromVerificationToken(verificationToken);

--- a/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
@@ -214,6 +214,7 @@ public class JwtTokenProvider {
         Cookie cookie = new Cookie("verificationToken", null);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
+        cookie.setSecure(true);
         cookie.setMaxAge(0);
         response.addCookie(cookie);
     }

--- a/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtTokenProvider.java
@@ -10,6 +10,7 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.exception.GlobalException;
@@ -205,7 +206,18 @@ public class JwtTokenProvider {
                 .signWith(secretKey)
                 .compact();
     }
-    
+
+    /**
+     * 인증번호 검증 쿠키 삭제
+     */
+    public void deleteVerificationCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("verificationToken", null);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+
     /**
      * 인증번호 검증 토큰에서 이메일 추출
      */

--- a/src/main/java/org/ject/support/domain/member/controller/MemberController.java
+++ b/src/main/java/org/ject/support/domain/member/controller/MemberController.java
@@ -50,6 +50,9 @@ public class MemberController implements MemberApiSpec {
         Authentication authentication = memberService.registerTempMember(registerRequest, email);
         customSuccessHandler.onAuthenticationSuccess(request, response, authentication);
 
+        // verification 토큰은 더 이상 필요 없으므로 삭제
+        jwtTokenProvider.deleteVerificationCookie(response);
+
         return true;
     }
 


### PR DESCRIPTION
## 📝 작업 내용

### 1. AccessToken 생성시 VerificationCookie 삭제
 - VerificationCookie 이 남게 되면서 불필요한 Verification 인증이 계속 진행 되는 부분을 방지 하고자 위 기능을 추가




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 접근 토큰 검증 로직 개선으로 인증 보안 강화
  * 회원 가입 완료 후 검증 토큰 자동 정리로 인증 쿠키 관리 개선
  * 잘못된 검증 토큰에 대한 인증 세션 초기화 처리 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->