### PR TITLE
feat: n8n에 지원서 제출 이벤트 발행 기능 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -27,6 +27,8 @@ import org.ject.support.domain.recruit.exception.QuestionException;
 import org.ject.support.domain.recruit.exception.RecruitErrorCode;
 import org.ject.support.domain.recruit.exception.RecruitException;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.ject.support.external.n8n.event.ApplicationSubmittedEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,7 +36,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.ject.support.domain.apply.domain.Apply.Status.JOINED;
 import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
@@ -52,6 +53,8 @@ public class ApplyService implements ApplyUsecase {
     private final MemberRepository memberRepository;
     private final Map2JsonSerializer map2JsonSerializer;
     private final String2MapSerializer string2MapSerializer;
+
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
     @PeriodAccessible(permitAllJob = true)
@@ -167,6 +170,10 @@ public class ApplyService implements ApplyUsecase {
 
         // 5. Apply 엔티티에 제출 위임 (검증 및 상태 변경 포함)
         apply.submit(applicationForm);
+
+        // 6. n8n에 지원 완료 이벤트 발행
+        applicationEventPublisher
+                .publishEvent(new ApplicationSubmittedEvent(apply.getId()));
     }
 
     @Override

--- a/src/main/java/org/ject/support/external/n8n/client/N8nClient.java
+++ b/src/main/java/org/ject/support/external/n8n/client/N8nClient.java
@@ -1,0 +1,47 @@
+package org.ject.support.external.n8n.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ject.support.domain.admin.dto.SubmittedApplyDetailResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class N8nClient {
+
+    private final WebClient webClient;
+
+    @Value("${n8n.secret-key}")
+    private String secretKey;
+
+    @Value("${n8n.webhook.application-submit}")
+    private String applicationSubmitWebhook;
+
+    public void send(SubmittedApplyDetailResponse payload) {
+        webClient.post()
+                .uri(applicationSubmitWebhook)
+                .header("Apply-Webhook-Secret", secretKey)
+                .bodyValue(payload)
+                .retrieve()
+                .toBodilessEntity()
+                .doOnSuccess(this::logSuccess)
+                .doOnError(this::logError)
+                .block();
+    }
+
+    private void logSuccess(ResponseEntity<Void> response) {
+        log.info("N8n message sent successfully (status={})", response.getStatusCode());
+    }
+
+    private void logError(Throwable e) {
+        log.error(
+                "N8n message send failed apply: {} - {}",
+                e.getClass().getSimpleName(),
+                e.getMessage()
+        );
+    }
+}

--- a/src/main/java/org/ject/support/external/n8n/event/ApplicationSubmittedEvent.java
+++ b/src/main/java/org/ject/support/external/n8n/event/ApplicationSubmittedEvent.java
@@ -1,0 +1,5 @@
+package org.ject.support.external.n8n.event;
+
+public record ApplicationSubmittedEvent(
+        Long applyId
+) {}

--- a/src/main/java/org/ject/support/external/n8n/listener/N8nApplicationSubmittedListener.java
+++ b/src/main/java/org/ject/support/external/n8n/listener/N8nApplicationSubmittedListener.java
@@ -1,0 +1,26 @@
+package org.ject.support.external.n8n.listener;
+
+import lombok.RequiredArgsConstructor;
+import org.ject.support.external.n8n.event.ApplicationSubmittedEvent;
+import org.ject.support.external.n8n.service.N8nApplyService;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Admin Page가 생기기 전 까지 n8n으로 지원서 제출 알림을 보냄
+ *  - Admin Page가 생기면 해당 기능은 제거될 예정
+ */
+@Component
+@RequiredArgsConstructor
+public class N8nApplicationSubmittedListener {
+
+    private final N8nApplyService n8nApplyService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ApplicationSubmittedEvent event) {
+        n8nApplyService.sendToN8n(event.applyId());
+    }
+}

--- a/src/main/java/org/ject/support/external/n8n/service/N8nApplyService.java
+++ b/src/main/java/org/ject/support/external/n8n/service/N8nApplyService.java
@@ -1,0 +1,66 @@
+package org.ject.support.external.n8n.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ject.support.common.util.String2MapSerializer;
+import org.ject.support.domain.admin.dto.SubmittedApplyDetailResponse;
+import org.ject.support.domain.apply.domain.ApplicationForm;
+import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
+import org.ject.support.domain.apply.exception.ApplyErrorCode;
+import org.ject.support.domain.apply.exception.ApplyException;
+import org.ject.support.domain.apply.repository.ApplyRepository;
+import org.ject.support.external.n8n.client.N8nClient;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class N8nApplyService {
+
+    private final ApplyRepository applyRepository;
+    private final String2MapSerializer string2MapSerializer;
+    private final N8nClient n8nClient;
+
+    @Transactional(readOnly = true)
+    public void sendToN8n(final Long applyId) {
+        // SubmittedApplyDetailResponse n8n 전송용으로 임시 재사용
+        SubmittedApplyDetailResponse response = applyRepository.findByIdAndStatusWithMember(applyId, Apply.Status.SUBMITTED)
+                .map(this::toSubmittedApplyDetailResponse)
+                .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
+        try {
+            n8nClient.send(response);
+        } catch (Exception e) {
+            log.error("Failed to send apply {} to n8n", applyId, e);
+        }
+
+    }
+
+    private SubmittedApplyDetailResponse toSubmittedApplyDetailResponse(final Apply apply) {
+        ApplicationForm submittedApplicationForm = apply.getApplicationForm();
+        Map<String, String> content = extractContent(submittedApplicationForm);
+        List<ApplyPortfolioDto> portfolios = extractPortfolios(submittedApplicationForm);
+        return SubmittedApplyDetailResponse.from(apply, content, portfolios);
+    }
+
+    private Map<String, String> extractContent(final ApplicationForm applicationForm) {
+        return Optional.ofNullable(applicationForm)
+                .map(ApplicationForm::getContent)
+                .map(string2MapSerializer::serializeAsMap)
+                .orElse(Map.of());
+    }
+
+    private List<ApplyPortfolioDto> extractPortfolios(final ApplicationForm applicationForm) {
+        return Optional.ofNullable(applicationForm)
+                .map(ApplicationForm::getPortfolios)
+                .orElse(List.of())
+                .stream()
+                .map(ApplyPortfolioDto::from)
+                .toList();
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -69,3 +69,8 @@ notification:
     webhook:
       admin-login: dummy-url-for-test
       supporter-token-issue: dummy-url-for-test
+
+n8n:
+  secret-key: n8n-test-secret-key
+  webhook:
+    application-submit: http://localhost:5678/webhook/application-submit

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -1,23 +1,5 @@
 package org.ject.support.domain.apply.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.ject.support.domain.apply.domain.Apply.Status.JOINED;
-import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
-import static org.ject.support.domain.apply.domain.Apply.Status.TEMP_SAVED;
-import static org.ject.support.domain.member.JobFamily.BE;
-import static org.ject.support.domain.member.JobFamily.PD;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.util.Map2JsonSerializer;
 import org.ject.support.common.util.String2MapSerializer;
@@ -45,10 +27,31 @@ import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.exception.QuestionException;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.ject.support.external.n8n.event.ApplicationSubmittedEvent;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ject.support.domain.apply.domain.Apply.Status.JOINED;
+import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
+import static org.ject.support.domain.apply.domain.Apply.Status.TEMP_SAVED;
+import static org.ject.support.domain.member.JobFamily.BE;
+import static org.ject.support.domain.member.JobFamily.PD;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ApplyServiceTest extends UnitTestSupport {
 
@@ -72,6 +75,9 @@ class ApplyServiceTest extends UnitTestSupport {
 
     @Mock
     String2MapSerializer string2MapSerializer;
+
+    @Mock
+    ApplicationEventPublisher applicationEventPublisher;
 
     @Test
     void 지원서_제출_성공() {
@@ -113,6 +119,10 @@ class ApplyServiceTest extends UnitTestSupport {
 
         // 3. apply의 상태가 SUBMITTED로 변경되었는지 확인
         assertThat(apply.getStatus()).isEqualTo(SUBMITTED);
+
+        // 4. AdminLoginNotificationEvent 이벤트가 발행되었는지 확인
+        verify(applicationEventPublisher)
+                .publishEvent(any(ApplicationSubmittedEvent.class));
     }
 
     @Test
@@ -164,6 +174,8 @@ class ApplyServiceTest extends UnitTestSupport {
         // then
         assertThat(apply.getStatus()).isEqualTo(SUBMITTED);
         assertThat(applicationForm.getPortfolios()).hasSize(1);
+        verify(applicationEventPublisher)
+                .publishEvent(any(ApplicationSubmittedEvent.class));
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

close #413 

## 📝 작업 내용

### 1. 지원서 제출 완료 시점에 n8n에 지원자, 지원서 정보를 담아 보내는 기능을 추가.
 - 4기 지원현황을 실시간으로 운영진이 보기 위해 만든 기능으로 Admin Client Page가 완성되기 전 임시기능
 - 추후 기능 삭제 시점에는, service코드에서 이벤트 발행 부분만 삭제하면 됩니다.
 
 ## Description
  - application-local 파일에 n8n 관련 환경 변수 추가 필요. dev, prod에는 업데이트 해두도록 하겠습니다.
```
n8n:
  secret-key: {key}
  webhook:
    application-submit: {url}
```

## 🙏 리뷰 요구사항 (선택)
 - 이 기능은 즉시 운영서버 배포가 필요해보이는데 4기 모집 릴리즈 이후 dev 브랜치에 push된 작업들을 main에 merge해도 문제 없을까요?
이상없으면 지금까지 작업된 것들을 운영서버에 배포하려고 합니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 애플리케이션 제출 시 외부 워크플로우 시스템으로 자동 전송 기능 추가

* **Tests**
  * 애플리케이션 제출 시 이벤트 발행 검증 추가

* **Chores**
  * 외부 시스템 연동을 위한 설정값 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->