### PR TITLE
feat: 미니 스터디 설명 필드 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/ministudy/dto/MiniStudyResponse.java
+++ b/src/main/java/org/ject/support/domain/ministudy/dto/MiniStudyResponse.java
@@ -4,7 +4,7 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 
 @Builder
-public record MiniStudyResponse(Long id, String name, String linkUrl, String imageUrl, String summary) {
+public record MiniStudyResponse(Long id, String name, String linkUrl, String imageUrl, String summary, String tag) {
 
     @QueryProjection
     public MiniStudyResponse {

--- a/src/main/java/org/ject/support/domain/ministudy/entity/MiniStudy.java
+++ b/src/main/java/org/ject/support/domain/ministudy/entity/MiniStudy.java
@@ -23,6 +23,9 @@ public class MiniStudy extends BaseTimeEntity {
     @Column(nullable = false)
     private String summary;
 
+    @Column(nullable = false)
+    private String tag;
+
     @Column(length = 2083)
     private String linkUrl;
 

--- a/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryImpl.java
@@ -28,7 +28,8 @@ public class MiniStudyQueryRepositoryImpl implements MiniStudyQueryRepository {
                         miniStudy.name,
                         miniStudy.linkUrl,
                         miniStudy.imageUrl,
-                        miniStudy.summary
+                        miniStudy.summary,
+                        miniStudy.tag
                 ))
                 .from(miniStudy)
                 .orderBy(miniStudy.id.desc())

--- a/src/main/resources/db/migration/V14__add_tag_column_to_mini_study.sql
+++ b/src/main/resources/db/migration/V14__add_tag_column_to_mini_study.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mini_study
+    ADD COLUMN tag VARCHAR(255) NOT NULL DEFAULT '';

--- a/src/test/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/ministudy/repository/MiniStudyQueryRepositoryTest.java
@@ -47,6 +47,7 @@ class MiniStudyQueryRepositoryTest {
         assertThat(firstResponse.id()).isNotNull();
         assertThat(firstResponse.name()).isEqualTo("미니 스터디 3"); // ID 내림차순이므로 마지막에 생성된 데이터가 첫 번째
         assertThat(firstResponse.summary()).isEqualTo("summary");
+        assertThat(firstResponse.tag()).isEqualTo("test-tag");
         assertThat(firstResponse.linkUrl()).isEqualTo("https://test.net/ministudy3");
         assertThat(firstResponse.imageUrl()).isEqualTo("https://test.net/image3.png");
 
@@ -60,6 +61,7 @@ class MiniStudyQueryRepositoryTest {
         return MiniStudy.builder()
                 .name(name)
                 .summary("summary")
+                .tag("test-tag")
                 .linkUrl("https://test.net/ministudy" + urlSafeName)
                 .imageUrl("https://test.net/image" + urlSafeName + ".png")
                 .build();


### PR DESCRIPTION
## #️⃣연관된 이슈

close #407 

## 📝 작업 내용

기존 summary 데이터를 tag로 migraition하고, summary에 ministudy에 대한 description 정보를 저장합니다.
- 미니 스터디 엔티티에 tag 필드를 추가
- DB Migration tag 필드 추가 (VARCHAR(255), NOT NULL)
- QueryDSL 조회 쿼리에 tag 필드 포함하도록 수정
- 미니 스터디 조회 테스트에 tag 필드 검증 로직 추가
- 테스트 데이터 생성 시 tag 필드 포함
