### PR TITLE
feat: 관리자 지원서 조회 API에 기수 파라미터 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/admin/controller/AdminTempApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/AdminTempApplyApiSpec.java
@@ -37,6 +37,7 @@ public interface AdminTempApplyApiSpec {
     )
     Page<TempSavedApplyResponse> getTempApplies(
             @RequestParam(required = false) JobFamily jobFamily,
+            @RequestParam(required = false) final Long semesterId,
             @PageableDefault(size = 15) final Pageable pageable
     );
 }

--- a/src/main/java/org/ject/support/domain/admin/controller/AdminTempApplyController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/AdminTempApplyController.java
@@ -40,7 +40,8 @@ public class AdminTempApplyController implements AdminTempApplyApiSpec {
 
     @GetMapping()
     public Page<TempSavedApplyResponse> getTempApplies(@RequestParam(required = false) JobFamily jobFamily,
+                                                       @RequestParam(required = false) final Long semesterId,
                                                        @PageableDefault(size = 15) Pageable pageable) {
-        return adminTempApplyService.getTempApplies(jobFamily, pageable);
+        return adminTempApplyService.getTempApplies(jobFamily, semesterId, pageable);
     }
 }

--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyApiSpec.java
@@ -28,6 +28,7 @@ public interface SubmittedApplyApiSpec {
             summary = "제출된 지원서 목록 조회",
             description = "제출된 지원서들의 목록을 조회합니다.")
     Page<SubmittedApplyResponse> findSubmittedApplies(@RequestParam(required = false) final JobFamily jobFamily,
+                                                      @RequestParam(required = false) final Long semesterId,
                                                       @PageableDefault(size = 15) final Pageable pageable);
 
     @Operation(

--- a/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
+++ b/src/main/java/org/ject/support/domain/admin/controller/SubmittedApplyController.java
@@ -37,8 +37,9 @@ public class SubmittedApplyController implements SubmittedApplyApiSpec {
     @Override
     @GetMapping
     public Page<SubmittedApplyResponse> findSubmittedApplies(@RequestParam(required = false) final JobFamily jobFamily,
+                                                             @RequestParam(required = false) final Long semesterId,
                                                              @PageableDefault(size = 15) final Pageable pageable) {
-        return submittedApplyService.findSubmittedApplies(jobFamily, pageable);
+        return submittedApplyService.findSubmittedApplies(jobFamily, semesterId, pageable);
     }
 
     @Override

--- a/src/main/java/org/ject/support/domain/admin/service/AdminTempApplyService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/AdminTempApplyService.java
@@ -56,9 +56,9 @@ public class AdminTempApplyService {
         applyRepository.delete(apply);
     }
 
-    public Page<TempSavedApplyResponse> getTempApplies(JobFamily jobFamily, Pageable pageable) {
+    public Page<TempSavedApplyResponse> getTempApplies(JobFamily jobFamily, Long semesterId, Pageable pageable) {
         Apply.Status tempSavedStatus = Apply.Status.TEMP_SAVED;
-        Page<Apply> applyPage = applyRepository.findAppliesByStatus(jobFamily, tempSavedStatus, pageable);
+        Page<Apply> applyPage = applyRepository.findAppliesByStatus(jobFamily, tempSavedStatus, semesterId, pageable);
 
         List<TempSavedApplyResponse> content = applyPage.getContent().stream()
                 .map(this::toTempSavedApplyResponse)

--- a/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
@@ -41,8 +41,9 @@ public class SubmittedApplyService {
 
     @Transactional(readOnly = true)
     public Page<SubmittedApplyResponse> findSubmittedApplies(final JobFamily jobFamily,
+                                                             final Long semesterId,
                                                              final Pageable pageable) {
-        Page<Apply> applyPage = applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, pageable);
+        Page<Apply> applyPage = applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
 
         List<SubmittedApplyResponse> content = applyPage.getContent().stream()
                 .map(this::toSubmittedApplyResponse)

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepository.java
@@ -8,5 +8,6 @@ import org.springframework.data.domain.Pageable;
 public interface ApplyQueryRepository {
     Page<Apply> findAppliesByStatus(final JobFamily jobFamily,
                                     final Apply.Status status,
+                                    final Long semesterId,
                                     final Pageable pageable);
 }

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryImpl.java
@@ -26,7 +26,9 @@ public class ApplyQueryRepositoryImpl implements ApplyQueryRepository {
 
     @Override
     public Page<Apply> findAppliesByStatus(final JobFamily jobFamily,
-                                           final Apply.Status status, final Pageable pageable) {
+                                           final Apply.Status status,
+                                           final Long semesterId,
+                                           final Pageable pageable) {
 
         List<Apply> content = queryFactory
                 .selectFrom(apply)
@@ -37,7 +39,8 @@ public class ApplyQueryRepositoryImpl implements ApplyQueryRepository {
                 .where(
                         apply.member.isDeleted.eq(false),
                         eqJobFamily(jobFamily),
-                        eqApplyStatus(status)
+                        eqApplyStatus(status),
+                        eqSemesterId(semesterId)
                 )
                 .orderBy(apply.createdAt.desc())
                 .offset(pageable.getOffset())
@@ -51,7 +54,8 @@ public class ApplyQueryRepositoryImpl implements ApplyQueryRepository {
                 .where(
                         apply.member.isDeleted.eq(false),
                         eqJobFamily(jobFamily),
-                        eqApplyStatus(status)
+                        eqApplyStatus(status),
+                        eqSemesterId(semesterId)
                 ).fetchOne();
 
         return PageResponse.from(content, pageable, total);
@@ -65,6 +69,12 @@ public class ApplyQueryRepositoryImpl implements ApplyQueryRepository {
     private BooleanExpression eqApplyStatus(final Apply.Status status) {
         return Optional.ofNullable(status)
                 .map(apply.status::eq)
+                .orElse(null);
+    }
+
+    private BooleanExpression eqSemesterId(final Long semesterId) {
+        return Optional.ofNullable(semesterId)
+                .map(apply.recruit.semester.id::eq)
                 .orElse(null);
     }
 }

--- a/src/test/java/org/ject/support/domain/admin/service/AdminTempApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/AdminTempApplyServiceTest.java
@@ -164,16 +164,17 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
     void 임시_저장된_지원서를_조회할때_결과가_없으면_빈페이지_반환한다() {
         // given
         Pageable pageable = PageRequest.of(0, 10);
+        Long semesterId = null;
         Page<Apply> applyPage = new PageImpl<>(List.of(), pageable, 0);
 
-        given(applyRepository.findAppliesByStatus(null, Apply.Status.TEMP_SAVED, pageable))
+        given(applyRepository.findAppliesByStatus(null, Apply.Status.TEMP_SAVED, semesterId, pageable))
                 .willReturn(applyPage);
 
         // when
-        Page<TempSavedApplyResponse> result = adminTempApplyService.getTempApplies(null, pageable);
+        Page<TempSavedApplyResponse> result = adminTempApplyService.getTempApplies(null, semesterId, pageable);
 
         // then
-        verify(applyRepository).findAppliesByStatus(null, Apply.Status.TEMP_SAVED, pageable);
+        verify(applyRepository).findAppliesByStatus(null, Apply.Status.TEMP_SAVED, semesterId, pageable);
         assertThat(result.getTotalElements()).isEqualTo(0);
         assertThat(result.getContent()).isEmpty();
     }
@@ -182,6 +183,7 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
     void 임시_저장된_지원서를_조회_한다() {
         // given
         Pageable pageable = PageRequest.of(0, 10);
+        Long semesterId = null;
 
         Member m1 = Member.builder().name("김1").build();
         Member m2 = Member.builder().name("김2").build();
@@ -210,20 +212,55 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
         List<Apply> applies = List.of(a1, a2);
         Page<Apply> applyPage = new PageImpl<>(applies, pageable, applies.size());
 
-        given(applyRepository.findAppliesByStatus(null, Apply.Status.TEMP_SAVED, pageable))
+        given(applyRepository.findAppliesByStatus(null, Apply.Status.TEMP_SAVED, semesterId, pageable))
                 .willReturn(applyPage);
 
         // applicationForm.content가 "{}" 이므로 이 호출을 stub 처리
         given(string2MapSerializer.serializeAsMap("{}")).willReturn(java.util.Map.of());
 
         Page<TempSavedApplyResponse> result =
-                adminTempApplyService.getTempApplies(null, pageable);
+                adminTempApplyService.getTempApplies(null, semesterId, pageable);
 
-        verify(applyRepository).findAppliesByStatus(null,Apply.Status.TEMP_SAVED, pageable);
+        verify(applyRepository).findAppliesByStatus(null, Apply.Status.TEMP_SAVED, semesterId, pageable);
         assertThat(result.getTotalElements()).isEqualTo(2);
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getContent().get(0).applyId()).isEqualTo(1L);
         assertThat(result.getContent().get(1).applyId()).isEqualTo(2L);
     }
 
+    @Test
+    void 임시_저장된_지원서를_semesterId로_필터링하여_조회한다() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        Long semesterId = 1L;
+
+        Member member = Member.builder().name("김젝트").build();
+        Semester semester = Semester.builder().name("1").build();
+        Recruit recruit = Recruit.builder().semester(semester).build();
+        ApplicationForm form = ApplicationForm.builder().content("{}").build();
+
+        Apply apply = Apply.builder()
+                .id(1L)
+                .member(member)
+                .recruit(recruit)
+                .status(Apply.Status.TEMP_SAVED)
+                .applicationForm(form)
+                .build();
+
+        List<Apply> applies = List.of(apply);
+        Page<Apply> applyPage = new PageImpl<>(applies, pageable, applies.size());
+
+        given(applyRepository.findAppliesByStatus(null, Apply.Status.TEMP_SAVED, semesterId, pageable))
+                .willReturn(applyPage);
+        given(string2MapSerializer.serializeAsMap("{}")).willReturn(java.util.Map.of());
+
+        // when
+        Page<TempSavedApplyResponse> result = adminTempApplyService.getTempApplies(null, semesterId, pageable);
+
+        // then
+        verify(applyRepository).findAppliesByStatus(null, Apply.Status.TEMP_SAVED, semesterId, pageable);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).applyId()).isEqualTo(1L);
+    }
 }

--- a/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
@@ -219,39 +219,41 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         // given
         var pageable = PageRequest.of(0, 15);
         var jobFamily = JobFamily.BE;
+        Long semesterId = null;
 
         var applies = List.of(submittedApply);
         var page = new PageImpl<>(applies, pageable, 1L);
 
-        given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED ,pageable))
+        given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable))
                 .willReturn(page);
 
         // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, pageable);
+        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, pageable);
+        verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
     }
 
     @Test
     void 제출된_지원서_목록_조회시_JobFamily가_null이면_전체_조회() {
         // given
         var pageable = PageRequest.of(0, 15);
+        Long semesterId = null;
         var applies = List.of(submittedApply);
         var page = new PageImpl<>(applies, pageable, 1L);
 
-        given(applyRepository.findAppliesByStatus(null, Status.SUBMITTED, pageable))
+        given(applyRepository.findAppliesByStatus(null, Status.SUBMITTED, semesterId, pageable))
                 .willReturn(page);
 
         // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(null, pageable);
+        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(null, semesterId, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(applyRepository).findAppliesByStatus(null, Status.SUBMITTED, pageable);
+        verify(applyRepository).findAppliesByStatus(null, Status.SUBMITTED, semesterId, pageable);
     }
 
     @Test
@@ -259,18 +261,19 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         // given
         var pageable = PageRequest.of(0, 15);
         var jobFamily = JobFamily.BE;
+        Long semesterId = null;
         var page = new PageImpl<Apply>(List.of(), pageable, 0L);
 
-        given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, pageable))
+        given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable))
                 .willReturn(page);
 
         // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, pageable);
+        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, pageable);
 
         // then
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
-        verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, pageable);
+        verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
     }
 
     @Test
@@ -278,6 +281,7 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         // given
         var pageable = PageRequest.of(1, 10, Sort.by("createdAt").descending());
         var jobFamily = JobFamily.BE;
+        Long semesterId = null;
 
         var member2 = Member.builder().name("김젝트2").build();
         var apply2 = Apply.builder()
@@ -291,18 +295,40 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         var applies = List.of(submittedApply, apply2);
         var page = new PageImpl<>(applies, pageable, 25L);
 
-        given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, pageable))
+        given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable))
                 .willReturn(page);
 
         // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, pageable);
+        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(25L);
         assertThat(result.getNumber()).isEqualTo(1);
         assertThat(result.getSize()).isEqualTo(10);
-        verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, pageable);
+        verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
+    }
+
+    @Test
+    void 제출된_지원서_목록을_semesterId로_필터링하여_조회() {
+        // given
+        var pageable = PageRequest.of(0, 15);
+        var jobFamily = JobFamily.BE;
+        Long semesterId = 1L;
+
+        var applies = List.of(submittedApply);
+        var page = new PageImpl<>(applies, pageable, 1L);
+
+        given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable))
+                .willReturn(page);
+
+        // when
+        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryTest.java
@@ -83,7 +83,7 @@ class ApplyQueryRepositoryTest {
         Apply.Status status = SUBMITTED;
 
         // when
-        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, pageable);
+        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(2);
@@ -110,7 +110,7 @@ class ApplyQueryRepositoryTest {
         Apply.Status status = SUBMITTED;
 
         // when
-        Page<Apply> result = applyRepository.findAppliesByStatus(null, status, pageable);
+        Page<Apply> result = applyRepository.findAppliesByStatus(null, status, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(3);
@@ -132,7 +132,7 @@ class ApplyQueryRepositoryTest {
         Apply.Status status = SUBMITTED;
 
         // when
-        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, pageable);
+        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
@@ -155,7 +155,7 @@ class ApplyQueryRepositoryTest {
         Apply.Status status = SUBMITTED;
 
         // when
-        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, pageable);
+        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
@@ -176,7 +176,7 @@ class ApplyQueryRepositoryTest {
         Apply.Status status = SUBMITTED;
 
         // when
-        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, pageable);
+        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(10);
@@ -192,7 +192,7 @@ class ApplyQueryRepositoryTest {
         Apply.Status status = SUBMITTED;
 
         // when
-        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, pageable);
+        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, null, pageable);
 
 
         // then
@@ -221,13 +221,55 @@ class ApplyQueryRepositoryTest {
         Apply.Status status = SUBMITTED;
 
         // when
-        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, pageable);
+        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(3);
         assertThat(result.getContent().get(0)).isEqualTo(apply3);
         assertThat(result.getContent().get(1)).isEqualTo(apply2);
         assertThat(result.getContent().get(2)).isEqualTo(apply1);
+    }
+
+    @Test
+    void semesterId로_제출된_지원서_필터링_조회() {
+        // given
+        Semester semester2 = semesterRepository.save(Semester.builder()
+                .name("2기")
+                .isRecruiting(false)
+                .build());
+
+        Recruit recruit1 = recruitRepository.save(Recruit.builder()
+                .semester(semester)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(7))
+                .jobFamily(BE)
+                .build());
+
+        Recruit recruit2 = recruitRepository.save(Recruit.builder()
+                .semester(semester2)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(7))
+                .jobFamily(BE)
+                .build());
+
+        Member member1 = createMember("be1@test.com", BE);
+        Member member2 = createMember("be2@test.com", BE);
+        memberRepository.saveAll(List.of(member1, member2));
+
+        Apply apply1 = getApply(member1, recruit1, SUBMITTED);
+        Apply apply2 = getApply(member2, recruit2, SUBMITTED);
+        applyRepository.saveAll(List.of(apply1, apply2));
+
+        Pageable pageable = PageRequest.of(0, 15);
+        Apply.Status status = SUBMITTED;
+
+        // when
+        Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, semester.getId(), pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().getFirst().getRecruit().getSemester()).isEqualTo(semester);
     }
 
     private Recruit getRecruit(JobFamily jobFamily) {


### PR DESCRIPTION
## #️⃣연관된 이슈

close #406

## 📝 작업 내용

지원서 목록 조회 API에 `semesterId` 필터링 기능을 추가했습니다.
- 컨트롤러에 `@RequestParam(required = false) final Long semesterId` 파라미터 추가
- 서비스 레이어에서 Repository로 semesterId 전달하도록 구현
- Repository의 `findAppliesByStatus` 메서드가 semesterId를 받아 필터링 수행
- `semesterId`는 optional 파라미터로 구현되어 기존 API 호출에 영향 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 지원서 조회 시 학기별 필터링 옵션 추가
    * 임시 저장 지원서 조회에 학기 필터 지원
    * 제출된 지원서 조회에 학기 필터 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->