### PR TITLE
chore: 스왑 메모리 설정 및 EBS 볼륨 스케일업

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,31 @@
+FROM eclipse-temurin:21-jre-alpine
 
-
-FROM eclipse-temurin:21-jdk-alpine
 WORKDIR /app
 
+# 보안 계정 생성
 RUN apk add --no-cache curl && \
     addgroup -S spring && adduser -S spring -G spring
 
+# JAR 파일 복사
 COPY build/libs/ject*.jar app.jar
+
+# 권한 변경
 RUN chown spring:spring app.jar
 
+# 계정 전환
 USER spring:spring
+
 EXPOSE 8080
 
-ENV JAVA_OPTS="-Xms512m -Xmx1024m -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:+UseStringDeduplication"
+# 환경 변수 설정
+ENV JAVA_OPTS="-XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:+UseStringDeduplication"
+
+# 프로파일을 환경변수로 분리
+ENV SPRING_PROFILES_ACTIVE=prod
+
+# 헬스체크
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
    CMD curl -f http://localhost:8080/health || exit 1
 
-
-ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -Dspring.profiles.active=prod -Duser.timezone=Asia/Seoul -jar app.jar"]
+# 실행 명령어
+ENTRYPOINT ["sh", "-c", "exec java -XX:MaxRAMPercentage=75.0 $JAVA_OPTS -Dspring.profiles.active=$SPRING_PROFILES_ACTIVE -Duser.timezone=Asia/Seoul -jar app.jar"]


### PR DESCRIPTION
## #️⃣연관된 이슈

close #431 

## 📝 작업 내용

#### 도커 파일 수정
- 베이스 이미지 변경: `eclipse-temurin:21-jdk-alpine`에서 `eclipse-temurin:21-jre-alpine`로 수정
  - 런타임에는 컴파일러가 필요 없으므로 JRE를 사용하여 이미지 크기를 최적화
- 메모리 설정 최적화:
  - 기존의 고정 힙 메모리 설정(`-Xms512m -Xmx1024m`)을 제거
  - 컨테이너 메모리 제한에 맞춰 유동적으로 힙 크기를 설정하도록 `-XX:MaxRAMPercentage=75.0` 옵션을 적용

#### 스왑 메모리 설정
- 2GB 스왑 파일 생성 및 swappiness로 튜닝하여 스왑 최적화
  - `free -h`
    ```
                   total        used        free      shared  buff/cache   available
    Mem:           1.9Gi       1.2Gi       175Mi       0.0Ki       510Mi       539Mi
    Swap:          2.0Gi          0B       2.0Gi
    ```
  - `sysctl vm.swappiness`
    ```
    vm.swappiness = 10
    ```

#### 배포 스크립트 수정
```
docker run -d \
        ...
        --memory="900m" \
        --memory-swap="2g" \
        -v /logs:/app/logs \
```
- 기본 평상 시에 880MB 사용하고 있어서, 물리 메모리 900MB사용으로 제한
- 부족할 시 스왑메모리까지 사용해서 2GB까지 제한
- 로그 path 설정

#### EBS 볼륨 스케일업
- 현재 EBS 볼륨 용량이 8GB로 5.6GB를 사용 중, 스왑까지 하면 저장 용량이 매우 부족
- 3GB(OS) + 2GB(Swap) + 8GB(Docker) + 2GB(Log) + 5GB(Free) = 20GB로 스케일업
  `/dev/nvme0n1p1     20G  3.9G   17G  20% /`
  - 디스크가 90% 넘어가면 성능이 떨어져서 항상 20~30%는 빈 공간으로 5GB로 설정
  - Docker Image 정리 스케줄링이 있어도 그 전까진 용량이 할당되므로 넉넉하게 8GB로 설정

#### 고민
- 스왑으로 설정한 용량만큼의 최적화도 필요 = 로그 파일 용량 최적화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **인프라 개선**
  * 애플리케이션 보안 강화: 전용 사용자로 실행
  * 헬스 체크 엔드포인트 추가로 서비스 모니터링 개선
  * 동적 메모리 할당 방식으로 변경하여 리소스 효율성 증대
  * 컨테이너 이미지 최적화로 배포 성능 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->