### PR TITLE
feat: 인증번호 재설정 이메일 발송 시 전송 횟수 제한 기능 추가

### DIFF
--- a/src/main/java/org/ject/support/external/email/service/EmailAuthService.java
+++ b/src/main/java/org/ject/support/external/email/service/EmailAuthService.java
@@ -1,16 +1,14 @@
 package org.ject.support.external.email.service;
 
+import java.time.Duration;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.ject.support.common.util.CodeGeneratorUtil;
 import org.ject.support.external.email.domain.EmailTemplate;
-import org.ject.support.external.email.exception.EmailErrorCode;
 import org.ject.support.external.email.exception.RateLimitException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
-
-import java.time.Duration;
-import java.util.Map;
 
 @Slf4j
 @Service

--- a/src/main/java/org/ject/support/external/email/service/EmailAuthService.java
+++ b/src/main/java/org/ject/support/external/email/service/EmailAuthService.java
@@ -34,7 +34,7 @@ public class EmailAuthService {
     }
 
     private void checkRateLimit(EmailTemplate sendGroupCode, String toEmail) {
-        if (sendGroupCode != EmailTemplate.AUTH_CODE) {
+        if (sendGroupCode == EmailTemplate.REMIND_APPLY) {
             return;
         }
 

--- a/src/test/java/org/ject/support/external/email/service/EmailAuthServiceTest.java
+++ b/src/test/java/org/ject/support/external/email/service/EmailAuthServiceTest.java
@@ -52,6 +52,25 @@ class EmailAuthServiceTest extends UnitTestSupport {
     }
 
     @Test
+    void 인증번호_재설정_시_Rate_Limit이_적용되어_있지_않다면_정상_발송된다() {
+        // given
+        String email = "test@example.com";
+
+        given(redisTemplate.hasKey(anyString())).willReturn(false);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        emailAuthService.sendAuthCode(EmailTemplate.PIN_RESET, email);
+
+        // then
+        // 1. Rate Limit 키가 설정되었는지 검증 (3분)
+        verify(valueOperations).set(eq("email:rate_limit:" + email), eq("1"), eq(Duration.ofMinutes(3)));
+        // 2. 이메일 발송이 호출되었는지 검증
+        verify(emailSendService).sendTemplatedEmail(eq(EmailTemplate.PIN_RESET), eq(email), any());
+    }
+
+
+    @Test
     void _3분_내에_재요청_시_RateLimitException이_발생한다() {
         // given
         String email = "test@example.com";
@@ -69,19 +88,19 @@ class EmailAuthServiceTest extends UnitTestSupport {
     }
 
     @Test
-    void PIN_재설정_메일은_Rate_Limit_영향을_받지_않는다() {
+    void 리마인더_메일은_Rate_Limit_영향을_받지_않는다() {
         // given
         String email = "test@example.com";
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
 
         // when
-        emailAuthService.sendAuthCode(EmailTemplate.PIN_RESET, email);
+        emailAuthService.sendAuthCode(EmailTemplate.REMIND_APPLY, email);
 
         // then
         // Rate Limit 체크(hasKey)를 하지 않아야 함
         verify(redisTemplate, never()).hasKey(anyString());
 
         // 이메일 발송은 정상 호출
-        verify(emailSendService).sendTemplatedEmail(eq(EmailTemplate.PIN_RESET), eq(email), any());
+        verify(emailSendService).sendTemplatedEmail(eq(EmailTemplate.REMIND_APPLY), eq(email), any());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #423 

## 📝 작업 내용

- rate limit check 로직에 EmailTemplate에서 리마인더 메일이 아니면 통과하는 로직으로 수정
  
  ```java
  if (sendGroupCode == EmailTemplate.REMIND_APPLY) {
      return;
  }
  ```
  
- 테스트 케이스 수정 및 추가
  - 리마인더 이메일 발송 시 rate limit 미적용
  - 인증번호 재설정 이메일 발송 시 rate limit 적용

## 🙏 리뷰 요구사항 (선택)

현재 이메일 관련한 기능에 대해 리팩토링할 부분이 있습니다.

>  EmailTemplate에서 AUTH 그룹 계열의 의미를 나타내는 필드를 추가해서 리팩토링

해당 PR에서 함께 할지 아니면 이슈화해서 새로운 작업으로 할지 고민입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **개선 사항**
  * 이메일 전송 시스템의 레이트 리미팅 로직을 개선하여 특정 알림 시나리오에서 더 신속한 이메일 전송을 지원합니다.
  * 새로운 이메일 템플릿을 추가하여 알림 및 신청 관련 이메일 기능을 확장했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->