### PR TITLE
feat: Jectalk 엔티티 스펙 변경

### DIFF
--- a/src/main/java/org/ject/support/domain/jectalk/controller/JectalkApiSpec.java
+++ b/src/main/java/org/ject/support/domain/jectalk/controller/JectalkApiSpec.java
@@ -1,11 +1,14 @@
 package org.ject.support.domain.jectalk.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.ject.support.domain.jectalk.dto.JectalkResponse;
+import org.ject.support.domain.project.entity.Project;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Jectalk", description = "젝톡 API")
 public interface JectalkApiSpec {
@@ -14,5 +17,8 @@ public interface JectalkApiSpec {
             summary = "젝톡 목록 조회",
             description = "젝톡 목록을 조회합니다."
     )
-    Page<JectalkResponse> findJectalks(@PageableDefault(size = 12) Pageable pageable);
+    Page<JectalkResponse> findJectalks(
+            @PageableDefault(size = 12) Pageable pageable,
+            @Parameter(description = "기수 (SEMESTER_1, SEMESTER_2, SEMESTER_3)", example = "SEMESTER_1")
+            @RequestParam(required = false) Project.Category category);
 }

--- a/src/main/java/org/ject/support/domain/jectalk/controller/JectalkController.java
+++ b/src/main/java/org/ject/support/domain/jectalk/controller/JectalkController.java
@@ -3,11 +3,13 @@ package org.ject.support.domain.jectalk.controller;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.jectalk.dto.JectalkResponse;
 import org.ject.support.domain.jectalk.service.JectalkService;
+import org.ject.support.domain.project.entity.Project;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,7 +21,9 @@ public class JectalkController implements JectalkApiSpec {
 
     @Override
     @GetMapping
-    public Page<JectalkResponse> findJectalks(@PageableDefault(size = 12) Pageable pageable) {
-        return jectalkService.findJectalks(pageable);
+    public Page<JectalkResponse> findJectalks(
+            @PageableDefault(size = 12) Pageable pageable,
+            @RequestParam(required = false) Project.Category category) {
+        return jectalkService.findJectalks(pageable, category);
     }
 }

--- a/src/main/java/org/ject/support/domain/jectalk/dto/JectalkResponse.java
+++ b/src/main/java/org/ject/support/domain/jectalk/dto/JectalkResponse.java
@@ -2,9 +2,17 @@ package org.ject.support.domain.jectalk.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
+import org.ject.support.domain.jectalk.enums.ContentType;
 
 @Builder
-public record JectalkResponse(Long id, String name, String youtubeUrl, String imageUrl, String summary) {
+public record JectalkResponse(
+        Long id,
+        String title,
+        String description,
+        String contentUrl,
+        ContentType contentType,
+        String thumbnailUrl,
+        String summary) {
 
     @QueryProjection
     public JectalkResponse {

--- a/src/main/java/org/ject/support/domain/jectalk/entity/Jectalk.java
+++ b/src/main/java/org/ject/support/domain/jectalk/entity/Jectalk.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;
 import org.ject.support.domain.jectalk.enums.ContentType;
+import org.ject.support.domain.project.entity.Project.Category;
 
 @Entity
 @Getter
@@ -38,4 +39,8 @@ public class Jectalk extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String author;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(30)", nullable = false)
+    private Category category;
 }

--- a/src/main/java/org/ject/support/domain/jectalk/entity/Jectalk.java
+++ b/src/main/java/org/ject/support/domain/jectalk/entity/Jectalk.java
@@ -4,10 +4,13 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;
+import org.ject.support.domain.jectalk.enums.ContentType;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,14 +21,21 @@ public class Jectalk extends BaseTimeEntity {
     private Long id;
 
     @Column(length = 50, nullable = false)
-    private String name;
+    private String title;
 
     @Column(nullable = false)
-    private String summary;
+    private String description;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContentType contentType;
 
     @Column(length = 2083)
-    private String youtubeUrl;
+    private String contentUrl;
 
     @Column(length = 2083)
-    private String imageUrl;
+    private String thumbnailUrl;
+
+    @Column(nullable = false)
+    private String author;
 }

--- a/src/main/java/org/ject/support/domain/jectalk/enums/ContentType.java
+++ b/src/main/java/org/ject/support/domain/jectalk/enums/ContentType.java
@@ -1,0 +1,13 @@
+package org.ject.support.domain.jectalk.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ContentType {
+    YOUTUBE("YouTube"),
+    ;
+
+    private final String name;
+}

--- a/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepository.java
@@ -1,9 +1,10 @@
 package org.ject.support.domain.jectalk.repository;
 
 import org.ject.support.domain.jectalk.dto.JectalkResponse;
+import org.ject.support.domain.project.entity.Project;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface JectalkQueryRepository {
-    Page<JectalkResponse> findJectalks(Pageable pageable);
+    Page<JectalkResponse> findJectalks(Pageable pageable, Project.Category category);
 }

--- a/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryImpl.java
@@ -1,17 +1,20 @@
 package org.ject.support.domain.jectalk.repository;
 
+import static org.ject.support.domain.jectalk.entity.QJectalk.jectalk;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.data.PageResponse;
 import org.ject.support.domain.jectalk.dto.JectalkResponse;
 import org.ject.support.domain.jectalk.dto.QJectalkResponse;
+import org.ject.support.domain.project.entity.Project;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-
-import static org.ject.support.domain.jectalk.entity.QJectalk.jectalk;
 
 @Repository
 @RequiredArgsConstructor
@@ -20,7 +23,7 @@ public class JectalkQueryRepositoryImpl implements JectalkQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<JectalkResponse> findJectalks(Pageable pageable) {
+    public Page<JectalkResponse> findJectalks(Pageable pageable, Project.Category category) {
         List<JectalkResponse> content = queryFactory
                 .select(new QJectalkResponse(
                         jectalk.id,
@@ -32,6 +35,7 @@ public class JectalkQueryRepositoryImpl implements JectalkQueryRepository {
                         jectalk.author
                 ))
                 .from(jectalk)
+                .where(categoryEq(category))
                 .orderBy(jectalk.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -39,8 +43,15 @@ public class JectalkQueryRepositoryImpl implements JectalkQueryRepository {
 
         JPAQuery<Long> countQuery = queryFactory
                 .select(jectalk.count())
-                .from(jectalk);
+                .from(jectalk)
+                .where(categoryEq(category));
 
         return PageResponse.from(content, pageable, countQuery.fetchFirst());
+    }
+
+    private BooleanExpression categoryEq(Project.Category category) {
+        return Optional.ofNullable(category)
+                .map(jectalk.category::eq)
+                .orElse(null);
     }
 }

--- a/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryImpl.java
@@ -24,10 +24,12 @@ public class JectalkQueryRepositoryImpl implements JectalkQueryRepository {
         List<JectalkResponse> content = queryFactory
                 .select(new QJectalkResponse(
                         jectalk.id,
-                        jectalk.name,
-                        jectalk.youtubeUrl,
-                        jectalk.imageUrl,
-                        jectalk.summary
+                        jectalk.title,
+                        jectalk.description,
+                        jectalk.contentUrl,
+                        jectalk.contentType,
+                        jectalk.thumbnailUrl,
+                        jectalk.author
                 ))
                 .from(jectalk)
                 .orderBy(jectalk.id.desc())

--- a/src/main/java/org/ject/support/domain/jectalk/service/JectalkService.java
+++ b/src/main/java/org/ject/support/domain/jectalk/service/JectalkService.java
@@ -3,6 +3,7 @@ package org.ject.support.domain.jectalk.service;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.jectalk.dto.JectalkResponse;
 import org.ject.support.domain.jectalk.repository.JectalkRepository;
+import org.ject.support.domain.project.entity.Project;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,9 +16,9 @@ public class JectalkService {
 
     private final JectalkRepository jectalkRepository;
 
-    @Cacheable(value = "jectalk", key = "#pageable.pageNumber + ':' + #pageable.pageSize")
+    @Cacheable(value = "jectalk", key = "#pageable.pageNumber + ':' + #pageable.pageSize + ':' + (#category != null ? #category.name() : 'ALL')")
     @Transactional(readOnly = true)
-    public Page<JectalkResponse> findJectalks(Pageable pageable) {
-        return jectalkRepository.findJectalks(pageable);
+    public Page<JectalkResponse> findJectalks(Pageable pageable, Project.Category category) {
+        return jectalkRepository.findJectalks(pageable, category);
     }
 }

--- a/src/main/resources/db/migration/V15__alter_jectalk_table_structure.sql
+++ b/src/main/resources/db/migration/V15__alter_jectalk_table_structure.sql
@@ -1,6 +1,6 @@
 -- Jectalk 테이블 구조 변경
 -- 기존: name, summary, youtube_url, image_url
--- 변경: title, description, content_type, content_url, thumbnail_url, author
+-- 변경: title, description, content_type, content_url, thumbnail_url, author, category
 
 -- author 컬럼 추가
 ALTER TABLE jectalk ADD COLUMN author VARCHAR(255) NOT NULL DEFAULT '';
@@ -11,13 +11,17 @@ UPDATE jectalk SET author = summary;
 -- content_type 컬럼 추가
 ALTER TABLE jectalk ADD COLUMN content_type VARCHAR(50) NOT NULL DEFAULT 'YOUTUBE';
 
+-- category 컬럼 추가
+ALTER TABLE jectalk ADD COLUMN category VARCHAR(30) NOT NULL DEFAULT 'SEMESTER_1';
+
 -- 컬럼명 변경
 ALTER TABLE jectalk CHANGE COLUMN name title VARCHAR(50) NOT NULL;
 ALTER TABLE jectalk CHANGE COLUMN summary description VARCHAR(255) NOT NULL;
 ALTER TABLE jectalk CHANGE COLUMN youtube_url content_url VARCHAR(2083) NULL;
 ALTER TABLE jectalk CHANGE COLUMN image_url thumbnail_url VARCHAR(2083) NULL;
 
--- author 컬럼의 DEFAULT 제거
+-- DEFAULT 제거
 ALTER TABLE jectalk MODIFY COLUMN author VARCHAR(255) NOT NULL;
 ALTER TABLE jectalk MODIFY COLUMN content_type VARCHAR(50) NOT NULL;
+ALTER TABLE jectalk MODIFY COLUMN category VARCHAR(30) NOT NULL;
 

--- a/src/main/resources/db/migration/V15__alter_jectalk_table_structure.sql
+++ b/src/main/resources/db/migration/V15__alter_jectalk_table_structure.sql
@@ -1,0 +1,23 @@
+-- Jectalk 테이블 구조 변경
+-- 기존: name, summary, youtube_url, image_url
+-- 변경: title, description, content_type, content_url, thumbnail_url, author
+
+-- author 컬럼 추가
+ALTER TABLE jectalk ADD COLUMN author VARCHAR(255) NOT NULL DEFAULT '';
+
+-- 기존 summary 데이터를 author로 마이그레이션
+UPDATE jectalk SET author = summary;
+
+-- content_type 컬럼 추가
+ALTER TABLE jectalk ADD COLUMN content_type VARCHAR(50) NOT NULL DEFAULT '';
+
+-- 컬럼명 변경
+ALTER TABLE jectalk CHANGE COLUMN name title VARCHAR(50) NOT NULL;
+ALTER TABLE jectalk CHANGE COLUMN summary description VARCHAR(255) NOT NULL;
+ALTER TABLE jectalk CHANGE COLUMN youtube_url content_url VARCHAR(2083) NULL;
+ALTER TABLE jectalk CHANGE COLUMN image_url thumbnail_url VARCHAR(2083) NULL;
+
+-- author 컬럼의 DEFAULT 제거
+ALTER TABLE jectalk MODIFY COLUMN author VARCHAR(255) NOT NULL;
+ALTER TABLE jectalk MODIFY COLUMN content_type VARCHAR(50) NOT NULL;
+

--- a/src/main/resources/db/migration/V15__alter_jectalk_table_structure.sql
+++ b/src/main/resources/db/migration/V15__alter_jectalk_table_structure.sql
@@ -9,7 +9,7 @@ ALTER TABLE jectalk ADD COLUMN author VARCHAR(255) NOT NULL DEFAULT '';
 UPDATE jectalk SET author = summary;
 
 -- content_type 컬럼 추가
-ALTER TABLE jectalk ADD COLUMN content_type VARCHAR(50) NOT NULL DEFAULT '';
+ALTER TABLE jectalk ADD COLUMN content_type VARCHAR(50) NOT NULL DEFAULT 'YOUTUBE';
 
 -- 컬럼명 변경
 ALTER TABLE jectalk CHANGE COLUMN name title VARCHAR(50) NOT NULL;

--- a/src/test/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryTest.java
@@ -43,17 +43,21 @@ class JectalkQueryRepositoryTest {
         assertThat(responses).hasSize(2); // 현재 페이지의 데이터 개수
         responses.forEach(jectalkResponse -> {
             assertThat(jectalkResponse.id()).isNotNull();
-            assertThat(jectalkResponse.name()).isNotNull();
-            assertThat(jectalkResponse.imageUrl()).isNotNull();
-            assertThat(jectalkResponse.youtubeUrl()).isNotNull();
+            assertThat(jectalkResponse.title()).isNotNull();
+            assertThat(jectalkResponse.thumbnailUrl()).isNotNull();
+            assertThat(jectalkResponse.contentUrl()).isNotNull();
+            assertThat(jectalkResponse.description()).isNotNull();
+            assertThat(jectalkResponse.contentType()).isNotNull();
             assertThat(jectalkResponse.summary()).isNotNull();
         });
 
         JectalkResponse firstResponse = responses.get(0);
-        assertThat(firstResponse.name()).isEqualTo("젝톡 3"); // ID 내림차순이므로 마지막에 생성된 데이터가 첫 번째
-        assertThat(firstResponse.summary()).isEqualTo("summary");
-        assertThat(firstResponse.youtubeUrl()).isEqualTo("https://youtube.com/jectalk3");
-        assertThat(firstResponse.imageUrl()).isEqualTo("https://image.com/jectalk3.png");
+        assertThat(firstResponse.title()).isEqualTo("젝톡 3"); // ID 내림차순이므로 마지막에 생성된 데이터가 첫 번째
+        assertThat(firstResponse.description()).isEqualTo("description");
+        assertThat(firstResponse.contentUrl()).isEqualTo("https://youtube.com/jectalk3");
+        assertThat(firstResponse.thumbnailUrl()).isEqualTo("https://image.com/jectalk3.png");
+        assertThat(firstResponse.summary()).isEqualTo("author");
+
 
         // 두 번째 페이지 조회
         Page<JectalkResponse> secondPage = jectalkRepository.findJectalks(PageRequest.of(1, 2));
@@ -63,10 +67,12 @@ class JectalkQueryRepositoryTest {
     private Jectalk createJectalk(String name) {
         String urlSafeName = "jectalk" + name.replaceAll("[젝톡 ]", "");
         return Jectalk.builder()
-                .name(name)
-                .summary("summary")
-                .youtubeUrl("https://youtube.com/" + urlSafeName)
-                .imageUrl("https://image.com/" + urlSafeName + ".png")
+                .title(name)
+                .description("description")
+                .contentType(org.ject.support.domain.jectalk.enums.ContentType.YOUTUBE)
+                .contentUrl("https://youtube.com/" + urlSafeName)
+                .thumbnailUrl("https://image.com/" + urlSafeName + ".png")
+                .author("author")
                 .build();
     }
 }

--- a/src/test/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/jectalk/repository/JectalkQueryRepositoryTest.java
@@ -3,6 +3,7 @@ package org.ject.support.domain.jectalk.repository;
 import java.util.List;
 import org.ject.support.domain.jectalk.dto.JectalkResponse;
 import org.ject.support.domain.jectalk.entity.Jectalk;
+import org.ject.support.domain.project.entity.Project;
 import org.ject.support.testconfig.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ class JectalkQueryRepositoryTest {
         jectalkRepository.saveAll(List.of(jectalk1, jectalk2, jectalk3));
 
         // when
-        Page<JectalkResponse> result = jectalkRepository.findJectalks(PageRequest.of(0, 2));
+        Page<JectalkResponse> result = jectalkRepository.findJectalks (PageRequest.of(0, 2), null);
 
         // then
         assertThat(result).isNotNull();
@@ -50,7 +51,6 @@ class JectalkQueryRepositoryTest {
             assertThat(jectalkResponse.contentType()).isNotNull();
             assertThat(jectalkResponse.summary()).isNotNull();
         });
-
         JectalkResponse firstResponse = responses.get(0);
         assertThat(firstResponse.title()).isEqualTo("젝톡 3"); // ID 내림차순이므로 마지막에 생성된 데이터가 첫 번째
         assertThat(firstResponse.description()).isEqualTo("description");
@@ -60,8 +60,47 @@ class JectalkQueryRepositoryTest {
 
 
         // 두 번째 페이지 조회
-        Page<JectalkResponse> secondPage = jectalkRepository.findJectalks(PageRequest.of(1, 2));
+        Page<JectalkResponse> secondPage = jectalkRepository.findJectalks(PageRequest.of(1, 2), null);
         assertThat(secondPage.getContent()).hasSize(1); // 마지막 페이지는 1개의 데이터만 존재
+    }
+
+    @Test
+    @DisplayName("젝톡 목록 조회 - 카테고리 필터링")
+    void findJectalksByCategory() {
+        // given
+        Jectalk jectalk1 = createJectalkWithCategory("젝톡 1기-1", Project.Category.SEMESTER_1);
+        Jectalk jectalk2 = createJectalkWithCategory("젝톡 1기-2", Project.Category.SEMESTER_1);
+        Jectalk jectalk3 = createJectalkWithCategory("젝톡 2기-1", Project.Category.SEMESTER_2);
+        Jectalk jectalk4 = createJectalkWithCategory("젝톡 2기-2", Project.Category.SEMESTER_2);
+        jectalkRepository.saveAll(List.of(jectalk1, jectalk2, jectalk3, jectalk4));
+
+        // when - 1기 조회
+        Page<JectalkResponse> result1 = jectalkRepository.findJectalks(PageRequest.of(0, 10), Project.Category.SEMESTER_1);
+
+        // then
+        assertThat(result1.getTotalElements()).isEqualTo(2);
+
+        // when - 2기 조회
+        Page<JectalkResponse> result2 = jectalkRepository.findJectalks(PageRequest.of(0, 10), Project.Category.SEMESTER_2);
+
+        // then
+        assertThat(result2.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("젝톡 목록 조회 - 카테고리 미지정 시 전체 조회")
+    void findJectalksWithoutCategory() {
+        // given
+        Jectalk jectalk1 = createJectalkWithCategory("젝톡 1기", Project.Category.SEMESTER_1);
+        Jectalk jectalk2 = createJectalkWithCategory("젝톡 2기", Project.Category.SEMESTER_2);
+        Jectalk jectalk3 = createJectalkWithCategory("젝톡 3기", Project.Category.SEMESTER_3);
+        jectalkRepository.saveAll(List.of(jectalk1, jectalk2, jectalk3));
+
+        // when - category=null로 전체 조회
+        Page<JectalkResponse> result = jectalkRepository.findJectalks(PageRequest.of(0, 10), null);
+
+        // then - 모든 기수의 젝톡이 조회됨
+        assertThat(result.getTotalElements()).isEqualTo(3);
     }
 
     private Jectalk createJectalk(String name) {
@@ -73,6 +112,20 @@ class JectalkQueryRepositoryTest {
                 .contentUrl("https://youtube.com/" + urlSafeName)
                 .thumbnailUrl("https://image.com/" + urlSafeName + ".png")
                 .author("author")
+                .category(Project.Category.SEMESTER_1)
+                .build();
+    }
+
+    private Jectalk createJectalkWithCategory(String name, Project.Category category) {
+        String urlSafeName = "jectalk" + name.replaceAll("[젝톡 기\\-]", "");
+        return Jectalk.builder()
+                .title(name)
+                .description("description")
+                .contentType(org.ject.support.domain.jectalk.enums.ContentType.YOUTUBE)
+                .contentUrl("https://youtube.com/" + urlSafeName)
+                .thumbnailUrl("https://image.com/" + urlSafeName + ".png")
+                .author("author")
+                .category(category)
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #411 

## 📝 작업 내용

#### 변경된 스펙에 따른 Jectalk 엔티티의 구조를 변경했습니다.
- `Jectalk` 엔티티 필드 변경
  - `name` → `title`: 더 명확한 필드명으로 변경
  - `summary` → `description`: 설명 내용을 담는 필드로 변경
  - `youtubeUrl` → `contentUrl`: 다양한 콘텐츠 타입을 지원하기 위한 일반화
  - `imageUrl` → `thumbnailUrl`: 썸네일 이미지임을 명확히 표
  - 신규 추가: `author` - 발표자/저자 정보
  - 신규 추가: `contentType` - 콘텐츠 타입 구분
- `JectalkResponse` DTO 변경
  ```java
  public record JectalkResponse(
      Long id,
      String title,           // name → title
      String description,     // summary → description
      String contentUrl,      // youtubeUrl → contentUrl
      ContentType contentType, // 신규 추가
      String thumbnailUrl,    // imageUrl → thumbnailUrl
      String summary         // author 정보 (신규 추가)
  )
  ```
- `ContentType` Enum 추가
  - `YOUTUBE`: YouTube 콘텐츠 타입
  - 향후 다양한 타입으로 확장 가능
- QueryDSL 쿼리에서 새로운 필드명 사용하도록 업데이트
- 데이터베이스 마이그레이션을 위한 Flyway query 추가

## 🙏 리뷰 요구사항 (선택)

- 데이터베이스 마이그레이션 스크립트 검토 부탁드립니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 콘텐츠 저자(author) 및 카테고리 필터 추가(엔드포인트에 선택적 카테고리 파라미터 도입)
  * 콘텐츠 타입(ContentType) 도입으로 미디어 유형 명시 지원

* **Refactor**
  * 응답 및 도메인 모델 필드명 정규화(타이틀/설명/콘텐츠 URL/썸네일 등) 및 관련 쿼리/캐시 조정
  * 데이터베이스 스키마 변경 및 마이그레이션 수행

* **Tests**
  * 변경된 모델과 카테고리 필터에 맞춘 테스트 및 검증 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->