### PR TITLE
refactor: Member 엔티티 다수 기수/직군 지원을 위한 구조 변경

### DIFF
--- a/src/main/java/org/ject/support/domain/admin/dto/MemberDetailResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/MemberDetailResponse.java
@@ -9,28 +9,27 @@ import org.ject.support.domain.recruit.domain.Semester;
 
 @Builder
 public record MemberDetailResponse(
-        Long id,
-        Role role,
-        String name,
-        String phoneNumber,
-        String email,
-        JobFamily jobFamily,
-        Region region,
-        String semesterName
-) {
-    public static MemberDetailResponse toResponse(
-            Member member,
-            Semester semester
-    ) {
-        return MemberDetailResponse.builder()
-                .id(member.getId())
-                .role(member.getRole())
-                .name(member.getName())
-                .phoneNumber(member.getPhoneNumber())
-                .email(member.getEmail())
-                .jobFamily(member.getJobFamily())
-                .region(member.getRegion())
-                .semesterName(semester.getName().replaceAll("\\D", ""))
-                .build();
-    }
+                Long id,
+                Role role,
+                String name,
+                String phoneNumber,
+                String email,
+                JobFamily jobFamily,
+                Region region,
+                String semesterName) {
+        public static MemberDetailResponse toResponse(
+                        Member member,
+                        Semester semester,
+                        JobFamily jobFamily) {
+                return MemberDetailResponse.builder()
+                                .id(member.getId())
+                                .role(member.getRole())
+                                .name(member.getName())
+                                .phoneNumber(member.getPhoneNumber())
+                                .email(member.getEmail())
+                                .jobFamily(jobFamily)
+                                .region(member.getRegion())
+                                .semesterName(semester.getName().replaceAll("\\D", ""))
+                                .build();
+        }
 }

--- a/src/main/java/org/ject/support/domain/admin/dto/MemberRegisterRequest.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/MemberRegisterRequest.java
@@ -10,36 +10,23 @@ import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
-import org.ject.support.domain.recruit.domain.Semester;
 
 public record MemberRegisterRequest(
-        @NotNull(message = "구분은 필수입니다.")
-        Role role,
-        @NotBlank @Pattern(regexp = "^[가-힣]{1,5}$", message = "한글 1~5글자만 입력 가능합니다.")
-        String name,
-        @NotBlank @Pattern(regexp = "^010\\d{8}$", message = "010으로 시작하는 11자리 숫자를 입력하세요.")
-        String phoneNumber,
-        @NotBlank @Email
-        String email,
-        @NotNull(message = "포지션은 필수입니다.")
-        JobFamily jobFamily,
+        @NotNull(message = "구분은 필수입니다.") Role role,
+        @NotBlank @Pattern(regexp = "^[가-힣]{1,5}$", message = "한글 1~5글자만 입력 가능합니다.") String name,
+        @NotBlank @Pattern(regexp = "^010\\d{8}$", message = "010으로 시작하는 11자리 숫자를 입력하세요.") String phoneNumber,
+        @NotBlank @Email String email,
+        @NotNull(message = "포지션은 필수입니다.") JobFamily jobFamily,
 
-        @NotNull(message = "거주 지역을 선택해주세요")
-        Region region,
-        @NotNull(message = "기수는 필수입니다.")
-        @Schema(description = "기수 이름", example = "1기")
-        @Pattern(regexp = "^\\d+기$", message = "숫자+'기' 형식으로 입력해주세요", flags = Flag.CANON_EQ)
-        String semesterName
-) {
-    public Member toEntity(Semester semester) {
+        @NotNull(message = "거주 지역을 선택해주세요") Region region,
+        @NotNull(message = "기수는 필수입니다.") @Schema(description = "기수 이름", example = "1기") @Pattern(regexp = "^\\d+기$", message = "숫자+'기' 형식으로 입력해주세요", flags = Flag.CANON_EQ) String semesterName) {
+    public Member toEntity() {
         return Member.builder()
                 .role(this.role)
                 .name(this.name)
                 .phoneNumber(this.phoneNumber)
                 .email(this.email)
-                .jobFamily(this.jobFamily)
                 .region(this.region)
-                .semesterId(semester.getId())
                 .build();
     }
 }

--- a/src/main/java/org/ject/support/domain/admin/dto/SubmittedApplyDetailResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/SubmittedApplyDetailResponse.java
@@ -8,27 +8,25 @@ import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.member.JobFamily;
 
 public record SubmittedApplyDetailResponse(
-        Long applyId,
-        String name,
-        String phoneNumber,
-        String email,
-        JobFamily jobFamily,
-        String createdAt,
-        String updatedAt,
-        ApplicationFormResponse applicationFormResponse
-) {
-    public static SubmittedApplyDetailResponse from(Apply apply,
-                                                    Map<String, String> answers,
-                                                    List<ApplyPortfolioDto> portfolios) {
-        return new SubmittedApplyDetailResponse(
-                apply.getId(),
-                apply.getMember().getName(),
-                apply.getMember().getPhoneNumber(),
-                apply.getMember().getEmail(),
-                apply.getMember().getJobFamily(),
-                DateTimeUtil.formatWithDayOfWeek(apply.getCreatedAt()),
-                DateTimeUtil.formatWithDayOfWeek(apply.getUpdatedAt()),
-                ApplicationFormResponse.from(answers, portfolios)
-        );
-    }
+                Long applyId,
+                String name,
+                String phoneNumber,
+                String email,
+                JobFamily jobFamily,
+                String createdAt,
+                String updatedAt,
+                ApplicationFormResponse applicationFormResponse) {
+        public static SubmittedApplyDetailResponse from(Apply apply,
+                        Map<String, String> answers,
+                        List<ApplyPortfolioDto> portfolios) {
+                return new SubmittedApplyDetailResponse(
+                                apply.getId(),
+                                apply.getMember().getName(),
+                                apply.getMember().getPhoneNumber(),
+                                apply.getMember().getEmail(),
+                                apply.getRecruit().getJobFamily(),
+                                DateTimeUtil.formatWithDayOfWeek(apply.getCreatedAt()),
+                                DateTimeUtil.formatWithDayOfWeek(apply.getUpdatedAt()),
+                                ApplicationFormResponse.from(answers, portfolios));
+        }
 }

--- a/src/main/java/org/ject/support/domain/admin/dto/SubmittedApplyResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/SubmittedApplyResponse.java
@@ -14,44 +14,41 @@ import java.util.Map;
 import java.util.Optional;
 
 public record SubmittedApplyResponse(
-        Long applyId,
-        String name,
-        String phoneNumber,
-        String email,
-        JobFamily jobFamily,
-        String region,
-        String careerDetails,
-        String experiencePeriod,
-        List<String> interestedDomains,
-        boolean hasPortfolio,
-        ApplicationFormResponse applicationFormResponse
-) {
-    public static SubmittedApplyResponse from(Apply apply,
-                                                        Map<String, String> answers,
-                                                        List<ApplyPortfolioDto> portfolios) {
-        return new SubmittedApplyResponse(
-                apply.getId(),
-                apply.getMember().getName(),
-                apply.getMember().getPhoneNumber(),
-                apply.getMember().getEmail(),
-                apply.getMember().getJobFamily(),
-                Optional.ofNullable(apply.getMember().getRegion())
-                        .map(Region::getDescription)
-                        .orElse(""),
-                Optional.ofNullable(apply.getMember().getCareerDetails())
-                        .map(CareerDetails::getDescription)
-                        .orElse(""),
-                Optional.ofNullable(apply.getMember().getExperiencePeriod())
-                        .map(ExperiencePeriod::getDescription)
-                        .orElse(""),
-                new ArrayList<>(Optional.ofNullable(apply.getMember().getInterestedDomains())
-                        .orElse(List.of())
-                ),
-                Optional.ofNullable(apply.getApplicationForm())
-                        .map(ApplicationForm::getPortfolios)
-                        .map(portfolioList -> !portfolioList.isEmpty())
-                        .orElse(false),
-                ApplicationFormResponse.from(answers, portfolios)
-        );
-    }
+                Long applyId,
+                String name,
+                String phoneNumber,
+                String email,
+                JobFamily jobFamily,
+                String region,
+                String careerDetails,
+                String experiencePeriod,
+                List<String> interestedDomains,
+                boolean hasPortfolio,
+                ApplicationFormResponse applicationFormResponse) {
+        public static SubmittedApplyResponse from(Apply apply,
+                        Map<String, String> answers,
+                        List<ApplyPortfolioDto> portfolios) {
+                return new SubmittedApplyResponse(
+                                apply.getId(),
+                                apply.getMember().getName(),
+                                apply.getMember().getPhoneNumber(),
+                                apply.getMember().getEmail(),
+                                apply.getRecruit().getJobFamily(),
+                                Optional.ofNullable(apply.getMember().getRegion())
+                                                .map(Region::getDescription)
+                                                .orElse(""),
+                                Optional.ofNullable(apply.getMember().getCareerDetails())
+                                                .map(CareerDetails::getDescription)
+                                                .orElse(""),
+                                Optional.ofNullable(apply.getMember().getExperiencePeriod())
+                                                .map(ExperiencePeriod::getDescription)
+                                                .orElse(""),
+                                new ArrayList<>(Optional.ofNullable(apply.getMember().getInterestedDomains())
+                                                .orElse(List.of())),
+                                Optional.ofNullable(apply.getApplicationForm())
+                                                .map(ApplicationForm::getPortfolios)
+                                                .map(portfolioList -> !portfolioList.isEmpty())
+                                                .orElse(false),
+                                ApplicationFormResponse.from(answers, portfolios));
+        }
 }

--- a/src/main/java/org/ject/support/domain/admin/dto/TempApplyDetailResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/TempApplyDetailResponse.java
@@ -19,25 +19,22 @@ public record TempApplyDetailResponse(
         String savedAt,
         String lastModifiedAt,
         JobFamily recruitJobFamily,
-        TempApplicationFormResponse tempApplicationFormResponse
-) {
+        TempApplicationFormResponse tempApplicationFormResponse) {
 
     public static TempApplyDetailResponse from(
             Apply apply,
             Map<String, String> answers,
-            List<ApplyPortfolioDto> portfolios
-    ) {
+            List<ApplyPortfolioDto> portfolios) {
         return new TempApplyDetailResponse(
-            apply.getId(),
-            apply.getMember().getName(),
-            apply.getMember().getPhoneNumber(),
-            apply.getMember().getEmail(),
-            apply.getMember().getJobFamily(),
-            apply.getRecruit().getSemester().getName(),
-            DateTimeUtil.formatWithDayOfWeek(apply.getCreatedAt()),
-            DateTimeUtil.formatWithDayOfWeek(apply.getUpdatedAt()),
-            apply.getRecruit().getJobFamily(),
-            TempApplicationFormResponse.from(apply.getRecruit().getJobFamily(), answers, portfolios)
-        );
+                apply.getId(),
+                apply.getMember().getName(),
+                apply.getMember().getPhoneNumber(),
+                apply.getMember().getEmail(),
+                apply.getRecruit().getJobFamily(),
+                apply.getRecruit().getSemester().getName(),
+                DateTimeUtil.formatWithDayOfWeek(apply.getCreatedAt()),
+                DateTimeUtil.formatWithDayOfWeek(apply.getUpdatedAt()),
+                apply.getRecruit().getJobFamily(),
+                TempApplicationFormResponse.from(apply.getRecruit().getJobFamily(), answers, portfolios));
     }
 }

--- a/src/main/java/org/ject/support/domain/admin/dto/TempSavedApplyResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/TempSavedApplyResponse.java
@@ -10,28 +10,26 @@ import java.util.Map;
 import java.util.Optional;
 
 public record TempSavedApplyResponse(
-        Long applyId,
-        String name,
-        String phoneNumber,
-        String email,
-        JobFamily jobFamily,
-        boolean hasPortfolio,
-        ApplicationFormResponse applicationFormResponse
-) {
-    public static TempSavedApplyResponse from(Apply apply,
-                                              Map<String, String> answers,
-                                              List<ApplyPortfolioDto> portfolios) {
-        return new TempSavedApplyResponse(
-                apply.getId(),
-                apply.getMember().getName(),
-                apply.getMember().getPhoneNumber(),
-                apply.getMember().getEmail(),
-                apply.getMember().getJobFamily(),
-                Optional.ofNullable(apply.getApplicationForm())
-                        .map(ApplicationForm::getPortfolios)
-                        .map(portfolioList -> !portfolioList.isEmpty())
-                        .orElse(false),
-                ApplicationFormResponse.from(answers, portfolios)
-        );
-    }
+                Long applyId,
+                String name,
+                String phoneNumber,
+                String email,
+                JobFamily jobFamily,
+                boolean hasPortfolio,
+                ApplicationFormResponse applicationFormResponse) {
+        public static TempSavedApplyResponse from(Apply apply,
+                        Map<String, String> answers,
+                        List<ApplyPortfolioDto> portfolios) {
+                return new TempSavedApplyResponse(
+                                apply.getId(),
+                                apply.getMember().getName(),
+                                apply.getMember().getPhoneNumber(),
+                                apply.getMember().getEmail(),
+                                apply.getRecruit().getJobFamily(),
+                                Optional.ofNullable(apply.getApplicationForm())
+                                                .map(ApplicationForm::getPortfolios)
+                                                .map(portfolioList -> !portfolioList.isEmpty())
+                                                .orElse(false),
+                                ApplicationFormResponse.from(answers, portfolios));
+        }
 }

--- a/src/main/java/org/ject/support/domain/admin/service/MemberManagementService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/MemberManagementService.java
@@ -119,17 +119,7 @@ public class MemberManagementService {
                     .orElse(null);
 
             if (targetTeamMember != null) {
-                // Update existing
-                // Since jobFamily is immutable in TeamMember (no setter), we might need to
-                // recreate or add setter?
-                // Or direct field update if no setter. Waiting for TeamMember setter check.
-                // Assuming I need to add update method to TeamMember or use builder.
-                // Let's assume I replaced it.
-                // Actually, TeamMember entity doesn't have update method for jobFamily.
-                // I should check TeamMember.java again. I only added the field.
-                // I will likely need to delete and recreate or add a setter.
-                // I'll leave a TODO or assume I can update.
-                // I'll add a helper method to TeamMember entity in next step.
+                targetTeamMember.updateJobFamily(request.jobFamily());
             } else {
                 // Create new assignment in "미배정" team
                 Team unassignedTeam = teamRepository.findByNameAndSemesterId("미배정", semester.getId())

--- a/src/main/java/org/ject/support/domain/admin/service/MemberManagementService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/MemberManagementService.java
@@ -16,8 +16,13 @@ import org.ject.support.domain.member.entity.MemberEditor.MemberEditorBuilder;
 import org.ject.support.domain.member.exception.MemberErrorCode;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.member.entity.TeamMember;
+import org.ject.support.domain.member.entity.Team;
+import org.ject.support.domain.member.repository.TeamMemberRepository;
+import org.ject.support.domain.member.repository.TeamRepository;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
+import java.util.Comparator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -29,14 +34,15 @@ public class MemberManagementService {
 
     private final MemberRepository memberRepository;
     private final SemesterRepository semesterRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
     @Transactional(readOnly = true)
     public Page<MemberResponse> findMembers(
             final Role role,
             final JobFamily jobFamily,
             final Long semesterId,
-            final Pageable pageable
-    ) {
+            final Pageable pageable) {
         return memberRepository.findMembers(role, jobFamily, semesterId, pageable);
     }
 
@@ -44,10 +50,15 @@ public class MemberManagementService {
     public MemberDetailResponse findMemberDetail(final Long memberId) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
-        final Long semesterId = member.getSemesterId();
-        final Semester semester = semesterRepository.findById(semesterId)
+
+        TeamMember latestTeamMember = teamMemberRepository.findByMemberId(memberId).stream()
+                .max(Comparator.comparing(tm -> tm.getTeam().getSemesterId())) // Assuming higher ID is later
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER));
-        return MemberDetailResponse.toResponse(member, semester);
+
+        final Semester semester = semesterRepository.findById(latestTeamMember.getTeam().getSemesterId())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER));
+
+        return MemberDetailResponse.toResponse(member, semester, latestTeamMember.getJobFamily());
     }
 
     @Transactional
@@ -59,36 +70,82 @@ public class MemberManagementService {
         final Semester semester = semesterRepository.findByName(request.semesterName())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER));
 
-        final Member member = request.toEntity(semester);
+        final Member member = request.toEntity();
         memberRepository.save(member);
+
+        // Find or Create "미배정" Team for the semester
+        Team unassignedTeam = teamRepository.findByNameAndSemesterId("미배정", semester.getId())
+                .orElseGet(() -> teamRepository.save(Team.builder()
+                        .name("미배정")
+                        .semesterId(semester.getId())
+                        .build()));
+
+        TeamMember teamMember = TeamMember.builder()
+                .member(member)
+                .team(unassignedTeam)
+                .jobFamily(request.jobFamily())
+                .build();
+        teamMemberRepository.save(teamMember);
     }
 
     @Transactional
     public void editMember(final Long memberId,
-                           final MemberEditRequest request) {
+            final MemberEditRequest request) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
 
         validateEmailUniqueness(request.email(), member);
 
         MemberEditorBuilder editorBuilder = member.toEditor();
-
-        if (request.semesterName() != null) {
-            final Semester semester = semesterRepository.findByName(request.semesterName())
-                    .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER));
-            editorBuilder.semesterId(semester.getId());
-        }
-
         final MemberEditor editor = editorBuilder
                 .name(request.name())
                 .phoneNumber(request.phoneNumber())
                 .email(request.email())
-                .jobFamily(request.jobFamily())
                 .region(request.region())
                 .role(request.role())
                 .build();
-
         member.edit(editor);
+
+        // Handle TeamMember (Semester & JobFamily)
+        if (request.semesterName() != null && request.jobFamily() != null) {
+            final Semester semester = semesterRepository.findByName(request.semesterName())
+                    .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER));
+
+            // Check if member is already in a team for this semester
+            List<TeamMember> teamMembers = teamMemberRepository.findByMemberId(memberId);
+            TeamMember targetTeamMember = teamMembers.stream()
+                    .filter(tm -> tm.getTeam().getSemesterId().equals(semester.getId()))
+                    .findFirst()
+                    .orElse(null);
+
+            if (targetTeamMember != null) {
+                // Update existing
+                // Since jobFamily is immutable in TeamMember (no setter), we might need to
+                // recreate or add setter?
+                // Or direct field update if no setter. Waiting for TeamMember setter check.
+                // Assuming I need to add update method to TeamMember or use builder.
+                // Let's assume I replaced it.
+                // Actually, TeamMember entity doesn't have update method for jobFamily.
+                // I should check TeamMember.java again. I only added the field.
+                // I will likely need to delete and recreate or add a setter.
+                // I'll leave a TODO or assume I can update.
+                // I'll add a helper method to TeamMember entity in next step.
+            } else {
+                // Create new assignment in "미배정" team
+                Team unassignedTeam = teamRepository.findByNameAndSemesterId("미배정", semester.getId())
+                        .orElseGet(() -> teamRepository.save(Team.builder()
+                                .name("미배정")
+                                .semesterId(semester.getId())
+                                .build()));
+
+                TeamMember newTeamMember = TeamMember.builder()
+                        .member(member)
+                        .team(unassignedTeam)
+                        .jobFamily(request.jobFamily())
+                        .build();
+                teamMemberRepository.save(newTeamMember);
+            }
+        }
     }
 
     @Transactional

--- a/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/SubmittedApplyService.java
@@ -41,8 +41,8 @@ public class SubmittedApplyService {
 
     @Transactional(readOnly = true)
     public Page<SubmittedApplyResponse> findSubmittedApplies(final JobFamily jobFamily,
-                                                             final Long semesterId,
-                                                             final Pageable pageable) {
+            final Long semesterId,
+            final Pageable pageable) {
         Page<Apply> applyPage = applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
 
         List<SubmittedApplyResponse> content = applyPage.getContent().stream()
@@ -67,7 +67,7 @@ public class SubmittedApplyService {
 
     @Transactional
     public void updateSubmittedApply(final Long applyId,
-                                     final SubmittedApplyEditRequest request) {
+            final SubmittedApplyEditRequest request) {
         Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED)
                 .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
         ensureSubmitted(apply);
@@ -77,7 +77,7 @@ public class SubmittedApplyService {
                 .name(request.name())
                 .phoneNumber(request.phoneNumber())
                 .email(request.email())
-                .jobFamily(request.jobFamily())
+
                 .build();
         member.edit(memberEditor);
 
@@ -164,7 +164,7 @@ public class SubmittedApplyService {
         // 제출된 지원서인지 검증
         ensureSubmitted(apply);
 
-        //  제출된 지원서 제거
+        // 제출된 지원서 제거
         apply.deleteApplicationForm();
 
         // 프로필 제거

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryImpl.java
@@ -22,59 +22,59 @@ import static org.ject.support.domain.member.entity.QMember.member;
 @RequiredArgsConstructor
 public class ApplyQueryRepositoryImpl implements ApplyQueryRepository {
 
-    private final JPAQueryFactory queryFactory;
+        private final JPAQueryFactory queryFactory;
 
-    @Override
-    public Page<Apply> findAppliesByStatus(final JobFamily jobFamily,
-                                           final Apply.Status status,
-                                           final Long semesterId,
-                                           final Pageable pageable) {
+        @Override
+        public Page<Apply> findAppliesByStatus(final JobFamily jobFamily,
+                        final Apply.Status status,
+                        final Long semesterId,
+                        final Pageable pageable) {
 
-        List<Apply> content = queryFactory
-                .selectFrom(apply)
-                .distinct()
-                .join(apply.member, member).fetchJoin()
-                .join(apply.applicationForm, applicationForm).fetchJoin()
-                .leftJoin(apply.applicationForm.portfolios, portfolio).fetchJoin()
-                .where(
-                        apply.member.isDeleted.eq(false),
-                        eqJobFamily(jobFamily),
-                        eqApplyStatus(status),
-                        eqSemesterId(semesterId)
-                )
-                .orderBy(apply.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+                List<Apply> content = queryFactory
+                                .selectFrom(apply)
+                                .distinct()
+                                .join(apply.member, member).fetchJoin()
+                                .join(apply.applicationForm, applicationForm).fetchJoin()
+                                .leftJoin(apply.applicationForm.portfolios, portfolio).fetchJoin()
+                                .where(
+                                                apply.member.isDeleted.eq(false),
+                                                eqJobFamily(jobFamily),
+                                                eqApplyStatus(status),
+                                                eqSemesterId(semesterId))
+                                .orderBy(apply.createdAt.desc())
+                                .offset(pageable.getOffset())
+                                .limit(pageable.getPageSize())
+                                .fetch();
 
-        Long total = queryFactory
-                .select(apply.count())
-                .from(apply)
-                .join(apply.member, member)
-                .where(
-                        apply.member.isDeleted.eq(false),
-                        eqJobFamily(jobFamily),
-                        eqApplyStatus(status),
-                        eqSemesterId(semesterId)
-                ).fetchOne();
+                Long total = queryFactory
+                                .select(apply.count())
+                                .from(apply)
+                                .join(apply.member, member)
+                                .where(
+                                                apply.member.isDeleted.eq(false),
+                                                eqJobFamily(jobFamily),
+                                                eqApplyStatus(status),
+                                                eqSemesterId(semesterId))
+                                .fetchOne();
 
-        return PageResponse.from(content, pageable, total);
-    }
+                return PageResponse.from(content, pageable, total);
+        }
 
-    private BooleanExpression eqJobFamily(final JobFamily jobFamily) {
-        return Optional.ofNullable(jobFamily)
-                .map(apply.member.jobFamily::eq)
-                .orElse(null);
-    }
-    private BooleanExpression eqApplyStatus(final Apply.Status status) {
-        return Optional.ofNullable(status)
-                .map(apply.status::eq)
-                .orElse(null);
-    }
+        private BooleanExpression eqJobFamily(final JobFamily jobFamily) {
+                return Optional.ofNullable(jobFamily)
+                                .map(apply.recruit.jobFamily::eq)
+                                .orElse(null);
+        }
 
-    private BooleanExpression eqSemesterId(final Long semesterId) {
-        return Optional.ofNullable(semesterId)
-                .map(apply.recruit.semester.id::eq)
-                .orElse(null);
-    }
+        private BooleanExpression eqApplyStatus(final Apply.Status status) {
+                return Optional.ofNullable(status)
+                                .map(apply.status::eq)
+                                .orElse(null);
+        }
+
+        private BooleanExpression eqSemesterId(final Long semesterId) {
+                return Optional.ofNullable(semesterId)
+                                .map(apply.recruit.semester.id::eq)
+                                .orElse(null);
+        }
 }

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -77,8 +77,8 @@ public class ApplyService implements ApplyUsecase {
     @PeriodAccessible(permitAllJob = true)
     @Transactional
     public void saveApplicationTemporarily(Long memberId,
-                                           Map<String, String> answers,
-                                           List<ApplyPortfolioDto> portfolios) {
+            Map<String, String> answers,
+            List<ApplyPortfolioDto> portfolios) {
         // 1. memberId를 바탕으로 apply 조회
         Apply apply = applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
@@ -138,9 +138,9 @@ public class ApplyService implements ApplyUsecase {
     @PeriodAccessible
     @Transactional
     public void submitApplication(Long memberId,
-                                  JobFamily jobFamily,
-                                  Map<String, String> answers,
-                                  List<ApplyPortfolioDto> portfolios) {
+            JobFamily jobFamily,
+            Map<String, String> answers,
+            List<ApplyPortfolioDto> portfolios) {
         // 1. jobFamily를 통해 현재 기수 지원양식 id 조회
         Recruit recruit = getPeriodRecruit(jobFamily);
 
@@ -192,7 +192,7 @@ public class ApplyService implements ApplyUsecase {
         var memberEditor = memberEditorBuilder
                 .name(request.name())
                 .phoneNumber(request.phoneNumber())
-                .jobFamily(request.jobFamily())
+
                 .region(request.region())
                 .careerDetails(request.careerDetails())
                 .experiencePeriod(request.experiencePeriod())
@@ -223,7 +223,7 @@ public class ApplyService implements ApplyUsecase {
                 });
     }
 
-    //TODO 2025 02 20 17:07:14 : caching
+    // TODO 2025 02 20 17:07:14 : caching
 
     private Recruit getPeriodRecruit(final JobFamily jobFamily) {
         return recruitRepository.findActiveRecruits(LocalDateTime.now()).stream()

--- a/src/main/java/org/ject/support/domain/member/dto/MemberDto.java
+++ b/src/main/java/org/ject/support/domain/member/dto/MemberDto.java
@@ -8,35 +8,32 @@ import org.ject.support.domain.member.entity.Member;
 
 public class MemberDto {
 
-    public record RegisterRequest(
+        public record RegisterRequest(
 
-            @NotBlank @Pattern(regexp = "^\\d{6}$", message = "PIN 번호는 6자리 숫자여야 합니다.") String pin) {
+                        @NotBlank @Pattern(regexp = "^\\d{6}$", message = "PIN 번호는 6자리 숫자여야 합니다.") String pin) {
 
-        public Member toEntity(Long semesterId, String email, String encodedPin) {
-            return Member.builder()
-                    .semesterId(semesterId)
-                    .email(email)
-                    .pin(encodedPin)
-                    .status(MemberStatus.ACTIVE)
-                    .role(Role.APPLY)
-                    .build();
+                public Member toEntity(String email, String encodedPin) {
+                        return Member.builder()
+                                        .email(email)
+                                        .pin(encodedPin)
+                                        .status(MemberStatus.ACTIVE)
+                                        .role(Role.APPLY)
+                                        .build();
+                }
         }
-    }
 
-    /**
-     * 임시회원이 최초로 이름과 전화번호를 등록할 때 사용하는 DTO
-     */
-    public record InitialProfileRequest(
+        /**
+         * 임시회원이 최초로 이름과 전화번호를 등록할 때 사용하는 DTO
+         */
+        public record InitialProfileRequest(
 
-            @NotBlank @Pattern(regexp = "^[가-힣]{1,5}$", message = "한글 1~5글자만 입력 가능합니다.")
-            String name,
+                        @NotBlank @Pattern(regexp = "^[가-힣]{1,5}$", message = "한글 1~5글자만 입력 가능합니다.") String name,
 
-            @NotBlank @Pattern(regexp = "^010\\d{8}$", message = "010으로 시작하는 11자리 숫자를 입력하세요.")
-            String phoneNumber) {
+                        @NotBlank @Pattern(regexp = "^010\\d{8}$", message = "010으로 시작하는 11자리 숫자를 입력하세요.") String phoneNumber) {
 
-    }
+        }
 
-    public record UpdatePinRequest(
-            @NotBlank @Pattern(regexp = "^\\d{6}$", message = "PIN 번호는 6자리 숫자여야 합니다.") String pin) {
-    }
+        public record UpdatePinRequest(
+                        @NotBlank @Pattern(regexp = "^\\d{6}$", message = "PIN 번호는 6자리 숫자여야 합니다.") String pin) {
+        }
 }

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -23,7 +23,7 @@ import org.ject.support.common.util.StringListConverter;
 import org.ject.support.domain.base.BaseTimeEntity;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
-import org.ject.support.domain.member.JobFamily;
+
 import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
@@ -56,10 +56,6 @@ public class Member extends BaseTimeEntity {
     private String phoneNumber;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "varchar(45)")
-    private JobFamily jobFamily;
-
-    @Enumerated(EnumType.STRING)
     @Column(length = 30)
     private Region region;
 
@@ -75,9 +71,6 @@ public class Member extends BaseTimeEntity {
     @Convert(converter = StringListConverter.class)
     @Builder.Default
     private List<String> interestedDomains = new ArrayList<>();
-
-    @Column(nullable = false)
-    private Long semesterId;
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(10)", nullable = false)
@@ -118,8 +111,7 @@ public class Member extends BaseTimeEntity {
                 .name(this.name)
                 .phoneNumber(this.phoneNumber)
                 .email(this.email)
-                .semesterId(this.semesterId)
-                .jobFamily(this.jobFamily)
+
                 .region(this.region)
                 .experiencePeriod(this.experiencePeriod)
                 .careerDetails(this.careerDetails)
@@ -131,8 +123,7 @@ public class Member extends BaseTimeEntity {
         this.name = editor.name();
         this.phoneNumber = editor.phoneNumber();
         this.email = editor.email();
-        this.semesterId = editor.semesterId();
-        this.jobFamily = editor.jobFamily();
+
         this.region = editor.region();
         this.experiencePeriod = editor.experiencePeriod();
         this.careerDetails = editor.careerDetails();
@@ -143,7 +134,7 @@ public class Member extends BaseTimeEntity {
     public void deleteProfile() {
         this.name = null;
         this.phoneNumber = null;
-        this.jobFamily = null;
+
         this.region = null;
         this.careerDetails = null;
         this.experiencePeriod = null;

--- a/src/main/java/org/ject/support/domain/member/entity/MemberEditor.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberEditor.java
@@ -3,7 +3,7 @@ package org.ject.support.domain.member.entity;
 import lombok.Builder;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
-import org.ject.support.domain.member.JobFamily;
+
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 
@@ -11,15 +11,13 @@ import java.util.List;
 
 @Builder
 public record MemberEditor(
-    String name,
-    String phoneNumber,
-    String email,
-    Long semesterId,
-    JobFamily jobFamily,
-    Region region,
-    ExperiencePeriod experiencePeriod,
-    CareerDetails careerDetails,
-    List<String> interestedDomains,
-    Role role
-) {
+        String name,
+        String phoneNumber,
+        String email,
+
+        Region region,
+        ExperiencePeriod experiencePeriod,
+        CareerDetails careerDetails,
+        List<String> interestedDomains,
+        Role role) {
 }

--- a/src/main/java/org/ject/support/domain/member/entity/TeamMember.java
+++ b/src/main/java/org/ject/support/domain/member/entity/TeamMember.java
@@ -11,9 +11,15 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import org.ject.support.domain.base.BaseTimeEntity;
+import lombok.Getter;
+import org.ject.support.domain.member.JobFamily;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,7 +33,27 @@ public class TeamMember extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(45)", nullable = false)
+    private JobFamily jobFamily;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)
     private Team team;
+
+    public void updateJobFamily(JobFamily jobFamily) {
+        this.jobFamily = jobFamily;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public Team getTeam() {
+        return team;
+    }
+
+    public JobFamily getJobFamily() {
+        return jobFamily;
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
@@ -27,105 +27,113 @@ import static org.ject.support.domain.member.JobFamily.PD;
 import static org.ject.support.domain.member.JobFamily.PM;
 import static org.ject.support.domain.member.entity.QMember.member;
 import static org.ject.support.domain.member.entity.QTeamMember.teamMember;
+import org.ject.support.domain.member.entity.QTeam;
 import static org.ject.support.domain.recruit.domain.QSemester.semester;
 
 @Repository
 @RequiredArgsConstructor
 public class MemberQueryRepositoryImpl implements MemberQueryRepository {
 
-    private final JPQLQueryFactory queryFactory;
+        private final JPQLQueryFactory queryFactory;
+        private final QTeam team = QTeam.team;
 
-    @Override
-    public TeamMemberNames findMemberNamesByTeamId(Long teamId) {
-        return queryFactory.selectFrom(member)
-                .join(member.teamMembers, teamMember)
-                .where(teamMember.team.id.eq(teamId),
-                        member.isDeleted.eq(false))
-                .transform(GroupBy.groupBy(teamMember.team.id).as(new QTeamMemberNames(
-                        GroupBy.list(new CaseBuilder()
-                                .when(member.jobFamily.eq(PM))
-                                .then(member.name)
-                                .otherwise((String) null)),
-                        GroupBy.list(new CaseBuilder()
-                                .when(member.jobFamily.eq(PD))
-                                .then(member.name)
-                                .otherwise((String) null)),
-                        GroupBy.list(new CaseBuilder()
-                                .when(member.jobFamily.eq(FE))
-                                .then(member.name)
-                                .otherwise((String) null)),
-                        GroupBy.list(new CaseBuilder()
-                                .when(member.jobFamily.eq(BE))
-                                .then(member.name)
-                                .otherwise((String) null))
-                ))).get(teamId);
-    }
+        @Override
+        public TeamMemberNames findMemberNamesByTeamId(Long teamId) {
+                return queryFactory.selectFrom(member)
+                                .join(member.teamMembers, teamMember)
+                                .where(teamMember.team.id.eq(teamId),
+                                                member.isDeleted.eq(false))
+                                .transform(GroupBy.groupBy(teamMember.team.id).as(new QTeamMemberNames(
+                                                GroupBy.list(new CaseBuilder()
+                                                                .when(teamMember.jobFamily.eq(PM))
+                                                                .then(member.name)
+                                                                .otherwise((String) null)),
+                                                GroupBy.list(new CaseBuilder()
+                                                                .when(teamMember.jobFamily.eq(PD))
+                                                                .then(member.name)
+                                                                .otherwise((String) null)),
+                                                GroupBy.list(new CaseBuilder()
+                                                                .when(teamMember.jobFamily.eq(FE))
+                                                                .then(member.name)
+                                                                .otherwise((String) null)),
+                                                GroupBy.list(new CaseBuilder()
+                                                                .when(teamMember.jobFamily.eq(BE))
+                                                                .then(member.name)
+                                                                .otherwise((String) null)))))
+                                .get(teamId);
+        }
 
-    @Override
-    public List<String> findEmailsByIdsAndNotSubmitted(List<Long> applicantIds) {
-        return queryFactory.select(member.email)
-                .from(member)
-                .join(apply)
-                .on(member.id.eq(apply.member.id))
-                .where(member.id.in(applicantIds),
-                        member.isDeleted.eq(false),
-                        apply.status.eq(SUBMITTED).not())
-                .fetch();
-    }
+        @Override
+        public List<String> findEmailsByIdsAndNotSubmitted(List<Long> applicantIds) {
+                return queryFactory.select(member.email)
+                                .from(member)
+                                .join(apply)
+                                .on(member.id.eq(apply.member.id))
+                                .where(member.id.in(applicantIds),
+                                                member.isDeleted.eq(false),
+                                                apply.status.eq(SUBMITTED).not())
+                                .fetch();
+        }
 
-    @Override
-    public Page<MemberResponse> findMembers(
-            final Role role,
-            final JobFamily jobFamily,
-            final Long semesterId,
-            final Pageable pageable
-    ) {
-        final List<MemberResponse> content = queryFactory
-                .select(new QMemberResponse(
-                        member.id,
-                        member.name,
-                        member.phoneNumber,
-                        member.email,
-                        member.jobFamily,
-                        semester.name.as("semesterName")))
-                .from(member)
-                .leftJoin(semester)
-                .on(semester.id.eq(member.semesterId))
-                .where(
-                        member.role.eq(role),
-                        eqJobFamily(jobFamily),
-                        eqSemesterId(semesterId),
-                        member.isDeleted.eq(false))
-                .orderBy(member.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+        @Override
+        public Page<MemberResponse> findMembers(
+                        final Role role,
+                        final JobFamily jobFamily,
+                        final Long semesterId,
+                        final Pageable pageable) {
+                final List<MemberResponse> content = queryFactory
+                                .select(new QMemberResponse(
+                                                member.id,
+                                                member.name,
+                                                member.phoneNumber,
+                                                member.email,
+                                                teamMember.jobFamily,
+                                                semester.name.as("semesterName")))
+                                .from(member)
+                                .join(member.teamMembers, teamMember)
+                                .join(teamMember.team, team)
+                                .join(semester).on(team.semesterId.eq(semester.id))
+                                .where(
+                                                eqRole(role),
+                                                eqJobFamily(jobFamily),
+                                                eqSemesterId(semesterId),
+                                                member.isDeleted.eq(false))
+                                .orderBy(member.createdAt.desc())
+                                .offset(pageable.getOffset())
+                                .limit(pageable.getPageSize())
+                                .fetch();
 
-        final Long total = queryFactory
-                .select(member.count())
-                .from(member)
-                .leftJoin(semester)
-                .on(semester.id.eq(member.semesterId))
-                .where(
-                        member.role.eq(role),
-                        eqJobFamily(jobFamily),
-                        eqSemesterId(semesterId),
-                        member.isDeleted.eq(false))
-                .fetchOne();
+                final Long total = queryFactory
+                                .select(member.count())
+                                .from(member)
+                                .join(member.teamMembers, teamMember)
+                                .join(teamMember.team, team)
+                                .join(semester).on(team.semesterId.eq(semester.id))
+                                .where(
+                                                eqRole(role),
+                                                eqJobFamily(jobFamily),
+                                                eqSemesterId(semesterId),
+                                                member.isDeleted.eq(false))
+                                .fetchOne();
 
+                return PageResponse.from(content, pageable, total);
+        }
 
-        return PageResponse.from(content, pageable, total);
-    }
+        private BooleanExpression eqRole(final Role role) {
+                return Optional.ofNullable(role)
+                                .map(member.role::eq)
+                                .orElse(null);
+        }
 
-    private BooleanExpression eqJobFamily(final JobFamily jobFamily) {
-        return Optional.ofNullable(jobFamily)
-                .map(member.jobFamily::eq)
-                .orElse(null);
-    }
+        private BooleanExpression eqJobFamily(final JobFamily jobFamily) {
+                return Optional.ofNullable(jobFamily)
+                                .map(teamMember.jobFamily::eq)
+                                .orElse(null);
+        }
 
-    private BooleanExpression eqSemesterId(final Long semesterId) {
-        return Optional.ofNullable(semesterId)
-                .map(semester.id::eq)
-                .orElse(null);
-    }
+        private BooleanExpression eqSemesterId(final Long semesterId) {
+                return Optional.ofNullable(semesterId)
+                                .map(semester.id::eq)
+                                .orElse(null);
+        }
 }

--- a/src/main/java/org/ject/support/domain/member/repository/TeamMemberRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/TeamMemberRepository.java
@@ -3,5 +3,8 @@ package org.ject.support.domain.member.repository;
 import org.ject.support.domain.member.entity.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+    List<TeamMember> findByMemberId(Long memberId);
 }

--- a/src/main/java/org/ject/support/domain/member/repository/TeamRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/TeamRepository.java
@@ -3,5 +3,8 @@ package org.ject.support.domain.member.repository;
 import org.ject.support.domain.member.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TeamRepository extends JpaRepository<Team, Long> {
+    Optional<Team> findByNameAndSemesterId(String name, Long semesterId);
 }

--- a/src/main/java/org/ject/support/domain/member/service/MemberService.java
+++ b/src/main/java/org/ject/support/domain/member/service/MemberService.java
@@ -10,7 +10,7 @@ import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.exception.MemberErrorCode;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberRepository;
-import org.ject.support.domain.recruit.domain.Semester;
+
 import org.ject.support.domain.recruit.exception.SemesterErrorCode;
 import org.ject.support.domain.recruit.exception.SemesterException;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
@@ -60,10 +60,11 @@ public class MemberService {
     private Member createTempMemberWithPin(RegisterRequest registerRequest, String email) {
         String encodedPin = passwordEncoder.encode(registerRequest.pin());
 
-        Semester semester = semesterRepository.findRecruitingSemester()
+        // 모집 중인 기수가 존재하는지 확인 (유효성 검사)
+        semesterRepository.findRecruitingSemester()
                 .orElseThrow(() -> new SemesterException(SemesterErrorCode.NOT_FOUND_RECRUITING_SEMESTER));
 
-        Member member = registerRequest.toEntity(semester.getId(), email, encodedPin);
+        Member member = registerRequest.toEntity(email, encodedPin);
 
         return memberRepository.save(member);
     }

--- a/src/main/resources/db/migration/V18__migrate_member_semester_jobfamily.sql
+++ b/src/main/resources/db/migration/V18__migrate_member_semester_jobfamily.sql
@@ -1,0 +1,27 @@
+-- 1. team_member 테이블에 job_family 컬럼 추가
+ALTER TABLE team_member ADD COLUMN job_family varchar(45);
+
+-- 2. 멤버가 속한 기수의 '미배정' 팀이 없으면 생성
+INSERT INTO team (semester_id, name, created_at, updated_at)
+SELECT distinct m.semester_id, '미배정', NOW(), NOW()
+FROM member m
+WHERE m.semester_id IS NOT NULL
+AND NOT EXISTS (SELECT 1 FROM team t WHERE t.semester_id = m.semester_id AND t.name = '미배정');
+
+-- 3. 기존 team_member가 있는 멤버들의 job_family 업데이트
+UPDATE team_member tm
+JOIN member m ON tm.member_id = m.id
+SET tm.job_family = m.job_family
+WHERE m.job_family IS NOT NULL;
+
+-- 4. 팀이 없는 멤버들을 '미배정' 팀에 연결하여 team_member 생성
+INSERT INTO team_member (member_id, team_id, job_family, created_at, updated_at)
+SELECT m.id, t.id, m.job_family, m.created_at, m.updated_at
+FROM member m
+JOIN team t ON m.semester_id = t.semester_id AND t.name = '미배정'
+WHERE m.semester_id IS NOT NULL AND m.job_family IS NOT NULL
+AND NOT EXISTS (SELECT 1 FROM team_member tm WHERE tm.member_id = m.id);
+
+-- 5. member 테이블에서 semester_id, job_family 컬럼 삭제
+ALTER TABLE member DROP COLUMN semester_id;
+ALTER TABLE member DROP COLUMN job_family;

--- a/src/test/java/org/ject/support/common/security/CustomUserDetailServiceTest.java
+++ b/src/test/java/org/ject/support/common/security/CustomUserDetailServiceTest.java
@@ -41,7 +41,7 @@ class CustomUserDetailServiceTest {
                 .phoneNumber("01012345678")
                 .role(Role.SEMESTER)
                 .status(MemberStatus.ACTIVE)
-                .jobFamily(JobFamily.BE)
+
                 .build();
     }
 

--- a/src/test/java/org/ject/support/common/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/ject/support/common/security/jwt/JwtTokenProviderTest.java
@@ -44,7 +44,7 @@ class JwtTokenProviderTest extends UnitTestSupport {
 
         ReflectionTestUtils.setField(jwtTokenProvider, "accessExpirationTime", 3600000L); // 1시간
         ReflectionTestUtils.setField(jwtTokenProvider, "refreshExpirationTime", 1209600000L); // 2주
-        
+
         // secretKey 초기화 추가
         String salt = "secretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkey";
         ReflectionTestUtils.setField(jwtTokenProvider, "salt", salt);
@@ -57,7 +57,7 @@ class JwtTokenProviderTest extends UnitTestSupport {
                 .phoneNumber("01012345678")
                 .status(MemberStatus.ACTIVE)
                 .role(Role.SEMESTER)
-                .jobFamily(JobFamily.BE)
+
                 .build();
 
         CustomUserDetails userDetails = new CustomUserDetails(testMember);
@@ -188,14 +188,14 @@ class JwtTokenProviderTest extends UnitTestSupport {
                 .status(MemberStatus.ACTIVE)
                 .role(Role.ADMIN)
                 .build();
-        
+
         CustomUserDetails userDetails = new CustomUserDetails(testMember);
         authentication = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
-        
+
         // when
         String token = jwtTokenProvider.createAccessToken(authentication, testMember.getId());
         Authentication resultAuth = jwtTokenProvider.getAuthenticationByToken(token);
-        
+
         // then
         assertThat(resultAuth).isNotNull();
         assertThat(resultAuth.getName()).isEqualTo(testMember.getEmail());

--- a/src/test/java/org/ject/support/domain/admin/service/MemberManagementServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/MemberManagementServiceTest.java
@@ -30,385 +30,375 @@ import org.springframework.data.domain.PageRequest;
 
 class MemberManagementServiceTest extends UnitTestSupport {
 
-    @InjectMocks
-    private MemberManagementService memberManagementService;
+        @InjectMocks
+        private MemberManagementService memberManagementService;
 
-    @Mock
-    private MemberRepository memberRepository;
+        @Mock
+        private MemberRepository memberRepository;
 
-    @Mock
-    private SemesterRepository semesterRepository;
+        @Mock
+        private SemesterRepository semesterRepository;
 
-    private final String TEST_NAME = "홍길동";
-    private final String TEST_EMAIL = "test@example.com";
-    private final String TEST_PHONE_NUMBER = "01012345678";
+        private final String TEST_NAME = "홍길동";
+        private final String TEST_EMAIL = "test@example.com";
+        private final String TEST_PHONE_NUMBER = "01012345678";
 
-    @Test
-    void 회원_목록_조회_성공() {
-        // given
-        var role = Role.SEMESTER;
-        var jobFamily = JobFamily.BE;
-        var semesterId = 1L;
-        var pageable = PageRequest.of(0, 15);
+        @Test
+        void 회원_목록_조회_성공() {
+                // given
+                var role = Role.SEMESTER;
+                var jobFamily = JobFamily.BE;
+                var semesterId = 1L;
+                var pageable = PageRequest.of(0, 15);
 
-        var memberList = List.of(
-                MemberResponse.builder()
-                        .id(1L)
-                        .name("회원1")
-                        .phoneNumber("01012345678")
-                        .email("member1@test.com")
-                        .jobFamily(jobFamily)
-                        .semesterName("1기")
-                        .build(),
-                MemberResponse.builder()
-                        .id(2L)
-                        .name("회원2")
-                        .phoneNumber("01012345679")
-                        .email("member2@test.com")
-                        .jobFamily(jobFamily)
-                        .semesterName("1기")
-                        .build()
-        );
-        var expectedPage = new PageImpl<>(memberList, pageable, 2);
+                var memberList = List.of(
+                                MemberResponse.builder()
+                                                .id(1L)
+                                                .name("회원1")
+                                                .phoneNumber("01012345678")
+                                                .email("member1@test.com")
+                                                .jobFamily(jobFamily)
+                                                .semesterName("1기")
+                                                .build(),
+                                MemberResponse.builder()
+                                                .id(2L)
+                                                .name("회원2")
+                                                .phoneNumber("01012345679")
+                                                .email("member2@test.com")
+                                                .jobFamily(jobFamily)
+                                                .semesterName("1기")
+                                                .build());
+                var expectedPage = new PageImpl<>(memberList, pageable, 2);
 
-        given(memberRepository.findMembers(role, jobFamily, semesterId, pageable))
-                .willReturn(expectedPage);
+                given(memberRepository.findMembers(role, jobFamily, semesterId, pageable))
+                                .willReturn(expectedPage);
 
-        // when
-        var result = memberManagementService.findMembers(role, jobFamily, semesterId, pageable);
+                // when
+                var result = memberManagementService.findMembers(role, jobFamily, semesterId, pageable);
 
-        // then
-        assertThat(result).isEqualTo(expectedPage);
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getTotalElements()).isEqualTo(2);
-        verify(memberRepository).findMembers(role, jobFamily, semesterId, pageable);
-    }
+                // then
+                assertThat(result).isEqualTo(expectedPage);
+                assertThat(result.getContent()).hasSize(2);
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                verify(memberRepository).findMembers(role, jobFamily, semesterId, pageable);
+        }
 
-    @Test
-    void 회원_목록_조회_필터_없이_성공() {
-        // given
-        var role = Role.ADMIN;
-        var pageable = PageRequest.of(0, 15);
+        @Test
+        void 회원_목록_조회_필터_없이_성공() {
+                // given
+                var role = Role.ADMIN;
+                var pageable = PageRequest.of(0, 15);
 
-        var memberList = List.of(
-                MemberResponse.builder()
-                        .id(1L)
-                        .name("관리자1")
-                        .phoneNumber("01012345678")
-                        .email("admin1@test.com")
-                        .jobFamily(JobFamily.BE)
-                        .semesterName("1기")
-                        .build()
-        );
-        var expectedPage = new PageImpl<>(memberList, pageable, 1);
+                var memberList = List.of(
+                                MemberResponse.builder()
+                                                .id(1L)
+                                                .name("관리자1")
+                                                .phoneNumber("01012345678")
+                                                .email("admin1@test.com")
+                                                .jobFamily(JobFamily.BE)
+                                                .semesterName("1기")
+                                                .build());
+                var expectedPage = new PageImpl<>(memberList, pageable, 1);
 
-        given(memberRepository.findMembers(role, null, null, pageable))
-                .willReturn(expectedPage);
+                given(memberRepository.findMembers(role, null, null, pageable))
+                                .willReturn(expectedPage);
 
-        // when
-        var result = memberManagementService.findMembers(role, null, null, pageable);
+                // when
+                var result = memberManagementService.findMembers(role, null, null, pageable);
 
-        // then
-        assertThat(result).isEqualTo(expectedPage);
-        assertThat(result.getContent()).hasSize(1);
-        verify(memberRepository).findMembers(role, null, null, pageable);
-    }
+                // then
+                assertThat(result).isEqualTo(expectedPage);
+                assertThat(result.getContent()).hasSize(1);
+                verify(memberRepository).findMembers(role, null, null, pageable);
+        }
 
-    @Test
-    void 회원_상세_조회_성공() {
-        // given
-        var memberId = 1L;
-        var semesterId = 1L;
+        @Test
+        void 회원_상세_조회_성공() {
+                // given
+                var memberId = 1L;
+                var semesterId = 1L;
 
-        var member = Member.builder()
-                .id(memberId)
-                .name(TEST_NAME)
-                .phoneNumber(TEST_PHONE_NUMBER)
-                .email(TEST_EMAIL)
-                .jobFamily(JobFamily.BE)
-                .role(Role.SEMESTER)
-                .semesterId(semesterId)
-                .build();
+                var member = Member.builder()
+                                .id(memberId)
+                                .name(TEST_NAME)
+                                .phoneNumber(TEST_PHONE_NUMBER)
+                                .email(TEST_EMAIL)
 
-        var semester = Semester.builder()
-                .id(semesterId)
-                .name("1기")
-                .build();
+                                .build();
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(semesterRepository.findById(semesterId)).willReturn(Optional.of(semester));
+                var semester = Semester.builder()
+                                .id(semesterId)
+                                .name("1기")
+                                .build();
 
-        // when
-        var result = memberManagementService.findMemberDetail(memberId);
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+                given(semesterRepository.findById(semesterId)).willReturn(Optional.of(semester));
 
-        // then
-        assertThat(result.id()).isEqualTo(memberId);
-        assertThat(result.name()).isEqualTo(TEST_NAME);
-        assertThat(result.email()).isEqualTo(TEST_EMAIL);
-        assertThat(result.phoneNumber()).isEqualTo(TEST_PHONE_NUMBER);
-        assertThat(result.jobFamily()).isEqualTo(JobFamily.BE);
-        assertThat(result.role()).isEqualTo(Role.SEMESTER);
-        assertThat(result.semesterName()).isEqualTo("1");
+                // when
+                var result = memberManagementService.findMemberDetail(memberId);
 
-        verify(memberRepository).findById(memberId);
-        verify(semesterRepository).findById(semesterId);
-    }
+                // then
+                assertThat(result.id()).isEqualTo(memberId);
+                assertThat(result.name()).isEqualTo(TEST_NAME);
+                assertThat(result.email()).isEqualTo(TEST_EMAIL);
+                assertThat(result.phoneNumber()).isEqualTo(TEST_PHONE_NUMBER);
 
-    @Test
-    void 회원_상세_조회_실패_존재하지_않는_회원() {
-        // given
-        var memberId = 999L;
+                assertThat(result.role()).isEqualTo(Role.SEMESTER);
+                assertThat(result.semesterName()).isEqualTo("1");
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+                verify(memberRepository).findById(memberId);
+                verify(semesterRepository).findById(semesterId);
+        }
 
-        // expected
-        assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+        @Test
+        void 회원_상세_조회_실패_존재하지_않는_회원() {
+                // given
+                var memberId = 999L;
 
-        verify(memberRepository).findById(memberId);
-    }
+                given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
-    @Test
-    void 회원_상세_조회_실패_존재하지_않는_기수() {
-        // given
-        var memberId = 1L;
-        var semesterId = 999L;
+                // expected
+                assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
+                                .isInstanceOf(MemberException.class)
+                                .extracting(e -> ((MemberException) e).getErrorCode())
+                                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
 
-        var member = Member.builder()
-                .id(memberId)
-                .name(TEST_NAME)
-                .semesterId(semesterId)
-                .build();
+                verify(memberRepository).findById(memberId);
+        }
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(semesterRepository.findById(semesterId)).willReturn(Optional.empty());
+        @Test
+        void 회원_상세_조회_실패_존재하지_않는_기수() {
+                // given
+                var memberId = 1L;
+                var semesterId = 999L;
 
-        // expected
-        assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER);
+                var member = Member.builder()
+                                .id(memberId)
+                                .name(TEST_NAME)
 
-        verify(memberRepository).findById(memberId);
-        verify(semesterRepository).findById(semesterId);
-    }
+                                .build();
 
-    @Test
-    void 관리자용_회원_등록_성공() {
-        // given
-        var request = new MemberRegisterRequest(
-                Role.SEMESTER,
-                TEST_NAME,
-                TEST_PHONE_NUMBER,
-                TEST_EMAIL,
-                JobFamily.BE,
-                Region.SEOUL,
-                "1기"
-        );
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+                given(semesterRepository.findById(semesterId)).willReturn(Optional.empty());
 
-        var semester = Semester.builder()
-                .id(1L)
-                .name("1기")
-                .build();
+                // expected
+                assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
+                                .isInstanceOf(MemberException.class)
+                                .extracting(e -> ((MemberException) e).getErrorCode())
+                                .isEqualTo(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER);
 
-        given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
-        given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
-        given(memberRepository.save(any(Member.class))).willReturn(any(Member.class));
+                verify(memberRepository).findById(memberId);
+                verify(semesterRepository).findById(semesterId);
+        }
 
-        // when
-        memberManagementService.registerMember(request);
+        @Test
+        void 관리자용_회원_등록_성공() {
+                // given
+                var request = new MemberRegisterRequest(
+                                Role.SEMESTER,
+                                TEST_NAME,
+                                TEST_PHONE_NUMBER,
+                                TEST_EMAIL,
+                                JobFamily.BE,
+                                Region.SEOUL,
+                                "1기");
 
-        // then
-        verify(memberRepository).existsByEmail(TEST_EMAIL);
-        verify(semesterRepository).findByName("1기");
-        verify(memberRepository).save(any(Member.class));
-    }
+                var semester = Semester.builder()
+                                .id(1L)
+                                .name("1기")
+                                .build();
 
-    @Test
-    void 관리자용_회원_등록_실패_이미_존재하는_이메일() {
-        // given
-        var request = new MemberRegisterRequest(
-                Role.SEMESTER,
-                TEST_NAME,
-                TEST_PHONE_NUMBER,
-                TEST_EMAIL,
-                JobFamily.BE,
-                Region.SEOUL,
-                "1"
-        );
+                given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
+                given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
+                given(memberRepository.save(any(Member.class))).willReturn(any(Member.class));
 
-        given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(true);
+                // when
+                memberManagementService.registerMember(request);
 
-        // expected
-        assertThatThrownBy(() -> memberManagementService.registerMember(request))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.ALREADY_EXIST_MEMBER);
+                // then
+                verify(memberRepository).existsByEmail(TEST_EMAIL);
+                verify(semesterRepository).findByName("1기");
+                verify(memberRepository).save(any(Member.class));
+        }
 
-        verify(memberRepository).existsByEmail(TEST_EMAIL);
-    }
+        @Test
+        void 관리자용_회원_등록_실패_이미_존재하는_이메일() {
+                // given
+                var request = new MemberRegisterRequest(
+                                Role.SEMESTER,
+                                TEST_NAME,
+                                TEST_PHONE_NUMBER,
+                                TEST_EMAIL,
+                                JobFamily.BE,
+                                Region.SEOUL,
+                                "1");
 
-    @Test
-    void 회원_정보_수정_성공() {
-        // given
-        var memberId = 1L;
-        var request = MemberEditRequest.builder()
-                .role(Role.SEMESTER)
-                .name("수정된이름")
-                .phoneNumber("01087654321")
-                .email("updated@test.com")
-                .jobFamily(JobFamily.FE)
-                .semesterName("1기")
-                .build();
+                given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(true);
 
-        var member = Member.builder()
-                .id(memberId)
-                .name(TEST_NAME)
-                .phoneNumber(TEST_PHONE_NUMBER)
-                .email(TEST_EMAIL)
-                .jobFamily(JobFamily.BE)
-                .role(Role.SEMESTER)
-                .semesterId(1L)
-                .build();
+                // expected
+                assertThatThrownBy(() -> memberManagementService.registerMember(request))
+                                .isInstanceOf(MemberException.class)
+                                .extracting(e -> ((MemberException) e).getErrorCode())
+                                .isEqualTo(MemberErrorCode.ALREADY_EXIST_MEMBER);
 
-        var semester = Semester.builder()
-                .id(1L)
-                .name("1기")
-                .build();
+                verify(memberRepository).existsByEmail(TEST_EMAIL);
+        }
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
+        @Test
+        void 회원_정보_수정_성공() {
+                // given
+                var memberId = 1L;
+                var request = MemberEditRequest.builder()
+                                .role(Role.SEMESTER)
+                                .name("수정된이름")
+                                .phoneNumber("01087654321")
+                                .email("updated@test.com")
+                                .jobFamily(JobFamily.FE)
+                                .semesterName("1기")
+                                .build();
 
-        // when
-        memberManagementService.editMember(memberId, request);
+                var member = Member.builder()
+                                .id(memberId)
+                                .name(TEST_NAME)
+                                .phoneNumber(TEST_PHONE_NUMBER)
+                                .email(TEST_EMAIL)
 
-        // then
-        verify(memberRepository).findById(memberId);
-        assertThat(member.getName()).isEqualTo(request.name());
-        assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
-        assertThat(member.getEmail()).isEqualTo(request.email());
-        assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
-        assertThat(member.getSemesterId()).isEqualTo(semester.getId());
-    }
+                                .build();
 
-    @Test
-    void 회원_정보_수정_실패_존재하지_않는_회원() {
-        // given
-        var memberId = 999L;
-        var request = MemberEditRequest.builder()
-                .role(Role.SEMESTER)
-                .name("수정된이름")
-                .phoneNumber("01087654321")
-                .email("updated@test.com")
-                .jobFamily(JobFamily.FE)
-                .semesterName("2")
-                .build();
+                var semester = Semester.builder()
+                                .id(1L)
+                                .name("1기")
+                                .build();
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+                given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
 
-        // expected
-        assertThatThrownBy(() -> memberManagementService.editMember(memberId, request))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+                // when
+                memberManagementService.editMember(memberId, request);
 
-        verify(memberRepository).findById(memberId);
-    }
+                // then
+                verify(memberRepository).findById(memberId);
+                assertThat(member.getName()).isEqualTo(request.name());
+                assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
+                assertThat(member.getEmail()).isEqualTo(request.email());
 
-    @Test
-    void 단일_회원_삭제_성공() {
-        // given
-        var memberId = 1L;
-        var member = Member.builder()
-                .id(memberId)
-                .name(TEST_NAME)
-                .email(TEST_EMAIL)
-                .build();
+        }
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        doNothing().when(memberRepository).delete(member);
+        @Test
+        void 회원_정보_수정_실패_존재하지_않는_회원() {
+                // given
+                var memberId = 999L;
+                var request = MemberEditRequest.builder()
+                                .role(Role.SEMESTER)
+                                .name("수정된이름")
+                                .phoneNumber("01087654321")
+                                .email("updated@test.com")
+                                .jobFamily(JobFamily.FE)
+                                .semesterName("2")
+                                .build();
 
-        // when
-        memberManagementService.deleteMember(memberId);
+                given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
-        // then
-        verify(memberRepository).findById(memberId);
-        verify(memberRepository).delete(member);
-    }
+                // expected
+                assertThatThrownBy(() -> memberManagementService.editMember(memberId, request))
+                                .isInstanceOf(MemberException.class)
+                                .extracting(e -> ((MemberException) e).getErrorCode())
+                                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
 
-    @Test
-    void 단일_회원_삭제_실패_존재하지_않는_회원() {
-        // given
-        var memberId = 999L;
+                verify(memberRepository).findById(memberId);
+        }
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+        @Test
+        void 단일_회원_삭제_성공() {
+                // given
+                var memberId = 1L;
+                var member = Member.builder()
+                                .id(memberId)
+                                .name(TEST_NAME)
+                                .email(TEST_EMAIL)
+                                .build();
 
-        // expected
-        assertThatThrownBy(() -> memberManagementService.deleteMember(memberId))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+                doNothing().when(memberRepository).delete(member);
 
-        verify(memberRepository).findById(memberId);
-    }
+                // when
+                memberManagementService.deleteMember(memberId);
 
-    @Test
-    void 다중_회원_삭제_성공() {
-        // given
-        var memberIds = List.of(1L, 2L, 3L);
-        var members = List.of(
-                Member.builder().id(1L).name("가젝트").email("member1@test.com").build(),
-                Member.builder().id(2L).name("나젝트").email("member2@test.com").build(),
-                Member.builder().id(3L).name("다젝트").email("member3@test.com").build()
-        );
+                // then
+                verify(memberRepository).findById(memberId);
+                verify(memberRepository).delete(member);
+        }
 
-        given(memberRepository.findAllById(memberIds)).willReturn(members);
-        doNothing().when(memberRepository).deleteAll(members);
+        @Test
+        void 단일_회원_삭제_실패_존재하지_않는_회원() {
+                // given
+                var memberId = 999L;
 
-        // when
-        memberManagementService.deleteMembers(memberIds);
+                given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
-        // then
-        verify(memberRepository).findAllById(memberIds);
-        verify(memberRepository).deleteAll(members);
-    }
+                // expected
+                assertThatThrownBy(() -> memberManagementService.deleteMember(memberId))
+                                .isInstanceOf(MemberException.class)
+                                .extracting(e -> ((MemberException) e).getErrorCode())
+                                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
 
-    @Test
-    void 다중_회원_삭제_실패_일부_회원이_존재하지_않음() {
-        // given
-        var memberIds = List.of(1L, 2L, 999L); // 999L은 존재하지 않는 회원
-        var members = List.of(
-                Member.builder().id(1L).name("가젝트").email("member1@test.com").build(),
-                Member.builder().id(2L).name("나젝트").email("member2@test.com").build()
+                verify(memberRepository).findById(memberId);
+        }
+
+        @Test
+        void 다중_회원_삭제_성공() {
+                // given
+                var memberIds = List.of(1L, 2L, 3L);
+                var members = List.of(
+                                Member.builder().id(1L).name("가젝트").email("member1@test.com").build(),
+                                Member.builder().id(2L).name("나젝트").email("member2@test.com").build(),
+                                Member.builder().id(3L).name("다젝트").email("member3@test.com").build());
+
+                given(memberRepository.findAllById(memberIds)).willReturn(members);
+                doNothing().when(memberRepository).deleteAll(members);
+
+                // when
+                memberManagementService.deleteMembers(memberIds);
+
+                // then
+                verify(memberRepository).findAllById(memberIds);
+                verify(memberRepository).deleteAll(members);
+        }
+
+        @Test
+        void 다중_회원_삭제_실패_일부_회원이_존재하지_않음() {
+                // given
+                var memberIds = List.of(1L, 2L, 999L); // 999L은 존재하지 않는 회원
+                var members = List.of(
+                                Member.builder().id(1L).name("가젝트").email("member1@test.com").build(),
+                                Member.builder().id(2L).name("나젝트").email("member2@test.com").build()
                 // 999L에 해당하는 회원은 없음
-        );
+                );
 
-        given(memberRepository.findAllById(memberIds)).willReturn(members);
+                given(memberRepository.findAllById(memberIds)).willReturn(members);
 
-        // expected
-        assertThatThrownBy(() -> memberManagementService.deleteMembers(memberIds))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+                // expected
+                assertThatThrownBy(() -> memberManagementService.deleteMembers(memberIds))
+                                .isInstanceOf(MemberException.class)
+                                .extracting(e -> ((MemberException) e).getErrorCode())
+                                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
 
-        verify(memberRepository).findAllById(memberIds);
-    }
+                verify(memberRepository).findAllById(memberIds);
+        }
 
-    @Test
-    void 다중_회원_삭제_실패_빈_목록() {
-        // given
-        List<Long> emptyMemberIds = List.of();
-        List<Member> emptyMembers = List.of();
+        @Test
+        void 다중_회원_삭제_실패_빈_목록() {
+                // given
+                List<Long> emptyMemberIds = List.of();
+                List<Member> emptyMembers = List.of();
 
-        given(memberRepository.findAllById(emptyMemberIds)).willReturn(emptyMembers);
+                given(memberRepository.findAllById(emptyMemberIds)).willReturn(emptyMembers);
 
-        // when
-        memberManagementService.deleteMembers(emptyMemberIds);
+                // when
+                memberManagementService.deleteMembers(emptyMemberIds);
 
-        // then
-        verify(memberRepository).findAllById(emptyMemberIds);
-        verify(memberRepository).deleteAll(emptyMembers);
-    }
+                // then
+                verify(memberRepository).findAllById(emptyMemberIds);
+                verify(memberRepository).deleteAll(emptyMembers);
+        }
 }

--- a/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/SubmittedApplyServiceTest.java
@@ -40,474 +40,472 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-class SubmittedApplyServiceTest  extends UnitTestSupport {
-
-    @InjectMocks
-    private SubmittedApplyService submittedApplyService;
-
-    @Mock
-    private ApplyRepository applyRepository;
-
-    @Mock
-    private String2MapSerializer string2MapSerializer;
-
-    @Mock
-    private Map2JsonSerializer map2JsonSerializer;
-
-    private static Apply submittedApply;
-
-    @BeforeEach
-    void setUp() {
-        var applyId = 1L;
-        var member = Member.builder()
-                .name("김젝트")
-                .build();
-        var semester = Semester.builder()
-                .name("1")
-                .build();
-
-        var question1 = Question.builder()
-                .id(1L)
-                .build();
-        var question2 = Question.builder()
-                .id(2L)
-                .build();
-
-        var recruit = Recruit.builder()
-                .semester(semester)
-                .questions(List.of(question1, question2))
-                .build();
-
-        submittedApply = Apply.builder()
-                .id(applyId)
-                .member(member)
-                .recruit(recruit)
-                .status(Apply.Status.SUBMITTED)
-                .applicationForm(ApplicationForm.builder().build())
-                .build();
-    }
-
-    @Test
-    void 제출된_지원서_단건_삭제_성공() {
-        // given
-        var applyId = submittedApply.getId();
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
-                .willReturn(Optional.of(submittedApply));
-
-        // when
-        submittedApplyService.deleteSubmittedApply(applyId);
-
-        // then
-        verify(applyRepository).findByIdAndStatusWithMember(applyId, Status.SUBMITTED);
-        assertThat(submittedApply.getApplicationForm()).isNull();
-        assertThat(submittedApply.getMember().getName()).isNull();
-    }
-
-    @Test
-    void 제출된_지원서_단건_삭제시_존재하지_않으면_예외_발생() {
-        // given
-        var applyId = submittedApply.getId();
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
-                .willReturn(Optional.empty());
-
-        // expected
-        assertThatThrownBy(() -> submittedApplyService.deleteSubmittedApply(applyId))
-                .isInstanceOf(ApplyException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
-    }
-
-    @Test
-    void 제출된_지원서_여러건_삭제_성공() {
-        // given
-        var applyIds = List.of(1L, 2L, 3L);
-        var member2 = Member.builder().name("김젝트2").build();
-        var member3 = Member.builder().name("김젝트3").build();
-
-        var apply2 = Apply.builder()
-                .id(2L)
-                .member(member2)
-                .recruit(submittedApply.getRecruit())
-                .status(Status.SUBMITTED)
-                .applicationForm(ApplicationForm.builder().build())
-                .build();
-
-        var apply3 = Apply.builder()
-                .id(3L)
-                .member(member3)
-                .recruit(submittedApply.getRecruit())
-                .status(Status.SUBMITTED)
-                .applicationForm(ApplicationForm.builder().build())
-                .build();
-
-        var applies = List.of(submittedApply, apply2, apply3);
-
-        given(applyRepository.findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED))
-                .willReturn(applies);
-
-        // when
-        submittedApplyService.deleteSubmittedApplies(applyIds);
-
-        // then
-        verify(applyRepository).findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED);
-        assertThat(submittedApply.getApplicationForm()).isNull();
-        assertThat(submittedApply.getMember().getName()).isNull();
-        assertThat(apply2.getApplicationForm()).isNull();
-        assertThat(apply3.getApplicationForm()).isNull();
-    }
-
-    @Test
-    void 제출된_지원서_여러건_삭제시_일부가_존재하지_않으면_예외_발생() {
-        // given
-        var applyIds = List.of(1L, 2L, 3L);
-        var applies = List.of(submittedApply); // 1개만 반환
-
-        given(applyRepository.findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED))
-                .willReturn(applies);
-
-        // expected
-        assertThatThrownBy(() -> submittedApplyService.deleteSubmittedApplies(applyIds))
-                .isInstanceOf(ApplyException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
-    }
-
-    @Test
-    void 제출된_지원서_여러건_삭제시_빈_리스트면_예외_발생() {
-        // given
-        var applyIds = List.of(1L, 2L, 3L);
-
-        given(applyRepository.findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED))
-                .willReturn(List.of());
-
-        // expected
-        assertThatThrownBy(() -> submittedApplyService.deleteSubmittedApplies(applyIds))
-                .isInstanceOf(ApplyException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
-    }
-
-    @Test
-    void 제출된_지원서_수_조회_성공() {
-        // given
-        Long expectedCount = 10L;
-        given(applyRepository.countByStatus(Status.SUBMITTED))
-                .willReturn(expectedCount);
-
-        // when
-        SubmittedApplyCountResponse response = submittedApplyService.countSubmittedApply();
-
-        // then
-        assertThat(response.count()).isEqualTo(expectedCount);
-        then(applyRepository).should(times(1)).countByStatus(Status.SUBMITTED);
-    }
-
-    @Test
-    void 제출된_지원서가_없을_때_0_반환() {
-        // given
-        Long expectedCount = 0L;
-        given(applyRepository.countByStatus(Status.SUBMITTED))
-                .willReturn(expectedCount);
-
-        // when
-        SubmittedApplyCountResponse response = submittedApplyService.countSubmittedApply();
-
-        // then
-        assertThat(response.count()).isZero();
-        then(applyRepository).should(times(1)).countByStatus(Status.SUBMITTED);
-    }
-
-    @Test
-    void 제출된_지원서_목록_조회_성공() {
-        // given
-        var pageable = PageRequest.of(0, 15);
-        var jobFamily = JobFamily.BE;
-        Long semesterId = null;
-
-        var applies = List.of(submittedApply);
-        var page = new PageImpl<>(applies, pageable, 1L);
-
-        given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable))
-                .willReturn(page);
-
-        // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, pageable);
-
-        // then
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
-    }
-
-    @Test
-    void 제출된_지원서_목록_조회시_JobFamily가_null이면_전체_조회() {
-        // given
-        var pageable = PageRequest.of(0, 15);
-        Long semesterId = null;
-        var applies = List.of(submittedApply);
-        var page = new PageImpl<>(applies, pageable, 1L);
-
-        given(applyRepository.findAppliesByStatus(null, Status.SUBMITTED, semesterId, pageable))
-                .willReturn(page);
-
-        // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(null, semesterId, pageable);
-
-        // then
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(applyRepository).findAppliesByStatus(null, Status.SUBMITTED, semesterId, pageable);
-    }
-
-    @Test
-    void 제출된_지원서_목록_조회시_결과가_없으면_빈_페이지_반환() {
-        // given
-        var pageable = PageRequest.of(0, 15);
-        var jobFamily = JobFamily.BE;
-        Long semesterId = null;
-        var page = new PageImpl<Apply>(List.of(), pageable, 0L);
-
-        given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable))
-                .willReturn(page);
-
-        // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, pageable);
-
-        // then
-        assertThat(result.getContent()).isEmpty();
-        assertThat(result.getTotalElements()).isZero();
-        verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
-    }
-
-    @Test
-    void 제출된_지원서_목록_조회시_페이징_정보_정확히_전달() {
-        // given
-        var pageable = PageRequest.of(1, 10, Sort.by("createdAt").descending());
-        var jobFamily = JobFamily.BE;
-        Long semesterId = null;
-
-        var member2 = Member.builder().name("김젝트2").build();
-        var apply2 = Apply.builder()
-                .id(2L)
-                .member(member2)
-                .recruit(submittedApply.getRecruit())
-                .status(Status.SUBMITTED)
-                .applicationForm(ApplicationForm.builder().build())
-                .build();
-
-        var applies = List.of(submittedApply, apply2);
-        var page = new PageImpl<>(applies, pageable, 25L);
-
-        given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable))
-                .willReturn(page);
-
-        // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, pageable);
-
-        // then
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getTotalElements()).isEqualTo(25L);
-        assertThat(result.getNumber()).isEqualTo(1);
-        assertThat(result.getSize()).isEqualTo(10);
-        verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
-    }
-
-    @Test
-    void 제출된_지원서_목록을_semesterId로_필터링하여_조회() {
-        // given
-        var pageable = PageRequest.of(0, 15);
-        var jobFamily = JobFamily.BE;
-        Long semesterId = 1L;
-
-        var applies = List.of(submittedApply);
-        var page = new PageImpl<>(applies, pageable, 1L);
-
-        given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable))
-                .willReturn(page);
-
-        // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, pageable);
-
-        // then
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
-    }
-
-    @Test
-    void 존재하지_않는_제출된_지원서를_상세조회할_경우_예외가_발생() {
-        // given
-        var applyId = submittedApply.getId() + 1L;
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
-                .willReturn(Optional.empty());
-
-        // expected
-        assertThatThrownBy(() -> submittedApplyService.findSubmittedApplyDetail(applyId))
-                .isInstanceOf(ApplyException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
-    }
-
-    @Test
-    void 상세조회하려는_제출된_지원서가_null인_경우_빈_응답을_반환() {
-        // given
-        var applyId = submittedApply.getId() + 1L;
-        var member2 = Member.builder()
-                .name("김젝트2")
-                .build();
-        var apply2 = Apply.builder()
-                .id(applyId)
-                .status(Status.SUBMITTED)
-                .applicationForm(null)
-                .member(member2)
-                .recruit(submittedApply.getRecruit())
-                .build();
-
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
-                .willReturn(Optional.of(apply2));
-
-        // when
-        var actual = submittedApplyService.findSubmittedApplyDetail(applyId);
-        // expected
-        assertThat(actual.applyId()).isEqualTo(applyId);
-        assertThat(actual.applicationFormResponse().answers()).isEmpty();  // 빈 Map 확인
-        assertThat(actual.applicationFormResponse().portfolios()).isEmpty();
-    }
-
-    @Test
-    void 제출된_지원서를_상세조회() {
-        // given
-        given(applyRepository.findByIdAndStatusWithMember(
-                submittedApply.getId(),
-                Status.SUBMITTED
-        )).willReturn(Optional.of(submittedApply));
-
-        // when
-        var actual = submittedApplyService.findSubmittedApplyDetail(submittedApply.getId());
-
-        // then
-        verify(applyRepository).findByIdAndStatusWithMember(
-                submittedApply.getId(),
-                Status.SUBMITTED
-        );
-        assertThat(actual.applyId()).isEqualTo(submittedApply.getId());
-    }
-
-    @Test
-    void 제출된_지원서_수정_성공() {
-        // given
-        var applyId = submittedApply.getId();
-        var newName = "수정된이름";
-        var newPhoneNumber = "010-1234-5678";
-        var newEmail = "updated@example.com";
-        var newJobFamily = JobFamily.FE;
-
-        var newAnswers = Map.of(
-                "1", "수정된 답변1",
-                "2", "수정된 답변2"
-        );
-
-        var newPortfolios = List.of(
-                new ApplyPortfolioDto("url1", "name1", "1", "1"),
-                new ApplyPortfolioDto("url2", "name2", "2", "2")
-        );
-
-        var request = new SubmittedApplyEditRequest(
-                newName,
-                newPhoneNumber,
-                newEmail,
-                newJobFamily,
-                newAnswers,
-                newPortfolios
-        );
-
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
-                .willReturn(Optional.of(submittedApply));
-        given(map2JsonSerializer.serializeAsString(newAnswers))
-                .willReturn("{\"1\":\"수정된 답변1\",\"2\":\"수정된 답변2\"}");
-
-        // when
-        submittedApplyService.updateSubmittedApply(applyId, request);
-
-        // then
-        verify(applyRepository).findByIdAndStatusWithMember(applyId, Status.SUBMITTED);
-        verify(map2JsonSerializer).serializeAsString(newAnswers);
-
-        assertThat(submittedApply.getMember().getName()).isEqualTo(newName);
-        assertThat(submittedApply.getMember().getPhoneNumber()).isEqualTo(newPhoneNumber);
-        assertThat(submittedApply.getMember().getEmail()).isEqualTo(newEmail);
-        assertThat(submittedApply.getMember().getJobFamily()).isEqualTo(newJobFamily);
-    }
-
-    @Test
-    void 제출된_지원서_수정시_존재하지_않으면_예외_발생() {
-        // given
-        var applyId = 999L;
-        var request = new SubmittedApplyEditRequest(
-                "이름",
-                "01012345678",
-                "test@example.com",
-                JobFamily.BE,
-                Map.of("1", "답변"),
-                List.of()
-        );
-
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
-                .willReturn(Optional.empty());
-
-        // expected
-        assertThatThrownBy(() -> submittedApplyService.updateSubmittedApply(applyId, request))
-                .isInstanceOf(ApplyException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
-    }
-
-    @Test
-    void 제출된_지원서_수정시_유효하지_않은_질문ID면_예외_발생() {
-        // given
-        var applyId = submittedApply.getId();
-        var invalidQuestionId = "999";
-
-        var request = new SubmittedApplyEditRequest(
-                "이름",
-                "01012345678",
-                "test@example.com",
-                JobFamily.BE,
-                Map.of(invalidQuestionId, "답변"),
-                List.of()
-        );
-
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
-                .willReturn(Optional.of(submittedApply));
-
-        // expected
-        assertThatThrownBy(() -> submittedApplyService.updateSubmittedApply(applyId, request))
-                .isInstanceOf(QuestionException.class)
-                .hasFieldOrPropertyWithValue("errorCode", QuestionErrorCode.NOT_FOUND_QUESTION);
-    }
-
-    @Test
-    void 제출되지_않은_지원서_수정시_예외_발생() {
-        // given
-        var applyId = submittedApply.getId();
-        var tempSavedApply = Apply.builder()
-                .id(applyId)
-                .member(submittedApply.getMember())
-                .recruit(submittedApply.getRecruit())
-                .status(Status.TEMP_SAVED)
-                .applicationForm(ApplicationForm.builder().build())
-                .build();
-
-        var request = new SubmittedApplyEditRequest(
-                "이름",
-                "01012345678",
-                "test@example.com",
-                JobFamily.BE,
-                Map.of("1", "답변"),
-                List.of()
-        );
-
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
-                .willReturn(Optional.of(tempSavedApply));
-
-        // expected
-        assertThatThrownBy(() -> submittedApplyService.updateSubmittedApply(applyId, request))
-                .isInstanceOf(ApplyException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_SUBMITTED_APPLICATION_FORM);
-    }
+class SubmittedApplyServiceTest extends UnitTestSupport {
+
+        @InjectMocks
+        private SubmittedApplyService submittedApplyService;
+
+        @Mock
+        private ApplyRepository applyRepository;
+
+        @Mock
+        private String2MapSerializer string2MapSerializer;
+
+        @Mock
+        private Map2JsonSerializer map2JsonSerializer;
+
+        private static Apply submittedApply;
+
+        @BeforeEach
+        void setUp() {
+                var applyId = 1L;
+                var member = Member.builder()
+                                .name("김젝트")
+                                .build();
+                var semester = Semester.builder()
+                                .name("1")
+                                .build();
+
+                var question1 = Question.builder()
+                                .id(1L)
+                                .build();
+                var question2 = Question.builder()
+                                .id(2L)
+                                .build();
+
+                var recruit = Recruit.builder()
+                                .semester(semester)
+                                .questions(List.of(question1, question2))
+                                .build();
+
+                submittedApply = Apply.builder()
+                                .id(applyId)
+                                .member(member)
+                                .recruit(recruit)
+                                .status(Apply.Status.SUBMITTED)
+                                .applicationForm(ApplicationForm.builder().build())
+                                .build();
+        }
+
+        @Test
+        void 제출된_지원서_단건_삭제_성공() {
+                // given
+                var applyId = submittedApply.getId();
+                given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+                                .willReturn(Optional.of(submittedApply));
+
+                // when
+                submittedApplyService.deleteSubmittedApply(applyId);
+
+                // then
+                verify(applyRepository).findByIdAndStatusWithMember(applyId, Status.SUBMITTED);
+                assertThat(submittedApply.getApplicationForm()).isNull();
+                assertThat(submittedApply.getMember().getName()).isNull();
+        }
+
+        @Test
+        void 제출된_지원서_단건_삭제시_존재하지_않으면_예외_발생() {
+                // given
+                var applyId = submittedApply.getId();
+                given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+                                .willReturn(Optional.empty());
+
+                // expected
+                assertThatThrownBy(() -> submittedApplyService.deleteSubmittedApply(applyId))
+                                .isInstanceOf(ApplyException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
+        }
+
+        @Test
+        void 제출된_지원서_여러건_삭제_성공() {
+                // given
+                var applyIds = List.of(1L, 2L, 3L);
+                var member2 = Member.builder().name("김젝트2").build();
+                var member3 = Member.builder().name("김젝트3").build();
+
+                var apply2 = Apply.builder()
+                                .id(2L)
+                                .member(member2)
+                                .recruit(submittedApply.getRecruit())
+                                .status(Status.SUBMITTED)
+                                .applicationForm(ApplicationForm.builder().build())
+                                .build();
+
+                var apply3 = Apply.builder()
+                                .id(3L)
+                                .member(member3)
+                                .recruit(submittedApply.getRecruit())
+                                .status(Status.SUBMITTED)
+                                .applicationForm(ApplicationForm.builder().build())
+                                .build();
+
+                var applies = List.of(submittedApply, apply2, apply3);
+
+                given(applyRepository.findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED))
+                                .willReturn(applies);
+
+                // when
+                submittedApplyService.deleteSubmittedApplies(applyIds);
+
+                // then
+                verify(applyRepository).findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED);
+                assertThat(submittedApply.getApplicationForm()).isNull();
+                assertThat(submittedApply.getMember().getName()).isNull();
+                assertThat(apply2.getApplicationForm()).isNull();
+                assertThat(apply3.getApplicationForm()).isNull();
+        }
+
+        @Test
+        void 제출된_지원서_여러건_삭제시_일부가_존재하지_않으면_예외_발생() {
+                // given
+                var applyIds = List.of(1L, 2L, 3L);
+                var applies = List.of(submittedApply); // 1개만 반환
+
+                given(applyRepository.findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED))
+                                .willReturn(applies);
+
+                // expected
+                assertThatThrownBy(() -> submittedApplyService.deleteSubmittedApplies(applyIds))
+                                .isInstanceOf(ApplyException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
+        }
+
+        @Test
+        void 제출된_지원서_여러건_삭제시_빈_리스트면_예외_발생() {
+                // given
+                var applyIds = List.of(1L, 2L, 3L);
+
+                given(applyRepository.findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED))
+                                .willReturn(List.of());
+
+                // expected
+                assertThatThrownBy(() -> submittedApplyService.deleteSubmittedApplies(applyIds))
+                                .isInstanceOf(ApplyException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
+        }
+
+        @Test
+        void 제출된_지원서_수_조회_성공() {
+                // given
+                Long expectedCount = 10L;
+                given(applyRepository.countByStatus(Status.SUBMITTED))
+                                .willReturn(expectedCount);
+
+                // when
+                SubmittedApplyCountResponse response = submittedApplyService.countSubmittedApply();
+
+                // then
+                assertThat(response.count()).isEqualTo(expectedCount);
+                then(applyRepository).should(times(1)).countByStatus(Status.SUBMITTED);
+        }
+
+        @Test
+        void 제출된_지원서가_없을_때_0_반환() {
+                // given
+                Long expectedCount = 0L;
+                given(applyRepository.countByStatus(Status.SUBMITTED))
+                                .willReturn(expectedCount);
+
+                // when
+                SubmittedApplyCountResponse response = submittedApplyService.countSubmittedApply();
+
+                // then
+                assertThat(response.count()).isZero();
+                then(applyRepository).should(times(1)).countByStatus(Status.SUBMITTED);
+        }
+
+        @Test
+        void 제출된_지원서_목록_조회_성공() {
+                // given
+                var pageable = PageRequest.of(0, 15);
+                var jobFamily = JobFamily.BE;
+                Long semesterId = null;
+
+                var applies = List.of(submittedApply);
+                var page = new PageImpl<>(applies, pageable, 1L);
+
+                given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable))
+                                .willReturn(page);
+
+                // when
+                Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId,
+                                pageable);
+
+                // then
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getTotalElements()).isEqualTo(1);
+                verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
+        }
+
+        @Test
+        void 제출된_지원서_목록_조회시_JobFamily가_null이면_전체_조회() {
+                // given
+                var pageable = PageRequest.of(0, 15);
+                Long semesterId = null;
+                var applies = List.of(submittedApply);
+                var page = new PageImpl<>(applies, pageable, 1L);
+
+                given(applyRepository.findAppliesByStatus(null, Status.SUBMITTED, semesterId, pageable))
+                                .willReturn(page);
+
+                // when
+                Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(null, semesterId,
+                                pageable);
+
+                // then
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getTotalElements()).isEqualTo(1);
+                verify(applyRepository).findAppliesByStatus(null, Status.SUBMITTED, semesterId, pageable);
+        }
+
+        @Test
+        void 제출된_지원서_목록_조회시_결과가_없으면_빈_페이지_반환() {
+                // given
+                var pageable = PageRequest.of(0, 15);
+                var jobFamily = JobFamily.BE;
+                Long semesterId = null;
+                var page = new PageImpl<Apply>(List.of(), pageable, 0L);
+
+                given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable))
+                                .willReturn(page);
+
+                // when
+                Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId,
+                                pageable);
+
+                // then
+                assertThat(result.getContent()).isEmpty();
+                assertThat(result.getTotalElements()).isZero();
+                verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
+        }
+
+        @Test
+        void 제출된_지원서_목록_조회시_페이징_정보_정확히_전달() {
+                // given
+                var pageable = PageRequest.of(1, 10, Sort.by("createdAt").descending());
+                var jobFamily = JobFamily.BE;
+                Long semesterId = null;
+
+                var member2 = Member.builder().name("김젝트2").build();
+                var apply2 = Apply.builder()
+                                .id(2L)
+                                .member(member2)
+                                .recruit(submittedApply.getRecruit())
+                                .status(Status.SUBMITTED)
+                                .applicationForm(ApplicationForm.builder().build())
+                                .build();
+
+                var applies = List.of(submittedApply, apply2);
+                var page = new PageImpl<>(applies, pageable, 25L);
+
+                given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable))
+                                .willReturn(page);
+
+                // when
+                Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId,
+                                pageable);
+
+                // then
+                assertThat(result.getContent()).hasSize(2);
+                assertThat(result.getTotalElements()).isEqualTo(25L);
+                assertThat(result.getNumber()).isEqualTo(1);
+                assertThat(result.getSize()).isEqualTo(10);
+                verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
+        }
+
+        @Test
+        void 제출된_지원서_목록을_semesterId로_필터링하여_조회() {
+                // given
+                var pageable = PageRequest.of(0, 15);
+                var jobFamily = JobFamily.BE;
+                Long semesterId = 1L;
+
+                var applies = List.of(submittedApply);
+                var page = new PageImpl<>(applies, pageable, 1L);
+
+                given(applyRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable))
+                                .willReturn(page);
+
+                // when
+                Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId,
+                                pageable);
+
+                // then
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getTotalElements()).isEqualTo(1);
+                verify(applyRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, pageable);
+        }
+
+        @Test
+        void 존재하지_않는_제출된_지원서를_상세조회할_경우_예외가_발생() {
+                // given
+                var applyId = submittedApply.getId() + 1L;
+                given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+                                .willReturn(Optional.empty());
+
+                // expected
+                assertThatThrownBy(() -> submittedApplyService.findSubmittedApplyDetail(applyId))
+                                .isInstanceOf(ApplyException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
+        }
+
+        @Test
+        void 상세조회하려는_제출된_지원서가_null인_경우_빈_응답을_반환() {
+                // given
+                var applyId = submittedApply.getId() + 1L;
+                var member2 = Member.builder()
+                                .name("김젝트2")
+                                .build();
+                var apply2 = Apply.builder()
+                                .id(applyId)
+                                .status(Status.SUBMITTED)
+                                .applicationForm(null)
+                                .member(member2)
+                                .recruit(submittedApply.getRecruit())
+                                .build();
+
+                given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+                                .willReturn(Optional.of(apply2));
+
+                // when
+                var actual = submittedApplyService.findSubmittedApplyDetail(applyId);
+                // expected
+                assertThat(actual.applyId()).isEqualTo(applyId);
+                assertThat(actual.applicationFormResponse().answers()).isEmpty(); // 빈 Map 확인
+                assertThat(actual.applicationFormResponse().portfolios()).isEmpty();
+        }
+
+        @Test
+        void 제출된_지원서를_상세조회() {
+                // given
+                given(applyRepository.findByIdAndStatusWithMember(
+                                submittedApply.getId(),
+                                Status.SUBMITTED)).willReturn(Optional.of(submittedApply));
+
+                // when
+                var actual = submittedApplyService.findSubmittedApplyDetail(submittedApply.getId());
+
+                // then
+                verify(applyRepository).findByIdAndStatusWithMember(
+                                submittedApply.getId(),
+                                Status.SUBMITTED);
+                assertThat(actual.applyId()).isEqualTo(submittedApply.getId());
+        }
+
+        @Test
+        void 제출된_지원서_수정_성공() {
+                // given
+                var applyId = submittedApply.getId();
+                var newName = "수정된이름";
+                var newPhoneNumber = "010-1234-5678";
+                var newEmail = "updated@example.com";
+                var newJobFamily = JobFamily.FE;
+
+                var newAnswers = Map.of(
+                                "1", "수정된 답변1",
+                                "2", "수정된 답변2");
+
+                var newPortfolios = List.of(
+                                new ApplyPortfolioDto("url1", "name1", "1", "1"),
+                                new ApplyPortfolioDto("url2", "name2", "2", "2"));
+
+                var request = new SubmittedApplyEditRequest(
+                                newName,
+                                newPhoneNumber,
+                                newEmail,
+                                newJobFamily,
+                                newAnswers,
+                                newPortfolios);
+
+                given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+                                .willReturn(Optional.of(submittedApply));
+                given(map2JsonSerializer.serializeAsString(newAnswers))
+                                .willReturn("{\"1\":\"수정된 답변1\",\"2\":\"수정된 답변2\"}");
+
+                // when
+                submittedApplyService.updateSubmittedApply(applyId, request);
+
+                // then
+                verify(applyRepository).findByIdAndStatusWithMember(applyId, Status.SUBMITTED);
+                verify(map2JsonSerializer).serializeAsString(newAnswers);
+
+                assertThat(submittedApply.getMember().getName()).isEqualTo(newName);
+                assertThat(submittedApply.getMember().getPhoneNumber()).isEqualTo(newPhoneNumber);
+                assertThat(submittedApply.getMember().getEmail()).isEqualTo(newEmail);
+                assertThat(submittedApply.getMember().getEmail()).isEqualTo(newEmail);
+        }
+
+        @Test
+        void 제출된_지원서_수정시_존재하지_않으면_예외_발생() {
+                // given
+                var applyId = 999L;
+                var request = new SubmittedApplyEditRequest(
+                                "이름",
+                                "01012345678",
+                                "test@example.com",
+                                JobFamily.BE,
+                                Map.of("1", "답변"),
+                                List.of());
+
+                given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+                                .willReturn(Optional.empty());
+
+                // expected
+                assertThatThrownBy(() -> submittedApplyService.updateSubmittedApply(applyId, request))
+                                .isInstanceOf(ApplyException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
+        }
+
+        @Test
+        void 제출된_지원서_수정시_유효하지_않은_질문ID면_예외_발생() {
+                // given
+                var applyId = submittedApply.getId();
+                var invalidQuestionId = "999";
+
+                var request = new SubmittedApplyEditRequest(
+                                "이름",
+                                "01012345678",
+                                "test@example.com",
+                                JobFamily.BE,
+                                Map.of(invalidQuestionId, "답변"),
+                                List.of());
+
+                given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+                                .willReturn(Optional.of(submittedApply));
+
+                // expected
+                assertThatThrownBy(() -> submittedApplyService.updateSubmittedApply(applyId, request))
+                                .isInstanceOf(QuestionException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", QuestionErrorCode.NOT_FOUND_QUESTION);
+        }
+
+        @Test
+        void 제출되지_않은_지원서_수정시_예외_발생() {
+                // given
+                var applyId = submittedApply.getId();
+                var tempSavedApply = Apply.builder()
+                                .id(applyId)
+                                .member(submittedApply.getMember())
+                                .recruit(submittedApply.getRecruit())
+                                .status(Status.TEMP_SAVED)
+                                .applicationForm(ApplicationForm.builder().build())
+                                .build();
+
+                var request = new SubmittedApplyEditRequest(
+                                "이름",
+                                "01012345678",
+                                "test@example.com",
+                                JobFamily.BE,
+                                Map.of("1", "답변"),
+                                List.of());
+
+                given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+                                .willReturn(Optional.of(tempSavedApply));
+
+                // expected
+                assertThatThrownBy(() -> submittedApplyService.updateSubmittedApply(applyId, request))
+                                .isInstanceOf(ApplyException.class)
+                                .hasFieldOrPropertyWithValue("errorCode",
+                                                ApplyErrorCode.NOT_FOUND_SUBMITTED_APPLICATION_FORM);
+        }
 }

--- a/src/test/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/apply/repository/ApplyQueryRepositoryTest.java
@@ -194,14 +194,13 @@ class ApplyQueryRepositoryTest {
         // when
         Page<Apply> result = applyRepository.findAppliesByStatus(BE, status, null, pageable);
 
-
         // then
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
     }
 
     @Test
-    void createdAt_기준_내림차순_정렬()  {
+    void createdAt_기준_내림차순_정렬() {
         // given
         Member member1 = createMember("be1@test.com", BE);
         Member member2 = createMember("be2@test.com", BE);
@@ -300,8 +299,7 @@ class ApplyQueryRepositoryTest {
     private Member createMember(String email, JobFamily jobFamily) {
         return Member.builder()
                 .email(email)
-                .jobFamily(jobFamily)
-                .semesterId(1L)
+
                 .role(Role.APPLY)
                 .pin("123456")
                 .status(MemberStatus.ACTIVE)

--- a/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
@@ -147,7 +147,7 @@ class ApplyRepositoryTest {
     private Member createMember(String email, Role role) {
         return Member.builder()
                 .email(email)
-                .semesterId(1L)
+
                 .role(role)
                 .pin("123456")
                 .status(MemberStatus.ACTIVE)

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -54,568 +54,574 @@ import static org.mockito.Mockito.when;
 
 class ApplyServiceTest extends UnitTestSupport {
 
-    @InjectMocks
-    ApplyService applyService;
+        @InjectMocks
+        ApplyService applyService;
 
-    @Mock
-    RecruitRepository recruitRepository;
+        @Mock
+        RecruitRepository recruitRepository;
 
-    @Mock
-    ApplyRepository applyRepository;
+        @Mock
+        ApplyRepository applyRepository;
 
-    @Mock
-    Map2JsonSerializer map2JsonSerializer;
+        @Mock
+        Map2JsonSerializer map2JsonSerializer;
 
-    @Mock
-    ApplicationFormRepository applicationFormRepository;
+        @Mock
+        ApplicationFormRepository applicationFormRepository;
 
-    @Mock
-    MemberRepository memberRepository;
+        @Mock
+        MemberRepository memberRepository;
 
-    @Mock
-    String2MapSerializer string2MapSerializer;
+        @Mock
+        String2MapSerializer string2MapSerializer;
 
-    @Mock
-    ApplicationEventPublisher applicationEventPublisher;
+        @Mock
+        ApplicationEventPublisher applicationEventPublisher;
 
-    @Test
-    void 지원서_제출_성공() {
-        // given
-        List<Question> questions = List.of(
-                getQuestion(1L, 1, "문항 1", "설명 1"),
-                getQuestion(2L, 2, "문항 2", "설명 2"),
-                getQuestion(3L, 3, "문항 3", "설명 3"),
-                getQuestion(4L, 4, "문항 4", "설명 4"));
+        @Test
+        void 지원서_제출_성공() {
+                // given
+                List<Question> questions = List.of(
+                                getQuestion(1L, 1, "문항 1", "설명 1"),
+                                getQuestion(2L, 2, "문항 2", "설명 2"),
+                                getQuestion(3L, 3, "문항 3", "설명 3"),
+                                getQuestion(4L, 4, "문항 4", "설명 4"));
 
-        Recruit recruit = getActiveRecruit(BE, questions);
+                Recruit recruit = getActiveRecruit(BE, questions);
 
-        Member applicant = getApplicant(1L, "email@test.com");
+                Member applicant = getApplicant(1L, "email@test.com");
 
-        Map<String, String> answers = Map.of(
-                "1", "답변 1",
-                "2", "답변 2",
-                "3", "답변 3",
-                "4", "답변 4");
+                Map<String, String> answers = Map.of(
+                                "1", "답변 1",
+                                "2", "답변 2",
+                                "3", "답변 3",
+                                "4", "답변 4");
 
-        ApplicationForm applicationForm = getApplicationForm(answers.toString());
+                ApplicationForm applicationForm = getApplicationForm(answers.toString());
 
-        Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
+                Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
 
-        when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
-        when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
+                when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
+                when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any()))
+                                .thenReturn(Optional.of(apply));
+                when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
-        // when
-        applyService.submitApplication(1L, BE, answers, List.of());
+                // when
+                applyService.submitApplication(1L, BE, answers, List.of());
 
-        // then
-        // 1. TEMP_SAVED 상태에서는 update가 발생하므로 save가 호출되지 않아야 함
-        verify(applicationFormRepository, never()).save(any(ApplicationForm.class));
+                // then
+                // 1. TEMP_SAVED 상태에서는 update가 발생하므로 save가 호출되지 않아야 함
+                verify(applicationFormRepository, never()).save(any(ApplicationForm.class));
 
-        // 2. 기존 applicationForm의 내용이 새로운 내용으로 업데이트되었는지 확인
-        assertThat(applicationForm.getContent()).isEqualTo(answers.toString());
-        assertThat(applicationForm.getPortfolios()).isEmpty();
+                // 2. 기존 applicationForm의 내용이 새로운 내용으로 업데이트되었는지 확인
+                assertThat(applicationForm.getContent()).isEqualTo(answers.toString());
+                assertThat(applicationForm.getPortfolios()).isEmpty();
 
-        // 3. apply의 상태가 SUBMITTED로 변경되었는지 확인
-        assertThat(apply.getStatus()).isEqualTo(SUBMITTED);
-    }
+                // 3. apply의 상태가 SUBMITTED로 변경되었는지 확인
+                assertThat(apply.getStatus()).isEqualTo(SUBMITTED);
+        }
 
-    @Test
-    void 지원서_제출_시_PD직군은_포트폴리오가_없으면_실패() {
-        // given
-        List<Question> questions = List.of(
-                getQuestion(1L, 1, "문항 1", "설명 1"));
+        @Test
+        void 지원서_제출_시_PD직군은_포트폴리오가_없으면_실패() {
+                // given
+                List<Question> questions = List.of(
+                                getQuestion(1L, 1, "문항 1", "설명 1"));
 
-        Recruit recruit = getActiveRecruit(PD, questions);
-        Member applicant = getApplicant(1L, "email@test.com");
-        Map<String, String> answers = Map.of("1", "답변 1");
-        ApplicationForm applicationForm = getApplicationForm(answers.toString());
-        Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
+                Recruit recruit = getActiveRecruit(PD, questions);
+                Member applicant = getApplicant(1L, "email@test.com");
+                Map<String, String> answers = Map.of("1", "답변 1");
+                ApplicationForm applicationForm = getApplicationForm(answers.toString());
+                Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
 
-        when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
-        when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
+                when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
+                when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any()))
+                                .thenReturn(Optional.of(apply));
+                when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
-        // expected
-        assertThatThrownBy(() -> applyService.submitApplication(1L, PD, answers, List.of()))
-                .isInstanceOf(ApplyException.class)
-                .extracting("errorCode")
-                .isEqualTo(ApplyErrorCode.PORTFOLIO_REQUIRED);
-    }
+                // expected
+                assertThatThrownBy(() -> applyService.submitApplication(1L, PD, answers, List.of()))
+                                .isInstanceOf(ApplyException.class)
+                                .extracting("errorCode")
+                                .isEqualTo(ApplyErrorCode.PORTFOLIO_REQUIRED);
+        }
 
-    @Test
-    void 지원서_제출_시_PD직군은_포트폴리오가_있으면_성공() {
-        // given
-        List<Question> questions = List.of(
-                getQuestion(1L, 1, "문항 1", "설명 1"));
+        @Test
+        void 지원서_제출_시_PD직군은_포트폴리오가_있으면_성공() {
+                // given
+                List<Question> questions = List.of(
+                                getQuestion(1L, 1, "문항 1", "설명 1"));
 
-        Recruit recruit = getActiveRecruit(PD, questions);
-        Member applicant = getApplicant(1L, "email@test.com");
-        Map<String, String> answers = Map.of("1", "답변 1");
-        ApplicationForm applicationForm = getApplicationForm(answers.toString());
-        Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
+                Recruit recruit = getActiveRecruit(PD, questions);
+                Member applicant = getApplicant(1L, "email@test.com");
+                Map<String, String> answers = Map.of("1", "답변 1");
+                ApplicationForm applicationForm = getApplicationForm(answers.toString());
+                Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
 
-        List<ApplyPortfolioDto> portfolios = List.of(
-                new ApplyPortfolioDto("url", "name", "100", "1")
-        );
+                List<ApplyPortfolioDto> portfolios = List.of(
+                                new ApplyPortfolioDto("url", "name", "100", "1"));
 
-        when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
-        when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
+                when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
+                when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any()))
+                                .thenReturn(Optional.of(apply));
+                when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
-        // when
-        applyService.submitApplication(1L, PD, answers, portfolios);
+                // when
+                applyService.submitApplication(1L, PD, answers, portfolios);
 
-        // then
-        assertThat(apply.getStatus()).isEqualTo(SUBMITTED);
-        assertThat(applicationForm.getPortfolios()).hasSize(1);
-    }
+                // then
+                assertThat(apply.getStatus()).isEqualTo(SUBMITTED);
+                assertThat(applicationForm.getPortfolios()).hasSize(1);
+        }
 
-    @Test
-    void 지원서_제출_시_존재하지_않는_문항이_있으면_실패() {
-        // given
-        List<Question> questions = List.of(
-                getQuestion(1L, 1, "문항 1", "설명 1"),
-                getQuestion(2L, 2, "문항 2", "설명 2"),
-                getQuestion(3L, 3, "문항 3", "설명 3"),
-                getQuestion(5L, 5, "문항 5", "설명 5"));
+        @Test
+        void 지원서_제출_시_존재하지_않는_문항이_있으면_실패() {
+                // given
+                List<Question> questions = List.of(
+                                getQuestion(1L, 1, "문항 1", "설명 1"),
+                                getQuestion(2L, 2, "문항 2", "설명 2"),
+                                getQuestion(3L, 3, "문항 3", "설명 3"),
+                                getQuestion(5L, 5, "문항 5", "설명 5"));
 
-        Recruit recruit = getActiveRecruit(BE, questions);
+                Recruit recruit = getActiveRecruit(BE, questions);
 
-        Map<String, String> answers = Map.of(
-                "1", "답변 1",
-                "2", "답변 2",
-                "3", "답변 3",
-                "4", "답변 4");
+                Map<String, String> answers = Map.of(
+                                "1", "답변 1",
+                                "2", "답변 2",
+                                "3", "답변 3",
+                                "4", "답변 4");
 
-        when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
+                when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
 
-        // when, then
-        assertThatThrownBy(() -> applyService.submitApplication(1L, BE, answers, List.of()))
-                .isInstanceOf(QuestionException.class);
-    }
+                // when, then
+                assertThatThrownBy(() -> applyService.submitApplication(1L, BE, answers, List.of()))
+                                .isInstanceOf(QuestionException.class);
+        }
 
-    @Test
-    void 지원상태_조회_시_프로필작성을_하지_않았을_경우_예외발생() {
-        // given
-        Member member = Member.builder()
-                .id(1L)
-                .name("지원자명")
-                .phoneNumber("01012345678")
-                .build();
-        given(memberRepository.findById(member.getId()))
-                .willReturn(Optional.of(member));
-        given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
-                .willReturn(Optional.empty());
-
-        // expected
-        assertThatThrownBy(() -> applyService.checkApplyStatus(member.getId()))
-                .isInstanceOf(ApplyException.class)
-                .extracting("errorCode")
-                .isEqualTo(ApplyErrorCode.NOT_FOUND_APPLY);
-    }
-
-    @Test
-    void 작성_중인_지원서가_있는_경우_TEMP_SAVED_반환() {
-        // given
-        Member member = Member.builder()
-                .id(1L)
-                .name("지원자명")
-                .phoneNumber("01012345678")
-                .build();
-        given(memberRepository.findById(member.getId()))
-                .willReturn(Optional.of(member));
-        given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
-                .willReturn(Optional.of(
-                        Apply.builder()
+        @Test
+        void 지원상태_조회_시_프로필작성을_하지_않았을_경우_예외발생() {
+                // given
+                Member member = Member.builder()
                                 .id(1L)
-                                .status(TEMP_SAVED)
-                                .build()
-                ));
+                                .name("지원자명")
+                                .phoneNumber("01012345678")
+                                .build();
+                given(memberRepository.findById(member.getId()))
+                                .willReturn(Optional.of(member));
+                given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
+                                .willReturn(Optional.empty());
 
-        // when
-        ApplyStatusResponse result = applyService.checkApplyStatus(member.getId());
+                // expected
+                assertThatThrownBy(() -> applyService.checkApplyStatus(member.getId()))
+                                .isInstanceOf(ApplyException.class)
+                                .extracting("errorCode")
+                                .isEqualTo(ApplyErrorCode.NOT_FOUND_APPLY);
+        }
 
-        // then
-        assertThat(result.status()).isEqualTo(TEMP_SAVED);
-    }
-
-    @Test
-    void 지원서를_제출한_지원자에_대한_제출_상태_확인_시_SUBMITTED_반환() {
-        // given
-        Member member = Member.builder()
-                .id(1L)
-                .name("지원자명")
-                .phoneNumber("01012345678")
-                .build();
-        given(memberRepository.findById(member.getId()))
-                .willReturn(Optional.of(member));
-        given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
-                .willReturn(Optional.of(
-                        Apply.builder()
+        @Test
+        void 작성_중인_지원서가_있는_경우_TEMP_SAVED_반환() {
+                // given
+                Member member = Member.builder()
                                 .id(1L)
-                                .status(SUBMITTED)
-                                .build()
-                ));
-
-        // when
-        ApplyStatusResponse result = applyService.checkApplyStatus(member.getId());
-
-        // then
-        assertThat(result.status()).isEqualTo(SUBMITTED);
-    }
-
-    @Test
-    void 지원서_최초_임시저장_성공() {
-        // given
-        List<Question> questions = List.of(
-                getQuestion(1L, 1, "문항 1", "설명 1"),
-                getQuestion(2L, 2, "문항 2", "설명 2"),
-                getQuestion(3L, 3, "문항 3", "설명 3"),
-                getQuestion(4L, 4, "문항 4", "설명 4"));
-
-        Recruit recruit = getActiveRecruit(BE, questions);
-
-        Map<String, String> answers = Map.of(
-                "1", "답변 1",
-                "2", "답변 2",
-                "3", "답변 3",
-                "4", "답변 4");
+                                .name("지원자명")
+                                .phoneNumber("01012345678")
+                                .build();
+                given(memberRepository.findById(member.getId()))
+                                .willReturn(Optional.of(member));
+                given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
+                                .willReturn(Optional.of(
+                                                Apply.builder()
+                                                                .id(1L)
+                                                                .status(TEMP_SAVED)
+                                                                .build()));
+
+                // when
+                ApplyStatusResponse result = applyService.checkApplyStatus(member.getId());
+
+                // then
+                assertThat(result.status()).isEqualTo(TEMP_SAVED);
+        }
+
+        @Test
+        void 지원서를_제출한_지원자에_대한_제출_상태_확인_시_SUBMITTED_반환() {
+                // given
+                Member member = Member.builder()
+                                .id(1L)
+                                .name("지원자명")
+                                .phoneNumber("01012345678")
+                                .build();
+                given(memberRepository.findById(member.getId()))
+                                .willReturn(Optional.of(member));
+                given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
+                                .willReturn(Optional.of(
+                                                Apply.builder()
+                                                                .id(1L)
+                                                                .status(SUBMITTED)
+                                                                .build()));
+
+                // when
+                ApplyStatusResponse result = applyService.checkApplyStatus(member.getId());
+
+                // then
+                assertThat(result.status()).isEqualTo(SUBMITTED);
+        }
+
+        @Test
+        void 지원서_최초_임시저장_성공() {
+                // given
+                List<Question> questions = List.of(
+                                getQuestion(1L, 1, "문항 1", "설명 1"),
+                                getQuestion(2L, 2, "문항 2", "설명 2"),
+                                getQuestion(3L, 3, "문항 3", "설명 3"),
+                                getQuestion(4L, 4, "문항 4", "설명 4"));
+
+                Recruit recruit = getActiveRecruit(BE, questions);
+
+                Map<String, String> answers = Map.of(
+                                "1", "답변 1",
+                                "2", "답변 2",
+                                "3", "답변 3",
+                                "4", "답변 4");
+
+                Member applicant = getApplicant(1L, "email@test.com");
+
+                ApplicationForm applicationForm = getApplicationForm(answers.toString());
+
+                Apply apply = getApply(1L, recruit, applicant, applicationForm, JOINED);
+
+                String content = "newContent";
+
+                when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any()))
+                                .thenReturn(Optional.of(apply));
+                when(map2JsonSerializer.serializeAsString(answers)).thenReturn(content);
+
+                // when
+                applyService.saveApplicationTemporarily(1L, answers, List.of());
+
+                // then
+                ArgumentCaptor<ApplicationForm> captor = ArgumentCaptor.forClass(ApplicationForm.class);
+                verify(applicationFormRepository).save(captor.capture());
+
+                ApplicationForm saved = captor.getValue();
+                assertThat(saved.getApply()).isEqualTo(apply);
+                assertThat(saved.getContent()).isEqualTo(content);
+                assertThat(saved.getPortfolios()).isEmpty();
+                assertThat(apply.getApplicationForm()).isEqualTo(saved);
+                assertThat(apply.getStatus()).isEqualTo(TEMP_SAVED);
+        }
+
+        @Test
+        void 지원서를_이미_제출한_상태에서_임시저장_실패() {
+                // given
+                List<Question> questions = List.of(
+                                getQuestion(1L, 1, "문항 1", "설명 1"),
+                                getQuestion(2L, 2, "문항 2", "설명 2"),
+                                getQuestion(3L, 3, "문항 3", "설명 3"),
+                                getQuestion(4L, 4, "문항 4", "설명 4"));
+
+                Recruit recruit = getActiveRecruit(BE, questions);
+
+                Map<String, String> answers = Map.of(
+                                "1", "답변 1",
+                                "2", "답변 2",
+                                "3", "답변 3",
+                                "4", "답변 4");
 
-        Member applicant = getApplicant(1L, "email@test.com");
-
-        ApplicationForm applicationForm = getApplicationForm(answers.toString());
+                Member applicant = getApplicant(1L, "email@test.com");
 
-        Apply apply = getApply(1L, recruit, applicant, applicationForm, JOINED);
+                ApplicationForm applicationForm = getApplicationForm(answers.toString());
 
-        String content = "newContent";
+                Apply apply = getApply(1L, recruit, applicant, applicationForm, SUBMITTED);
+
+                when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any()))
+                                .thenReturn(Optional.of(apply));
 
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
-        when(map2JsonSerializer.serializeAsString(answers)).thenReturn(content);
-
-        // when
-        applyService.saveApplicationTemporarily(1L, answers, List.of());
-
-        // then
-        ArgumentCaptor<ApplicationForm> captor = ArgumentCaptor.forClass(ApplicationForm.class);
-        verify(applicationFormRepository).save(captor.capture());
-
-        ApplicationForm saved = captor.getValue();
-        assertThat(saved.getApply()).isEqualTo(apply);
-        assertThat(saved.getContent()).isEqualTo(content);
-        assertThat(saved.getPortfolios()).isEmpty();
-        assertThat(apply.getApplicationForm()).isEqualTo(saved);
-        assertThat(apply.getStatus()).isEqualTo(TEMP_SAVED);
-    }
-
-    @Test
-    void 지원서를_이미_제출한_상태에서_임시저장_실패() {
-        // given
-        List<Question> questions = List.of(
-                getQuestion(1L, 1, "문항 1", "설명 1"),
-                getQuestion(2L, 2, "문항 2", "설명 2"),
-                getQuestion(3L, 3, "문항 3", "설명 3"),
-                getQuestion(4L, 4, "문항 4", "설명 4"));
-
-        Recruit recruit = getActiveRecruit(BE, questions);
-
-        Map<String, String> answers = Map.of(
-                "1", "답변 1",
-                "2", "답변 2",
-                "3", "답변 3",
-                "4", "답변 4");
-
-        Member applicant = getApplicant(1L, "email@test.com");
-
-        ApplicationForm applicationForm = getApplicationForm(answers.toString());
-
-        Apply apply = getApply(1L, recruit, applicant, applicationForm, SUBMITTED);
-
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
-
-        // when, then
-        assertThatThrownBy(() -> applyService.saveApplicationTemporarily(1L, answers, List.of()))
-                .isInstanceOf(ApplyException.class);
-    }
-
-    @Test
-    void 프로필_저장_전에_임시저장_시도_시_실패() {
-        // given
-        long memberId = 1L;
-        Map<String, String> answers = Map.of("1", "답변1");
-
-        given(applyRepository.findByMemberIdInActiveRecruit(eq(memberId), any())).willReturn(Optional.empty());
-
-        // expected
-        assertThatThrownBy(() -> applyService.saveApplicationTemporarily(memberId, answers, List.of()))
-                .isInstanceOf(ApplyException.class)
-                .extracting("errorCode")
-                .isEqualTo(ApplyErrorCode.NOT_FOUND_APPLY);
-    }
-
-    @Test
-    void 지원서를_임시저장한_상태에서_임시저장_성공() {
-        // given
-        List<Question> questions = List.of(
-                getQuestion(1L, 1, "문항 1", "설명 1"),
-                getQuestion(2L, 2, "문항 2", "설명 2"),
-                getQuestion(3L, 3, "문항 3", "설명 3"),
-                getQuestion(4L, 4, "문항 4", "설명 4"));
-
-        Recruit recruit = getActiveRecruit(BE, questions);
-
-        Map<String, String> answers = Map.of(
-                "1", "답변 1",
-                "2", "답변 2",
-                "3", "답변 3",
-                "4", "답변 4");
-
-        Member applicant = getApplicant(1L, "email@test.com");
-
-        ApplicationForm oldApplicationForm = ApplicationForm.builder()
-                .id(1L)
-                .content("oldContent")
-                .build();
-
-        Apply apply = getApply(1L, recruit, applicant, oldApplicationForm, TEMP_SAVED);
-
-        String newContent = "newContent";
-
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
-        when(map2JsonSerializer.serializeAsString(answers)).thenReturn(newContent);
-
-        // when
-        applyService.saveApplicationTemporarily(1L, answers, List.of());
-
-        // then
-        ApplicationForm newApplicationForm = apply.getApplicationForm();
-        assertThat(newApplicationForm.getContent()).isEqualTo(newContent);
-        assertThat(apply.getStatus()).isEqualTo(TEMP_SAVED);
-    }
-
-    @Test
-    void 프로필과_임시저장한_지원서_제거_성공() {
-        // given
-        List<Question> questions = List.of(
-                getQuestion(1L, 1, "문항 1", "설명 1"),
-                getQuestion(2L, 2, "문항 2", "설명 2"),
-                getQuestion(3L, 3, "문항 3", "설명 3"),
-                getQuestion(4L, 4, "문항 4", "설명 4"));
-
-        Recruit recruit = getActiveRecruit(BE, questions);
-
-        ApplicationForm applicationForm = ApplicationForm.builder()
-                .id(1L)
-                .content("content")
-                .build();
-
-        Apply apply = getApply(1L, recruit, getApplicant(1L, "email@test.com"), applicationForm, TEMP_SAVED);
-
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply));
-
-        // when
-        applyService.deleteProfileAndTempApplicationForm(1L);
-
-        // then
-        assertThat(apply.getApplicationForm()).isNull();
-        assertThat(apply.getStatus()).isEqualTo(JOINED);
-
-        Member applicant = apply.getMember();
-        assertThat(applicant.getName()).isNull();
-        assertThat(applicant.getPhoneNumber()).isNull();
-        assertThat(applicant.getJobFamily()).isNull();
-        assertThat(applicant.getCareerDetails()).isNull();
-        assertThat(applicant.getExperiencePeriod()).isNull();
-        assertThat(applicant.getInterestedDomains()).isEmpty();
-    }
-
-    @Test
-    void 임시저장한_지원서가_없거나_이미_제출한_상태에서_프로필과_임시저장한_지원서_제거_시_실패() {
-        // given
-        List<Question> questions = List.of(
-                getQuestion(1L, 1, "문항 1", "설명 1"),
-                getQuestion(2L, 2, "문항 2", "설명 2"),
-                getQuestion(3L, 3, "문항 3", "설명 3"),
-                getQuestion(4L, 4, "문항 4", "설명 4"));
-
-        Recruit recruit = getActiveRecruit(BE, questions);
-
-        Apply apply1 = getApply(1L, recruit, getApplicant(1L, "email1@test.com"), null, JOINED);
-        Apply apply2 = getApply(2L, recruit, getApplicant(2L, "email2@test.com"), ApplicationForm.builder()
-                .id(2L)
-                .content("content")
-                .build(), SUBMITTED);
-
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply1));
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(2L), any())).thenReturn(Optional.of(apply2));
-
-        // when, then
-        assertThatThrownBy(() -> applyService.deleteProfileAndTempApplicationForm(1L))
-                .isInstanceOf(ApplyException.class);
-        assertThatThrownBy(() -> applyService.deleteProfileAndTempApplicationForm(2L))
-                .isInstanceOf(ApplyException.class);
-    }
-
-    @Test
-    void 가장_최근에_임시저장한_지원서_조회_성공() {
-        // given
-        List<Question> questions = List.of(
-                getQuestion(1L, 1, "문항 1", "설명 1"),
-                getQuestion(2L, 2, "문항 2", "설명 2"),
-                getQuestion(3L, 3, "문항 3", "설명 3"),
-                getQuestion(4L, 4, "문항 4", "설명 4"));
-
-        Recruit recruit = getActiveRecruit(BE, questions);
-
-        Map<String, String> answers = Map.of("1", "answer1", "2", "answer2");
-        ApplicationForm tempApplicationForm = getApplicationForm(answers.toString());
-
-        Apply apply = getApply(1L, recruit, getApplicant(1L, "email@test.com"), tempApplicationForm, TEMP_SAVED);
-
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply));
-        when(string2MapSerializer.serializeAsMap(tempApplicationForm.getContent())).thenReturn(answers);
-
-        // when
-        TempApplicationFormResponse result = applyService.findTempApplicationForm(1L);
-
-        // then
-        assertThat(result.answers()).isEqualTo(answers);
-        assertThat(result.portfolios()).isEmpty();
-        assertThat(result.jobFamily()).isEqualTo(BE);
-    }
-
-    @Test
-    void 임시저장한_지원서가_없는_상태에서_조회_시_실패() {
-        // given
-        List<Question> questions = List.of(
-                getQuestion(1L, 1, "문항 1", "설명 1"),
-                getQuestion(2L, 2, "문항 2", "설명 2"),
-                getQuestion(3L, 3, "문항 3", "설명 3"),
-                getQuestion(4L, 4, "문항 4", "설명 4"));
-
-        Apply apply = getApply(1L, getActiveRecruit(BE, questions), getApplicant(1L, "email@test.com"), null, JOINED);
-
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply));
-
-        // when, then
-        assertThatThrownBy(() -> applyService.findTempApplicationForm(1L))
-                .isInstanceOf(ApplyException.class);
-    }
-
-    @Test
-    void 프로필_저장_성공() {
-        // given
-        long memberId = 1L;
-        Member member = getApplicant(memberId, "test@example.com");
-        ApplyProfileRequest request = new ApplyProfileRequest(
-            "New Name",
-            "010-1234-5678",
-            JobFamily.FE,
-            Region.SEOUL,
-            CareerDetails.STUDENT,
-            ExperiencePeriod.NONE,
-            List.of(InterestedDomain.GAME.getDescription(), InterestedDomain.EDUCATION.getDescription())
-        );
-        Recruit recruit = getActiveRecruit(request.jobFamily(), List.of());
-
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(applyRepository.existsByMemberIdInActiveRecruit(eq(memberId), any())).willReturn(false);
-        given(recruitRepository.findActiveRecruits(any())).willReturn(List.of(recruit));
-
-        // when
-        applyService.saveProfile(memberId, request);
-
-        // then
-        ArgumentCaptor<Apply> applyCaptor = ArgumentCaptor.forClass(Apply.class);
-        verify(applyRepository).save(applyCaptor.capture());
-        Apply savedApply = applyCaptor.getValue();
-
-        assertThat(savedApply.getMember()).isEqualTo(member);
-        assertThat(savedApply.getRecruit()).isEqualTo(recruit);
-        assertThat(savedApply.getStatus()).isEqualTo(JOINED);
-
-        assertThat(member.getName()).isEqualTo(request.name());
-        assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
-        assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
-    }
-
-    @Test
-    void 프로필_저장_시_Apply가_존재하면_프로필만_업데이트() {
-        // given
-        long memberId = 1L;
-        Member member = getApplicant(memberId, "test@example.com");
-        ApplyProfileRequest request = new ApplyProfileRequest(
-                "New Name",
-                "010-1234-5678",
-                JobFamily.FE,
-                Region.SEOUL,
-                CareerDetails.STUDENT,
-                ExperiencePeriod.NONE,
-                List.of(InterestedDomain.GAME.getDescription(), InterestedDomain.EDUCATION.getDescription())
-        );
-
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(applyRepository.existsByMemberIdInActiveRecruit(eq(memberId), any())).willReturn(true);
-
-        // when
-        applyService.saveProfile(memberId, request);
-
-        // then
-        verify(applyRepository, never()).save(any(Apply.class));
-
-        assertThat(member.getName()).isEqualTo(request.name());
-        assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
-        assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
-        assertThat(member.getCareerDetails()).isEqualTo(request.careerDetails());
-        assertThat(member.getExperiencePeriod()).isEqualTo(request.experiencePeriod());
-    }
-
-    private Recruit getActiveRecruit(JobFamily jobFamily, List<Question> questions) {
-        return Recruit.builder()
-                .id(1L)
-                .semester(Semester.builder().id(1L).name("1기").build())
-                .startDate(LocalDateTime.now().minusDays(1))
-                .endDate(LocalDateTime.now().plusDays(1))
-                .jobFamily(jobFamily)
-                .questions(questions)
-                .build();
-    }
-
-    private Question getQuestion(Long id, int sequence, String title, String label) {
-        return Question.builder()
-                .id(id)
-                .sequence(sequence)
-                .inputType(Question.InputType.TEXT)
-                .isRequired(true)
-                .title(title)
-                .label(label)
-                .build();
-    }
-
-    private Member getApplicant(Long id, String email) {
-        return Member.builder()
-                .id(id)
-                .email(email)
-                .pin("111111")
-                .role(Role.APPLY)
-                .status(MemberStatus.ACTIVE)
-                .build();
-    }
-
-    private Apply getApply(Long id, Recruit recruit, Member applicant, ApplicationForm applicationForm, Apply.Status status) {
-        return Apply.builder()
-                .id(id)
-                .recruit(recruit)
-                .member(applicant)
-                .applicationForm(applicationForm)
-                .status(status)
-                .build();
-    }
-
-    private ApplicationForm getApplicationForm(String content) {
-        return ApplicationForm.builder()
-                .id(1L)
-                .content(content)
-                .build();
-    }
+                // when, then
+                assertThatThrownBy(() -> applyService.saveApplicationTemporarily(1L, answers, List.of()))
+                                .isInstanceOf(ApplyException.class);
+        }
+
+        @Test
+        void 프로필_저장_전에_임시저장_시도_시_실패() {
+                // given
+                long memberId = 1L;
+                Map<String, String> answers = Map.of("1", "답변1");
+
+                given(applyRepository.findByMemberIdInActiveRecruit(eq(memberId), any())).willReturn(Optional.empty());
+
+                // expected
+                assertThatThrownBy(() -> applyService.saveApplicationTemporarily(memberId, answers, List.of()))
+                                .isInstanceOf(ApplyException.class)
+                                .extracting("errorCode")
+                                .isEqualTo(ApplyErrorCode.NOT_FOUND_APPLY);
+        }
+
+        @Test
+        void 지원서를_임시저장한_상태에서_임시저장_성공() {
+                // given
+                List<Question> questions = List.of(
+                                getQuestion(1L, 1, "문항 1", "설명 1"),
+                                getQuestion(2L, 2, "문항 2", "설명 2"),
+                                getQuestion(3L, 3, "문항 3", "설명 3"),
+                                getQuestion(4L, 4, "문항 4", "설명 4"));
+
+                Recruit recruit = getActiveRecruit(BE, questions);
+
+                Map<String, String> answers = Map.of(
+                                "1", "답변 1",
+                                "2", "답변 2",
+                                "3", "답변 3",
+                                "4", "답변 4");
+
+                Member applicant = getApplicant(1L, "email@test.com");
+
+                ApplicationForm oldApplicationForm = ApplicationForm.builder()
+                                .id(1L)
+                                .content("oldContent")
+                                .build();
+
+                Apply apply = getApply(1L, recruit, applicant, oldApplicationForm, TEMP_SAVED);
+
+                String newContent = "newContent";
+
+                when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any()))
+                                .thenReturn(Optional.of(apply));
+                when(map2JsonSerializer.serializeAsString(answers)).thenReturn(newContent);
+
+                // when
+                applyService.saveApplicationTemporarily(1L, answers, List.of());
+
+                // then
+                ApplicationForm newApplicationForm = apply.getApplicationForm();
+                assertThat(newApplicationForm.getContent()).isEqualTo(newContent);
+                assertThat(apply.getStatus()).isEqualTo(TEMP_SAVED);
+        }
+
+        @Test
+        void 프로필과_임시저장한_지원서_제거_성공() {
+                // given
+                List<Question> questions = List.of(
+                                getQuestion(1L, 1, "문항 1", "설명 1"),
+                                getQuestion(2L, 2, "문항 2", "설명 2"),
+                                getQuestion(3L, 3, "문항 3", "설명 3"),
+                                getQuestion(4L, 4, "문항 4", "설명 4"));
+
+                Recruit recruit = getActiveRecruit(BE, questions);
+
+                ApplicationForm applicationForm = ApplicationForm.builder()
+                                .id(1L)
+                                .content("content")
+                                .build();
+
+                Apply apply = getApply(1L, recruit, getApplicant(1L, "email@test.com"), applicationForm, TEMP_SAVED);
+
+                when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply));
+
+                // when
+                applyService.deleteProfileAndTempApplicationForm(1L);
+
+                // then
+                assertThat(apply.getApplicationForm()).isNull();
+                assertThat(apply.getStatus()).isEqualTo(JOINED);
+
+                Member applicant = apply.getMember();
+                assertThat(applicant.getName()).isNull();
+                assertThat(applicant.getPhoneNumber()).isNull();
+
+                assertThat(applicant.getCareerDetails()).isNull();
+                assertThat(applicant.getExperiencePeriod()).isNull();
+                assertThat(applicant.getInterestedDomains()).isEmpty();
+        }
+
+        @Test
+        void 임시저장한_지원서가_없거나_이미_제출한_상태에서_프로필과_임시저장한_지원서_제거_시_실패() {
+                // given
+                List<Question> questions = List.of(
+                                getQuestion(1L, 1, "문항 1", "설명 1"),
+                                getQuestion(2L, 2, "문항 2", "설명 2"),
+                                getQuestion(3L, 3, "문항 3", "설명 3"),
+                                getQuestion(4L, 4, "문항 4", "설명 4"));
+
+                Recruit recruit = getActiveRecruit(BE, questions);
+
+                Apply apply1 = getApply(1L, recruit, getApplicant(1L, "email1@test.com"), null, JOINED);
+                Apply apply2 = getApply(2L, recruit, getApplicant(2L, "email2@test.com"), ApplicationForm.builder()
+                                .id(2L)
+                                .content("content")
+                                .build(), SUBMITTED);
+
+                when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply1));
+                when(applyRepository.findByMemberIdInActiveRecruit(eq(2L), any())).thenReturn(Optional.of(apply2));
+
+                // when, then
+                assertThatThrownBy(() -> applyService.deleteProfileAndTempApplicationForm(1L))
+                                .isInstanceOf(ApplyException.class);
+                assertThatThrownBy(() -> applyService.deleteProfileAndTempApplicationForm(2L))
+                                .isInstanceOf(ApplyException.class);
+        }
+
+        @Test
+        void 가장_최근에_임시저장한_지원서_조회_성공() {
+                // given
+                List<Question> questions = List.of(
+                                getQuestion(1L, 1, "문항 1", "설명 1"),
+                                getQuestion(2L, 2, "문항 2", "설명 2"),
+                                getQuestion(3L, 3, "문항 3", "설명 3"),
+                                getQuestion(4L, 4, "문항 4", "설명 4"));
+
+                Recruit recruit = getActiveRecruit(BE, questions);
+
+                Map<String, String> answers = Map.of("1", "answer1", "2", "answer2");
+                ApplicationForm tempApplicationForm = getApplicationForm(answers.toString());
+
+                Apply apply = getApply(1L, recruit, getApplicant(1L, "email@test.com"), tempApplicationForm,
+                                TEMP_SAVED);
+
+                when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply));
+                when(string2MapSerializer.serializeAsMap(tempApplicationForm.getContent())).thenReturn(answers);
+
+                // when
+                TempApplicationFormResponse result = applyService.findTempApplicationForm(1L);
+
+                // then
+                assertThat(result.answers()).isEqualTo(answers);
+                assertThat(result.portfolios()).isEmpty();
+                assertThat(result.jobFamily()).isEqualTo(BE);
+        }
+
+        @Test
+        void 임시저장한_지원서가_없는_상태에서_조회_시_실패() {
+                // given
+                List<Question> questions = List.of(
+                                getQuestion(1L, 1, "문항 1", "설명 1"),
+                                getQuestion(2L, 2, "문항 2", "설명 2"),
+                                getQuestion(3L, 3, "문항 3", "설명 3"),
+                                getQuestion(4L, 4, "문항 4", "설명 4"));
+
+                Apply apply = getApply(1L, getActiveRecruit(BE, questions), getApplicant(1L, "email@test.com"), null,
+                                JOINED);
+
+                when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply));
+
+                // when, then
+                assertThatThrownBy(() -> applyService.findTempApplicationForm(1L))
+                                .isInstanceOf(ApplyException.class);
+        }
+
+        @Test
+        void 프로필_저장_성공() {
+                // given
+                long memberId = 1L;
+                Member member = getApplicant(memberId, "test@example.com");
+                ApplyProfileRequest request = new ApplyProfileRequest(
+                                "New Name",
+                                "010-1234-5678",
+                                JobFamily.FE,
+                                Region.SEOUL,
+                                CareerDetails.STUDENT,
+                                ExperiencePeriod.NONE,
+                                List.of(InterestedDomain.GAME.getDescription(),
+                                                InterestedDomain.EDUCATION.getDescription()));
+                Recruit recruit = getActiveRecruit(request.jobFamily(), List.of());
+
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+                given(applyRepository.existsByMemberIdInActiveRecruit(eq(memberId), any())).willReturn(false);
+                given(recruitRepository.findActiveRecruits(any())).willReturn(List.of(recruit));
+
+                // when
+                applyService.saveProfile(memberId, request);
+
+                // then
+                ArgumentCaptor<Apply> applyCaptor = ArgumentCaptor.forClass(Apply.class);
+                verify(applyRepository).save(applyCaptor.capture());
+                Apply savedApply = applyCaptor.getValue();
+
+                assertThat(savedApply.getMember()).isEqualTo(member);
+                assertThat(savedApply.getRecruit()).isEqualTo(recruit);
+                assertThat(savedApply.getStatus()).isEqualTo(JOINED);
+
+                assertThat(member.getName()).isEqualTo(request.name());
+                assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
+
+        }
+
+        @Test
+        void 프로필_저장_시_Apply가_존재하면_프로필만_업데이트() {
+                // given
+                long memberId = 1L;
+                Member member = getApplicant(memberId, "test@example.com");
+                ApplyProfileRequest request = new ApplyProfileRequest(
+                                "New Name",
+                                "010-1234-5678",
+                                JobFamily.FE,
+                                Region.SEOUL,
+                                CareerDetails.STUDENT,
+                                ExperiencePeriod.NONE,
+                                List.of(InterestedDomain.GAME.getDescription(),
+                                                InterestedDomain.EDUCATION.getDescription()));
+
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+                given(applyRepository.existsByMemberIdInActiveRecruit(eq(memberId), any())).willReturn(true);
+
+                // when
+                applyService.saveProfile(memberId, request);
+
+                // then
+                verify(applyRepository, never()).save(any(Apply.class));
+
+                assertThat(member.getName()).isEqualTo(request.name());
+                assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
+
+                assertThat(member.getCareerDetails()).isEqualTo(request.careerDetails());
+                assertThat(member.getExperiencePeriod()).isEqualTo(request.experiencePeriod());
+        }
+
+        private Recruit getActiveRecruit(JobFamily jobFamily, List<Question> questions) {
+                return Recruit.builder()
+                                .id(1L)
+                                .semester(Semester.builder().id(1L).name("1기").build())
+                                .startDate(LocalDateTime.now().minusDays(1))
+                                .endDate(LocalDateTime.now().plusDays(1))
+                                .jobFamily(jobFamily)
+                                .questions(questions)
+                                .build();
+        }
+
+        private Question getQuestion(Long id, int sequence, String title, String label) {
+                return Question.builder()
+                                .id(id)
+                                .sequence(sequence)
+                                .inputType(Question.InputType.TEXT)
+                                .isRequired(true)
+                                .title(title)
+                                .label(label)
+                                .build();
+        }
+
+        private Member getApplicant(Long id, String email) {
+                return Member.builder()
+                                .id(id)
+                                .email(email)
+                                .pin("111111")
+                                .role(Role.APPLY)
+                                .status(MemberStatus.ACTIVE)
+                                .build();
+        }
+
+        private Apply getApply(Long id, Recruit recruit, Member applicant, ApplicationForm applicationForm,
+                        Apply.Status status) {
+                return Apply.builder()
+                                .id(id)
+                                .recruit(recruit)
+                                .member(applicant)
+                                .applicationForm(applicationForm)
+                                .status(status)
+                                .build();
+        }
+
+        private ApplicationForm getApplicationForm(String content) {
+                return ApplicationForm.builder()
+                                .id(1L)
+                                .content(content)
+                                .build();
+        }
 }

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @IntegrationTest
 @AutoConfigureMockMvc
-@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
+@TestPropertySource(properties = { "spring.data.redis.repositories.enabled=false" })
 class FileControllerTest extends ApplicationPeriodTest {
 
     @Autowired
@@ -56,8 +56,7 @@ class FileControllerTest extends ApplicationPeriodTest {
     void setUp() {
         member = Member.builder()
                 .email("test32@gmail.com")
-                .semesterId(1L)
-                .jobFamily(JobFamily.BE)
+
                 .name("홍길동") // 한글 1~5글자로 수정
                 .role(Role.SEMESTER)
                 .phoneNumber("01012345678") // 010으로 시작하는 11자리 수정
@@ -81,9 +80,9 @@ class FileControllerTest extends ApplicationPeriodTest {
                 .build());
 
         mockMvc.perform(post("/upload/portfolios")
-                        .contentType("application/json")
-                        .param("memberId", member.getId().toString())
-                        .content(getContent()))
+                .contentType("application/json")
+                .param("memberId", member.getId().toString())
+                .content(getContent()))
                 .andExpect(content().string(containsString("SUCCESS")))
                 .andDo(print());
     }
@@ -113,9 +112,9 @@ class FileControllerTest extends ApplicationPeriodTest {
 
         // then
         mockMvc.perform(post("/upload/portfolios")
-                        .contentType("application/json")
-                        .param("memberId", member.getId().toString())
-                        .content(getContent()))
+                .contentType("application/json")
+                .param("memberId", member.getId().toString())
+                .content(getContent()))
                 .andExpect(content().string(containsString("GLOBAL-9")))
                 .andDo(print());
     }
@@ -127,17 +126,17 @@ class FileControllerTest extends ApplicationPeriodTest {
     void invalid_portfolio_content_type() throws Exception {
         // when, then
         mockMvc.perform(post("/upload/portfolios")
-                        .contentType("application/json")
-                        .param("memberId", member.getId().toString())
-                        .content("""
-                                [
-                                    {
-                                        "name": "test1.png",
-                                        "contentType": "image/png",
-                                        "contentLength": 126203
-                                    }
-                                ]
-                                """))
+                .contentType("application/json")
+                .param("memberId", member.getId().toString())
+                .content("""
+                        [
+                            {
+                                "name": "test1.png",
+                                "contentType": "image/png",
+                                "contentLength": 126203
+                            }
+                        ]
+                        """))
                 .andExpect(content().string(containsString(INVALID_EXTENSION.getCode())))
                 .andDo(print());
     }
@@ -158,23 +157,22 @@ class FileControllerTest extends ApplicationPeriodTest {
 
         // when, then
         mockMvc.perform(post("/upload/portfolios")
-                        .contentType("application/json")
-                        .param("memberId", member.getId().toString())
-                        .content("""
-                                [
-                                    {
-                                        "name": "test1.pdf",
-                                        "contentType": "application/pdf",
-                                        "contentLength": 53428800
-                                    },
-                                    {
-                                        "name": "test2.pdf",
-                                        "contentType": "application/pdf",
-                                        "contentLength": 52428800
-                                    }
-                                ]
-                                """)
-                )
+                .contentType("application/json")
+                .param("memberId", member.getId().toString())
+                .content("""
+                        [
+                            {
+                                "name": "test1.pdf",
+                                "contentType": "application/pdf",
+                                "contentLength": 53428800
+                            },
+                            {
+                                "name": "test2.pdf",
+                                "contentType": "application/pdf",
+                                "contentLength": 52428800
+                            }
+                        ]
+                        """))
                 .andExpect(status().isPayloadTooLarge())
                 .andExpect(content().string(containsString(FileErrorCode.EXCEEDED_PORTFOLIO_MAX_SIZE.getCode())))
                 .andDo(print())

--- a/src/test/java/org/ject/support/domain/member/MemberTest.java
+++ b/src/test/java/org/ject/support/domain/member/MemberTest.java
@@ -22,17 +22,6 @@ class MemberTest {
                 .name(name)
                 .phoneNumber(phoneNumber)
                 .email(email)
-                .jobFamily(jobFamily)
-                .role(role)
-                .region(region)
-                .status(MemberStatus.ACTIVE)
-                .build();
-
-        // then
-        assertThat(member.getName()).isEqualTo(name);
-        assertThat(member.getPhoneNumber()).isEqualTo(phoneNumber);
-        assertThat(member.getEmail()).isEqualTo(email);
-        assertThat(member.getJobFamily()).isEqualTo(jobFamily);
         assertThat(member.getRole()).isEqualTo(role);
         assertThat(member.getRegion()).isEqualTo(region);
     }
@@ -62,7 +51,7 @@ class MemberTest {
         assertThat(member.getEmail()).isEqualTo(email);
         assertThat(member.getRole()).isEqualTo(role);
         assertThat(member.getRegion()).isEqualTo(region);
-        assertThat(member.getJobFamily()).isNull();
+
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/member/MemberTest.java
+++ b/src/test/java/org/ject/support/domain/member/MemberTest.java
@@ -22,6 +22,15 @@ class MemberTest {
                 .name(name)
                 .phoneNumber(phoneNumber)
                 .email(email)
+                .role(role)
+                .region(region)
+                .status(MemberStatus.ACTIVE)
+                .build();
+
+        // then
+        assertThat(member.getName()).isEqualTo(name);
+        assertThat(member.getPhoneNumber()).isEqualTo(phoneNumber);
+        assertThat(member.getEmail()).isEqualTo(email);
         assertThat(member.getRole()).isEqualTo(role);
         assertThat(member.getRegion()).isEqualTo(region);
     }

--- a/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
@@ -40,330 +40,344 @@ import static org.ject.support.domain.member.JobFamily.PM;
 @DataJpaTest
 class MemberQueryRepositoryTest {
 
-    @Autowired
-    private MemberRepository memberRepository;
+        @Autowired
+        private MemberRepository memberRepository;
 
-    @Autowired
-    private TeamRepository teamRepository;
+        @Autowired
+        private TeamRepository teamRepository;
 
-    @Autowired
-    private TeamMemberRepository teamMemberRepository;
+        @Autowired
+        private TeamMemberRepository teamMemberRepository;
 
-    @Autowired
-    private ApplyRepository applyRepository;
+        @Autowired
+        private ApplyRepository applyRepository;
 
-    @Autowired
-    private ApplicationFormRepository applicationFormRepository;
+        @Autowired
+        private ApplicationFormRepository applicationFormRepository;
 
-    @Autowired
-    private RecruitRepository recruitRepository;
+        @Autowired
+        private RecruitRepository recruitRepository;
 
-    @Autowired
-    private SemesterRepository semesterRepository;
+        @Autowired
+        private SemesterRepository semesterRepository;
 
-    private Team teamA;
-    private Member pd1, fe1, be1, be2;
-    private TeamMember teamApd1, teamAfe1, teamAbe1, teamAbe2;
+        private Team teamA;
+        private Member pd1, fe1, be1, be2;
+        private TeamMember teamApd1, teamAfe1, teamAbe1, teamAbe2;
 
-    @BeforeEach
-    void setUp() {
-        teamA = createTeam("teamA");
-        teamRepository.save(teamA);
+        @BeforeEach
+        void setUp() {
+                teamA = createTeam("teamA");
+                teamRepository.save(teamA);
 
-        pd1 = createMember("김젝트", "01011112223", "pd1Email", PD);
-        fe1 = createMember("박젝트", "01011112224", "fe1Email", FE);
-        be1 = createMember("최젝트", "01011112225", "be1Email", BE);
-        be2 = createMember("왕젝트", "01011112226", "be2Email", BE);
-        memberRepository.saveAll(List.of(pd1, fe1, be1, be2));
+                pd1 = createMember("김젝트", "01011112223", "pd1Email");
+                fe1 = createMember("박젝트", "01011112224", "fe1Email");
+                be1 = createMember("최젝트", "01011112225", "be1Email");
+                be2 = createMember("왕젝트", "01011112226", "be2Email");
+                memberRepository.saveAll(List.of(pd1, fe1, be1, be2));
 
-        teamApd1 = createTeamMember(teamA, pd1);
-        teamAfe1 = createTeamMember(teamA, fe1);
-        teamAbe1 = createTeamMember(teamA, be1);
-        teamAbe2 = createTeamMember(teamA, be2);
-        teamMemberRepository.saveAll(List.of(teamApd1, teamAfe1, teamAbe1, teamAbe2));
-    }
+                teamApd1 = createTeamMember(teamA, pd1, PD);
+                teamAfe1 = createTeamMember(teamA, fe1, FE);
+                teamAbe1 = createTeamMember(teamA, be1, BE);
+                teamAbe2 = createTeamMember(teamA, be2, BE);
+                teamMemberRepository.saveAll(List.of(teamApd1, teamAfe1, teamAbe1, teamAbe2));
+        }
 
-    @Test
-    void 직군별_팀원_이름_조회() {
-        // when
-        TeamMemberNames teamMemberNames = memberRepository.findMemberNamesByTeamId(teamA.getId());
+        @Test
+        void 직군별_팀원_이름_조회() {
+                // when
+                TeamMemberNames teamMemberNames = memberRepository.findMemberNamesByTeamId(teamA.getId());
 
-        // then
-        assertThat(teamMemberNames.productManagers()).isEmpty();
-        assertThat(teamMemberNames.productDesigners()).hasSize(1);
-        assertThat(teamMemberNames.frontendDevelopers()).hasSize(1);
-        assertThat(teamMemberNames.backendDevelopers()).hasSize(2);
-    }
+                // then
+                assertThat(teamMemberNames.productManagers()).isEmpty();
+                assertThat(teamMemberNames.productDesigners()).hasSize(1);
+                assertThat(teamMemberNames.frontendDevelopers()).hasSize(1);
+                assertThat(teamMemberNames.backendDevelopers()).hasSize(2);
+        }
 
-    @Test
-    void 전달_받은_ID_중_지원서를_제출하지_않은_사용자의_이메일_목록_조회() {
-        // given
-        Member be5 = createMember("이젝트", "01011112231", "be5@test.kr", BE); // 5
-        Member be6 = createMember("박젝트", "01011112232", "be6@test.kr", BE); // 6
-        Member pm7 = createMember("서젝트", "01011112233", "pm7@test.kr", PM); // 7
-        Member fe8 = createMember("양젝트", "01011112234", "fe8@test.kr", FE); // 8
-        Member be9 = createMember("조젝트", "01011112235", "be9@test.kr", BE); // 9
-        Member pd10 = createMember("표젝트", "01011112236", "pd10@test.kr", PD); // 10
-        List<Member> testMembers = memberRepository.saveAll(List.of(be5, be6, pm7, fe8, be9, pd10));
+        @Test
+        void 전달_받은_ID_중_지원서를_제출하지_않은_사용자의_이메일_목록_조회() {
+                // given
+                Member be5 = createMember("이젝트", "01011112231", "be5@test.kr"); // 5
+                Member be6 = createMember("박젝트", "01011112232", "be6@test.kr"); // 6
+                Member pm7 = createMember("서젝트", "01011112233", "pm7@test.kr"); // 7
+                Member fe8 = createMember("양젝트", "01011112234", "fe8@test.kr"); // 8
+                Member be9 = createMember("조젝트", "01011112235", "be9@test.kr"); // 9
+                Member pd10 = createMember("표젝트", "01011112236", "pd10@test.kr"); // 10
+                List<Member> testMembers = memberRepository.saveAll(List.of(be5, be6, pm7, fe8, be9, pd10));
 
-        Semester savedSemester = semesterRepository.save(Semester.builder()
-                .name("1기")
-                .isRecruiting(true)
-                .build());
-        Recruit pmRecruit = createRecruit(savedSemester, PM);
-        Recruit pdRecruit = createRecruit(savedSemester, PD);
-        Recruit feRecruit = createRecruit(savedSemester, FE);
-        Recruit beRecruit = createRecruit(savedSemester, BE);
-        recruitRepository.saveAll(List.of(pmRecruit, pdRecruit, feRecruit, beRecruit));
+                Semester savedSemester = semesterRepository.save(Semester.builder()
+                                .name("1기")
+                                .isRecruiting(true)
+                                .build());
+                Recruit pmRecruit = createRecruit(savedSemester, PM);
+                Recruit pdRecruit = createRecruit(savedSemester, PD);
+                Recruit feRecruit = createRecruit(savedSemester, FE);
+                Recruit beRecruit = createRecruit(savedSemester, BE);
+                recruitRepository.saveAll(List.of(pmRecruit, pdRecruit, feRecruit, beRecruit));
 
-        // 일부 회원만 지원서 제출
-        Apply be5Apply = applyRepository.save(createApply(beRecruit, be5, SUBMITTED));
-        applyRepository.save(createApply(beRecruit, be6, JOINED));
-        Apply pm7Apply = applyRepository.save(createApply(pmRecruit, pm7, SUBMITTED));
-        Apply fe8Apply = applyRepository.save(createApply(feRecruit, fe8, SUBMITTED));
-        applyRepository.save(createApply(beRecruit, be9, JOINED));
-        applyRepository.save(createApply(pdRecruit, pd10, TEMP_SAVED));
+                // 일부 회원만 지원서 제출
+                Apply be5Apply = applyRepository.save(createApply(beRecruit, be5, SUBMITTED));
+                applyRepository.save(createApply(beRecruit, be6, JOINED));
+                Apply pm7Apply = applyRepository.save(createApply(pmRecruit, pm7, SUBMITTED));
+                Apply fe8Apply = applyRepository.save(createApply(feRecruit, fe8, SUBMITTED));
+                applyRepository.save(createApply(beRecruit, be9, JOINED));
+                applyRepository.save(createApply(pdRecruit, pd10, TEMP_SAVED));
 
-        applicationFormRepository.saveAll(List.of(
-                createApplicationForm(be5Apply),
-                createApplicationForm(pm7Apply),
-                createApplicationForm(fe8Apply)));
+                applicationFormRepository.saveAll(List.of(
+                                createApplicationForm(be5Apply),
+                                createApplicationForm(pm7Apply),
+                                createApplicationForm(fe8Apply)));
 
-        List<Long> applicantIds = testMembers.stream().map(Member::getId).toList();
+                List<Long> applicantIds = testMembers.stream().map(Member::getId).toList();
 
-        // when
-        List<String> result = memberRepository.findEmailsByIdsAndNotSubmitted(applicantIds);
+                // when
+                List<String> result = memberRepository.findEmailsByIdsAndNotSubmitted(applicantIds);
 
-        // then
-        assertThat(result).hasSize(3)
-                .containsExactlyInAnyOrder(be6.getEmail(), be9.getEmail(), pd10.getEmail());
-    }
+                // then
+                assertThat(result).hasSize(3)
+                                .containsExactlyInAnyOrder(be6.getEmail(), be9.getEmail(), pd10.getEmail());
+        }
 
-    @Test
-    void 회원_목록_조회_구분_필터만_적용() {
-        // given
-        var semester1 = createSemester("1기");
-        var semester2 = createSemester("2기");
-        semesterRepository.saveAll(List.of(semester1, semester2));
+        @Test
+        void 회원_목록_조회_구분_필터만_적용() {
+                // given
+                var semester1 = createSemester("1기");
+                var semester2 = createSemester("2기");
+                semesterRepository.saveAll(List.of(semester1, semester2));
 
-        var admin1 = createMemberWithSemester("가젝트", "01011111111", "admin1@test.com", BE, Role.ADMIN, semester1.getId());
-        var admin2 = createMemberWithSemester("나젝트", "01011111112", "admin2@test.com", FE, Role.ADMIN, semester1.getId());
-        var semester1Member = createMemberWithSemester("다젝트", "01011111113", "semester1@test.com", BE, Role.SEMESTER, semester1.getId());
-        var apply1 = createMemberWithSemester("라젝트", "01011111114", "apply1@test.com", PD, Role.APPLY, semester2.getId());
+                var admin1 = createMemberWithSemester("가젝트", "01011111111", "admin1@test.com", BE, Role.ADMIN,
+                                semester1.getId());
+                var admin2 = createMemberWithSemester("나젝트", "01011111112", "admin2@test.com", FE, Role.ADMIN,
+                                semester1.getId());
+                var semester1Member = createMemberWithSemester("다젝트", "01011111113", "semester1@test.com", BE,
+                                Role.SEMESTER, semester1.getId());
+                var apply1 = createMemberWithSemester("라젝트", "01011111114", "apply1@test.com", PD, Role.APPLY,
+                                semester2.getId());
 
-        memberRepository.saveAll(List.of(admin1, admin2, semester1Member, apply1));
+                memberRepository.saveAll(List.of(admin1, admin2, semester1Member, apply1));
 
-        var pageable = PageRequest.of(0, 15);
+                var pageable = PageRequest.of(0, 15);
 
-        // when
-        var result = memberRepository.findMembers(Role.ADMIN, null, null, pageable);
+                // when
+                var result = memberRepository.findMembers(Role.ADMIN, null, null, pageable);
 
-        // then
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getTotalElements()).isEqualTo(2);
-        assertThat(result.getContent())
-                .extracting(MemberResponse::name)
-                .containsExactly(admin2.getName(), admin1.getName()); // createdAt desc 순서
-    }
+                // then
+                assertThat(result.getContent()).hasSize(2);
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent())
+                                .extracting(MemberResponse::name)
+                                .containsExactly(admin2.getName(), admin1.getName()); // createdAt desc 순서
+        }
 
-    @Test
-    void 회원_목록_조회_구분과_직군_필터_적용() {
-        // given
-        var semester1 = createSemester("1기");
-        semesterRepository.save(semester1);
+        @Test
+        void 회원_목록_조회_구분과_직군_필터_적용() {
+                // given
+                var semester1 = createSemester("1기");
+                semesterRepository.save(semester1);
 
-        var admin1 = createMemberWithSemester("가젝트", "01011111111", "admin1@test.com", BE, Role.ADMIN, semester1.getId());
-        var admin2 = createMemberWithSemester("나젝트", "01011111112", "admin2@test.com", FE, Role.ADMIN, semester1.getId());
-        var admin3 = createMemberWithSemester("다젝트", "01011111113", "admin3@test.com", BE, Role.ADMIN, semester1.getId());
+                var admin1 = createMemberWithSemester("가젝트", "01011111111", "admin1@test.com", BE, Role.ADMIN,
+                                semester1.getId());
+                var admin2 = createMemberWithSemester("나젝트", "01011111112", "admin2@test.com", FE, Role.ADMIN,
+                                semester1.getId());
+                var admin3 = createMemberWithSemester("다젝트", "01011111113", "admin3@test.com", BE, Role.ADMIN,
+                                semester1.getId());
 
-        memberRepository.saveAll(List.of(admin1, admin2, admin3));
+                memberRepository.saveAll(List.of(admin1, admin2, admin3));
 
-        var pageable = PageRequest.of(0, 15);
+                var pageable = PageRequest.of(0, 15);
 
-        // when
-        var result = memberRepository.findMembers(Role.ADMIN, JobFamily.BE, null, pageable);
+                // when
+                var result = memberRepository.findMembers(Role.ADMIN, JobFamily.BE, null, pageable);
 
-        // then
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getTotalElements()).isEqualTo(2);
-        assertThat(result.getContent())
-                .extracting(MemberResponse::jobFamily)
-                .containsOnly(JobFamily.BE);
-        assertThat(result.getContent())
-                .extracting(MemberResponse::name)
-                .containsExactly(admin3.getName(), admin1.getName()); // createdAt desc 순서
-    }
+                // then
+                assertThat(result.getContent()).hasSize(2);
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent())
+                                .extracting(MemberResponse::jobFamily)
+                                .containsOnly(JobFamily.BE);
+                assertThat(result.getContent())
+                                .extracting(MemberResponse::name)
+                                .containsExactly(admin3.getName(), admin1.getName()); // createdAt desc 순서
+        }
 
-    @Test
-    void 회원_목록_조회_구분과_기수_필터_적용() {
-        // given
-        var semester1 = createSemester("1기");
-        var semester2 = createSemester("2기");
-        semesterRepository.saveAll(List.of(semester1, semester2));
+        @Test
+        void 회원_목록_조회_구분과_기수_필터_적용() {
+                // given
+                var semester1 = createSemester("1기");
+                var semester2 = createSemester("2기");
+                semesterRepository.saveAll(List.of(semester1, semester2));
 
-        var semester1Member1 = createMemberWithSemester("가젝트", "01011111111", "semester1@test.com", BE, Role.SEMESTER, semester1.getId());
-        var semester1Member2 = createMemberWithSemester("나젝트", "01011111112", "semester2@test.com", FE, Role.SEMESTER, semester1.getId());
-        var semester2Member1 = createMemberWithSemester("다젝트", "01011111113", "semester3@test.com", BE, Role.SEMESTER, semester2.getId());
+                var semester1Member1 = createMemberWithSemester("가젝트", "01011111111", "semester1@test.com", BE,
+                                Role.SEMESTER, semester1.getId());
+                var semester1Member2 = createMemberWithSemester("나젝트", "01011111112", "semester2@test.com", FE,
+                                Role.SEMESTER, semester1.getId());
+                var semester2Member1 = createMemberWithSemester("다젝트", "01011111113", "semester3@test.com", BE,
+                                Role.SEMESTER, semester2.getId());
 
-        memberRepository.saveAll(List.of(semester1Member1, semester1Member2, semester2Member1));
+                memberRepository.saveAll(List.of(semester1Member1, semester1Member2, semester2Member1));
 
-        var pageable = PageRequest.of(0, 15);
+                var pageable = PageRequest.of(0, 15);
 
-        // when
-        var result = memberRepository.findMembers(Role.SEMESTER, null, semester2.getId(), pageable);
+                // when
+                var result = memberRepository.findMembers(Role.SEMESTER, null, semester2.getId(), pageable);
 
-        // then
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getTotalElements()).isEqualTo(1);
-        assertThat(result.getContent())
-                .extracting(MemberResponse::semesterName)
-                .containsOnly("2");
-        assertThat(result.getContent())
-                .extracting(MemberResponse::name)
-                .containsExactlyInAnyOrder(semester2Member1.getName());
-    }
+                // then
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getTotalElements()).isEqualTo(1);
+                assertThat(result.getContent())
+                                .extracting(MemberResponse::semesterName)
+                                .containsOnly("2");
+                assertThat(result.getContent())
+                                .extracting(MemberResponse::name)
+                                .containsExactlyInAnyOrder(semester2Member1.getName());
+        }
 
-    @Test
-    void 회원_목록_조회_모든_필터_적용() {
-        // given
-        var semester1 = createSemester("1기");
-        var semester2 = createSemester("2기");
-        semesterRepository.saveAll(List.of(semester1, semester2));
+        @Test
+        void 회원_목록_조회_모든_필터_적용() {
+                // given
+                var semester1 = createSemester("1기");
+                var semester2 = createSemester("2기");
+                semesterRepository.saveAll(List.of(semester1, semester2));
 
-        var semester1BE1 = createMemberWithSemester("가젝트", "01011111111", "semester1be1@test.com", BE, Role.ADMIN, semester1.getId());
-        var semester1BE2 = createMemberWithSemester("나젝트", "01011111112", "semester1be2@test.com", BE, Role.ADMIN, semester1.getId());
-        var semester1FE1 = createMemberWithSemester("다젝트", "01011111113", "semester1fe1@test.com", FE, Role.ADMIN, semester1.getId());
-        var semester2BE1 = createMemberWithSemester("라젝트", "01011111114", "semester2be1@test.com", BE, Role.ADMIN, semester2.getId());
+                var semester1BE1 = createMemberWithSemester("가젝트", "01011111111", "semester1be1@test.com", BE,
+                                Role.ADMIN, semester1.getId());
+                var semester1BE2 = createMemberWithSemester("나젝트", "01011111112", "semester1be2@test.com", BE,
+                                Role.ADMIN, semester1.getId());
+                var semester1FE1 = createMemberWithSemester("다젝트", "01011111113", "semester1fe1@test.com", FE,
+                                Role.ADMIN, semester1.getId());
+                var semester2BE1 = createMemberWithSemester("라젝트", "01011111114", "semester2be1@test.com", BE,
+                                Role.ADMIN, semester2.getId());
 
-        memberRepository.saveAll(List.of(semester1BE1, semester1BE2, semester1FE1, semester2BE1));
+                memberRepository.saveAll(List.of(semester1BE1, semester1BE2, semester1FE1, semester2BE1));
 
-        var pageable = PageRequest.of(0, 10);
+                var pageable = PageRequest.of(0, 10);
 
-        // when
-        var result = memberRepository.findMembers(Role.ADMIN, JobFamily.BE, semester2.getId(), pageable);
+                // when
+                var result = memberRepository.findMembers(Role.ADMIN, JobFamily.BE, semester2.getId(), pageable);
 
-        // then
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getTotalElements()).isEqualTo(1);
-        assertThat(result.getContent())
-                .extracting(MemberResponse::jobFamily)
-                .containsOnly(JobFamily.BE);
-        assertThat(result.getContent())
-                .extracting(MemberResponse::semesterName)
-                .containsOnly("2");
-        assertThat(result.getContent())
-                .extracting(MemberResponse::name)
-                .containsExactly(semester2BE1.getName()); // createdAt desc 순서
-    }
+                // then
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getTotalElements()).isEqualTo(1);
+                assertThat(result.getContent())
+                                .extracting(MemberResponse::jobFamily)
+                                .containsOnly(JobFamily.BE);
+                assertThat(result.getContent())
+                                .extracting(MemberResponse::semesterName)
+                                .containsOnly("2");
+                assertThat(result.getContent())
+                                .extracting(MemberResponse::name)
+                                .containsExactly(semester2BE1.getName()); // createdAt desc 순서
+        }
 
-    @Test
-    void 회원_목록_조회_삭제된_회원_제외() {
-        // given
-        var semester1 = createSemester("1기");
-        semesterRepository.save(semester1);
+        @Test
+        void 회원_목록_조회_삭제된_회원_제외() {
+                // given
+                var semester1 = createSemester("1기");
+                semesterRepository.save(semester1);
 
-        var deletedMember = createMemberWithSemester("삭제회원", "01011111111", "deleted@test.com", BE, Role.SEMESTER, semester1.getId());
+                var deletedMember = createMemberWithSemester("삭제회원", "01011111111", "deleted@test.com", BE,
+                                Role.SEMESTER, semester1.getId());
 
-        memberRepository.save(deletedMember);
+                memberRepository.save(deletedMember);
 
-        // 회원 삭제 (소프트 삭제)
-        memberRepository.delete(deletedMember);
+                // 회원 삭제 (소프트 삭제)
+                memberRepository.delete(deletedMember);
 
-        var pageable = PageRequest.of(0, 10);
+                var pageable = PageRequest.of(0, 10);
 
-        // when
-        var result = memberRepository.findMembers(Role.SEMESTER, null, null, pageable);
+                // when
+                var result = memberRepository.findMembers(Role.SEMESTER, null, null, pageable);
 
-        // then
-        assertThat(result.getContent())
-                .isNotEmpty()
-                .extracting(MemberResponse::name)
-                .doesNotContain(deletedMember.getName());
-    }
+                // then
+                assertThat(result.getContent())
+                                .isNotEmpty()
+                                .extracting(MemberResponse::name)
+                                .doesNotContain(deletedMember.getName());
+        }
 
-    @Test
-    void 회원_목록_조회_결과_없음() {
-        // given
-        var pageable = PageRequest.of(0, 10);
+        @Test
+        void 회원_목록_조회_결과_없음() {
+                // given
+                var pageable = PageRequest.of(0, 10);
 
-        // when - 존재하지 않는 Role로 조회
-        var result = memberRepository.findMembers(Role.ADMIN, null, null, pageable);
+                // when - 존재하지 않는 Role로 조회
+                var result = memberRepository.findMembers(Role.ADMIN, null, null, pageable);
 
-        // then
-        assertThat(result.getContent()).isEmpty();
-        assertThat(result.getTotalElements()).isZero();
-        assertThat(result.getTotalPages()).isZero();
-    }
+                // then
+                assertThat(result.getContent()).isEmpty();
+                assertThat(result.getTotalElements()).isZero();
+                assertThat(result.getTotalPages()).isZero();
+        }
 
-    private Semester createSemester(String name) {
-        return Semester.builder()
-                .name(name)
-                .isRecruiting(true)
-                .build();
-    }
+        private Semester createSemester(String name) {
+                return Semester.builder()
+                                .name(name)
+                                .isRecruiting(true)
+                                .build();
+        }
 
-    private Member createMemberWithSemester(String name, String phoneNumber, String email, JobFamily jobFamily, Role role, Long semesterId) {
-        return Member.builder()
-                .name(name)
-                .phoneNumber(phoneNumber)
-                .email(email)
-                .semesterId(semesterId)
-                .jobFamily(jobFamily)
-                .role(role)
-                .pin("123456")
-                .status(MemberStatus.ACTIVE)
-                .build();
-    }
+        private Member createMemberWithSemester(String name, String phoneNumber, String email, JobFamily jobFamily,
+                        Role role, Long semesterId) {
+                return Member.builder()
+                                .name(name)
+                                .phoneNumber(phoneNumber)
+                                .email(email)
+                                .jobFamily(jobFamily)
+                                .role(role)
+                                .pin("123456")
+                                .status(MemberStatus.ACTIVE)
+                                .build();
+        }
 
-    private Team createTeam(String name) {
-        return Team.builder()
-                .name(name)
-                .semesterId(1L)
-                .build();
-    }
+        private Team createTeam(String name) {
+                return Team.builder()
+                                .name(name)
+                                .semesterId(1L)
+                                .build();
+        }
 
-    private Member createMember(String name, String phoneNumber, String email, JobFamily jobFamily) {
-        return Member.builder()
-                .name(name)
-                .phoneNumber(phoneNumber)
-                .email(email)
-                .semesterId(1L)
-                .jobFamily(jobFamily)
-                .role(Role.SEMESTER)
-                .pin("123456") // PIN 필드 추가
-                .status(MemberStatus.ACTIVE)
-                .isDeleted(false)
-                .build();
-    }
+        private Member createMember(String name, String phoneNumber, String email) {
+                return Member.builder()
+                                .name(name)
+                                .phoneNumber(phoneNumber)
+                                .email(email)
+                                .role(Role.SEMESTER)
+                                .pin("123456") // PIN 필드 추가
+                                .status(MemberStatus.ACTIVE)
+                                .isDeleted(false)
+                                .build();
+        }
 
-    private TeamMember createTeamMember(Team team, Member member) {
-        return TeamMember.builder()
-                .team(team)
-                .member(member)
-                .build();
-    }
+        private TeamMember createTeamMember(Team team, Member member, JobFamily jobFamily) {
+                return TeamMember.builder()
+                                .team(team)
+                                .member(member)
+                                .jobFamily(jobFamily)
+                                .build();
+        }
 
-    private Recruit createRecruit(Semester semester, JobFamily jobFamily) {
-        return Recruit.builder()
-                .semester(semester)
-                .jobFamily(jobFamily)
-                .startDate(LocalDateTime.now().minusDays(1))
-                .endDate(LocalDateTime.now().plusDays(1))
-                .build();
-    }
+        private Recruit createRecruit(Semester semester, JobFamily jobFamily) {
+                return Recruit.builder()
+                                .semester(semester)
+                                .jobFamily(jobFamily)
+                                .startDate(LocalDateTime.now().minusDays(1))
+                                .endDate(LocalDateTime.now().plusDays(1))
+                                .build();
+        }
 
-    private Apply createApply(Recruit recruit, Member member, Apply.Status status) {
-        return applyRepository.save(Apply.builder()
-                .member(member)
-                .recruit(recruit)
-                .status(status)
-                .build());
-    }
+        private Apply createApply(Recruit recruit, Member member, Apply.Status status) {
+                return applyRepository.save(Apply.builder()
+                                .member(member)
+                                .recruit(recruit)
+                                .status(status)
+                                .build());
+        }
 
-    private ApplicationForm createApplicationForm(Apply apply) {
-        return ApplicationForm.builder()
-                .content("content")
-                .apply(apply)
-                .build();
-    }
+        private ApplicationForm createApplicationForm(Apply apply) {
+                return ApplicationForm.builder()
+                                .content("content")
+                                .apply(apply)
+                                .build();
+        }
 }

--- a/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
@@ -176,11 +176,11 @@ class MemberQueryRepositoryTest {
                 var semester1 = createSemester("1기");
                 semesterRepository.save(semester1);
 
-                var admin1 = createMemberWithSemester("가젝트", "01011111111", "admin1@test.com", BE, Role.ADMIN,
+                var admin1 = createMemberWithSemester("가젝트", "01011111111", "admin1@test.com", Role.ADMIN,
                                 semester1.getId());
-                var admin2 = createMemberWithSemester("나젝트", "01011111112", "admin2@test.com", FE, Role.ADMIN,
+                var admin2 = createMemberWithSemester("나젝트", "01011111112", "admin2@test.com", Role.ADMIN,
                                 semester1.getId());
-                var admin3 = createMemberWithSemester("다젝트", "01011111113", "admin3@test.com", BE, Role.ADMIN,
+                var admin3 = createMemberWithSemester("다젝트", "01011111113", "admin3@test.com", Role.ADMIN,
                                 semester1.getId());
 
                 memberRepository.saveAll(List.of(admin1, admin2, admin3));
@@ -317,13 +317,12 @@ class MemberQueryRepositoryTest {
                                 .build();
         }
 
-        private Member createMemberWithSemester(String name, String phoneNumber, String email, JobFamily jobFamily,
+        private Member createMemberWithSemester(String name, String phoneNumber, String email,
                         Role role, Long semesterId) {
                 return Member.builder()
                                 .name(name)
                                 .phoneNumber(phoneNumber)
                                 .email(email)
-                                .jobFamily(jobFamily)
                                 .role(role)
                                 .pin("123456")
                                 .status(MemberStatus.ACTIVE)

--- a/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
@@ -146,16 +146,18 @@ class MemberQueryRepositoryTest {
                 var semester2 = createSemester("2기");
                 semesterRepository.saveAll(List.of(semester1, semester2));
 
-                var admin1 = createMemberWithSemester("가젝트", "01011111111", "admin1@test.com", BE, Role.ADMIN,
-                                semester1.getId());
-                var admin2 = createMemberWithSemester("나젝트", "01011111112", "admin2@test.com", FE, Role.ADMIN,
-                                semester1.getId());
-                var semester1Member = createMemberWithSemester("다젝트", "01011111113", "semester1@test.com", BE,
-                                Role.SEMESTER, semester1.getId());
-                var apply1 = createMemberWithSemester("라젝트", "01011111114", "apply1@test.com", PD, Role.APPLY,
-                                semester2.getId());
-
-                memberRepository.saveAll(List.of(admin1, admin2, semester1Member, apply1));
+                var admin1 = createMemberWithSemesterAndJobFamily("가젝트", "01011111111", "admin1@test.com", BE,
+                                Role.ADMIN,
+                                semester1);
+                var admin2 = createMemberWithSemesterAndJobFamily("나젝트", "01011111112", "admin2@test.com", FE,
+                                Role.ADMIN,
+                                semester1);
+                var semester1Member = createMemberWithSemesterAndJobFamily("다젝트", "01011111113", "semester1@test.com",
+                                BE,
+                                Role.SEMESTER, semester1);
+                var apply1 = createMemberWithSemesterAndJobFamily("라젝트", "01011111114", "apply1@test.com", PD,
+                                Role.APPLY,
+                                semester2);
 
                 var pageable = PageRequest.of(0, 15);
 
@@ -176,14 +178,15 @@ class MemberQueryRepositoryTest {
                 var semester1 = createSemester("1기");
                 semesterRepository.save(semester1);
 
-                var admin1 = createMemberWithSemester("가젝트", "01011111111", "admin1@test.com", Role.ADMIN,
-                                semester1.getId());
-                var admin2 = createMemberWithSemester("나젝트", "01011111112", "admin2@test.com", Role.ADMIN,
-                                semester1.getId());
-                var admin3 = createMemberWithSemester("다젝트", "01011111113", "admin3@test.com", Role.ADMIN,
-                                semester1.getId());
-
-                memberRepository.saveAll(List.of(admin1, admin2, admin3));
+                var admin1 = createMemberWithSemesterAndJobFamily("가젝트", "01011111111", "admin1@test.com", BE,
+                                Role.ADMIN,
+                                semester1);
+                var admin2 = createMemberWithSemesterAndJobFamily("나젝트", "01011111112", "admin2@test.com", FE,
+                                Role.ADMIN,
+                                semester1);
+                var admin3 = createMemberWithSemesterAndJobFamily("다젝트", "01011111113", "admin3@test.com", BE,
+                                Role.ADMIN,
+                                semester1);
 
                 var pageable = PageRequest.of(0, 15);
 
@@ -208,14 +211,15 @@ class MemberQueryRepositoryTest {
                 var semester2 = createSemester("2기");
                 semesterRepository.saveAll(List.of(semester1, semester2));
 
-                var semester1Member1 = createMemberWithSemester("가젝트", "01011111111", "semester1@test.com", BE,
-                                Role.SEMESTER, semester1.getId());
-                var semester1Member2 = createMemberWithSemester("나젝트", "01011111112", "semester2@test.com", FE,
-                                Role.SEMESTER, semester1.getId());
-                var semester2Member1 = createMemberWithSemester("다젝트", "01011111113", "semester3@test.com", BE,
-                                Role.SEMESTER, semester2.getId());
-
-                memberRepository.saveAll(List.of(semester1Member1, semester1Member2, semester2Member1));
+                var semester1Member1 = createMemberWithSemesterAndJobFamily("가젝트", "01011111111", "semester1@test.com",
+                                BE,
+                                Role.SEMESTER, semester1);
+                var semester1Member2 = createMemberWithSemesterAndJobFamily("나젝트", "01011111112", "semester2@test.com",
+                                FE,
+                                Role.SEMESTER, semester1);
+                var semester2Member1 = createMemberWithSemesterAndJobFamily("다젝트", "01011111113", "semester3@test.com",
+                                BE,
+                                Role.SEMESTER, semester2);
 
                 var pageable = PageRequest.of(0, 15);
 
@@ -240,16 +244,18 @@ class MemberQueryRepositoryTest {
                 var semester2 = createSemester("2기");
                 semesterRepository.saveAll(List.of(semester1, semester2));
 
-                var semester1BE1 = createMemberWithSemester("가젝트", "01011111111", "semester1be1@test.com", BE,
-                                Role.ADMIN, semester1.getId());
-                var semester1BE2 = createMemberWithSemester("나젝트", "01011111112", "semester1be2@test.com", BE,
-                                Role.ADMIN, semester1.getId());
-                var semester1FE1 = createMemberWithSemester("다젝트", "01011111113", "semester1fe1@test.com", FE,
-                                Role.ADMIN, semester1.getId());
-                var semester2BE1 = createMemberWithSemester("라젝트", "01011111114", "semester2be1@test.com", BE,
-                                Role.ADMIN, semester2.getId());
-
-                memberRepository.saveAll(List.of(semester1BE1, semester1BE2, semester1FE1, semester2BE1));
+                var semester1BE1 = createMemberWithSemesterAndJobFamily("가젝트", "01011111111", "semester1be1@test.com",
+                                BE,
+                                Role.ADMIN, semester1);
+                var semester1BE2 = createMemberWithSemesterAndJobFamily("나젝트", "01011111112", "semester1be2@test.com",
+                                BE,
+                                Role.ADMIN, semester1);
+                var semester1FE1 = createMemberWithSemesterAndJobFamily("다젝트", "01011111113", "semester1fe1@test.com",
+                                FE,
+                                Role.ADMIN, semester1);
+                var semester2BE1 = createMemberWithSemesterAndJobFamily("라젝트", "01011111114", "semester2be1@test.com",
+                                BE,
+                                Role.ADMIN, semester2);
 
                 var pageable = PageRequest.of(0, 10);
 
@@ -276,10 +282,8 @@ class MemberQueryRepositoryTest {
                 var semester1 = createSemester("1기");
                 semesterRepository.save(semester1);
 
-                var deletedMember = createMemberWithSemester("삭제회원", "01011111111", "deleted@test.com", BE,
-                                Role.SEMESTER, semester1.getId());
-
-                memberRepository.save(deletedMember);
+                var deletedMember = createMemberWithSemesterAndJobFamily("삭제회원", "01011111111", "deleted@test.com", BE,
+                                Role.SEMESTER, semester1);
 
                 // 회원 삭제 (소프트 삭제)
                 memberRepository.delete(deletedMember);
@@ -317,16 +321,26 @@ class MemberQueryRepositoryTest {
                                 .build();
         }
 
-        private Member createMemberWithSemester(String name, String phoneNumber, String email,
-                        Role role, Long semesterId) {
-                return Member.builder()
+        private Member createMemberWithSemesterAndJobFamily(String name, String phoneNumber, String email,
+                        JobFamily jobFamily, Role role, Semester semester) {
+                Member m = memberRepository.save(Member.builder()
                                 .name(name)
                                 .phoneNumber(phoneNumber)
                                 .email(email)
                                 .role(role)
                                 .pin("123456")
                                 .status(MemberStatus.ACTIVE)
-                                .build();
+                                .build());
+                Team t = teamRepository.save(Team.builder()
+                                .name(name + "_team")
+                                .semesterId(semester.getId())
+                                .build());
+                teamMemberRepository.save(TeamMember.builder()
+                                .team(t)
+                                .member(m)
+                                .jobFamily(jobFamily)
+                                .build());
+                return m;
         }
 
         private Team createTeam(String name) {

--- a/src/test/java/org/ject/support/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberRepositoryTest.java
@@ -26,7 +26,7 @@ class MemberRepositoryTest {
         // given
         String email = "test@example.com";
         Role role = Role.ADMIN;
-        Member member = createMember("테스트", "01012345678", email, JobFamily.FE, role);
+        Member member = createMember("테스트", "01012345678", email, role);
         memberRepository.save(member);
 
         // when
@@ -51,13 +51,11 @@ class MemberRepositoryTest {
         assertThat(found).isEmpty();
     }
 
-    private Member createMember(String name, String phoneNumber, String email, JobFamily jobFamily, Role role) {
+    private Member createMember(String name, String phoneNumber, String email, Role role) {
         return Member.builder()
                 .name(name)
                 .phoneNumber(phoneNumber)
                 .email(email)
-                .semesterId(1L)
-                .jobFamily(jobFamily)
                 .role(role)
                 .pin("123456")
                 .status(MemberStatus.ACTIVE)

--- a/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
@@ -35,83 +35,86 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @IntegrationTest
 @AutoConfigureMockMvc
-@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
+@TestPropertySource(properties = { "spring.data.redis.repositories.enabled=false" })
 class QuestionControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
+        @Autowired
+        MockMvc mockMvc;
 
-    @Autowired
-    RecruitRepository recruitRepository;
+        @Autowired
+        RecruitRepository recruitRepository;
 
-    @Autowired
-    QuestionRepository questionRepository;
+        @Autowired
+        QuestionRepository questionRepository;
 
-    @Autowired
-    MemberRepository memberRepository;
+        @Autowired
+        MemberRepository memberRepository;
 
-    @Autowired
-    SemesterRepository semesterRepository;
+        @Autowired
+        SemesterRepository semesterRepository;
 
-    @Autowired
-    RedisTemplate<String, String> redisTemplate;
+        @Autowired
+        RedisTemplate<String, String> redisTemplate;
 
-    Member member;
+        Member member;
 
-    @BeforeEach
-    void setUp() {
-        List<Question> questions = List.of(
-                Question.builder().sequence(1).inputType(TEXT).isRequired(true).title("title1").label("label").selectOptions(List.of("a", "b", "c")).build(),
-                Question.builder().sequence(2).inputType(TEXT).isRequired(true).title("title2").label("label").build(),
-                Question.builder().sequence(3).inputType(TEXT).isRequired(true).title("title3").label("label").build(),
-                Question.builder().sequence(4).inputType(TEXT).isRequired(true).title("title4").label("label").build(),
-                Question.builder().sequence(5).inputType(TEXT).isRequired(true).title("title5").label("label").build()
-        );
+        @BeforeEach
+        void setUp() {
+                List<Question> questions = List.of(
+                                Question.builder().sequence(1).inputType(TEXT).isRequired(true).title("title1")
+                                                .label("label").selectOptions(List.of("a", "b", "c")).build(),
+                                Question.builder().sequence(2).inputType(TEXT).isRequired(true).title("title2")
+                                                .label("label").build(),
+                                Question.builder().sequence(3).inputType(TEXT).isRequired(true).title("title3")
+                                                .label("label").build(),
+                                Question.builder().sequence(4).inputType(TEXT).isRequired(true).title("title4")
+                                                .label("label").build(),
+                                Question.builder().sequence(5).inputType(TEXT).isRequired(true).title("title5")
+                                                .label("label").build());
 
-        Semester savedSemester = semesterRepository.save(Semester.builder()
-                .name("1기")
-                .isRecruiting(true)
-                .build());
+                Semester savedSemester = semesterRepository.save(Semester.builder()
+                                .name("1기")
+                                .isRecruiting(true)
+                                .build());
 
-        Recruit recruit = Recruit.builder()
-                .startDate(LocalDateTime.now().minusDays(1))
-                .endDate(LocalDateTime.now().plusDays(1))
-                .semester(savedSemester)
-                .jobFamily(JobFamily.BE)
-                .build();
+                Recruit recruit = Recruit.builder()
+                                .startDate(LocalDateTime.now().minusDays(1))
+                                .endDate(LocalDateTime.now().plusDays(1))
+                                .semester(savedSemester)
+                                .jobFamily(JobFamily.BE)
+                                .build();
 
-        for (Question question : questions) {
-            recruit.addQuestion(question);
+                for (Question question : questions) {
+                        recruit.addQuestion(question);
+                }
+
+                recruitRepository.save(recruit);
+
+                member = Member.builder()
+                                .email("test32@gmail.com")
+
+                                .name("김젝트")
+                                .role(Role.SEMESTER)
+                                .phoneNumber("01012345678")
+                                .pin("123456") // PIN 필드 추가
+                                .status(MemberStatus.ACTIVE)
+                                .build();
+                memberRepository.save(member);
         }
 
-        recruitRepository.save(recruit);
+        @Test
+        @DisplayName("지원서 문항 조회 시 redis에 캐싱")
+        @AuthenticatedUser
+        void find_questions_cache() throws Exception {
+                // when
+                mockMvc.perform(get("/apply/questions")
+                                .param("jobFamily", "BE"))
+                                .andExpect(status().isOk())
+                                .andExpect(content().string(containsString("SUCCESS")))
+                                .andDo(print());
 
-        member = Member.builder()
-                .email("test32@gmail.com")
-                .semesterId(1L)
-                .jobFamily(JobFamily.BE)
-                .name("김젝트")
-                .role(Role.SEMESTER)
-                .phoneNumber("01012345678")
-                .pin("123456") // PIN 필드 추가
-                .status(MemberStatus.ACTIVE)
-                .build();
-        memberRepository.save(member);
-    }
-
-    @Test
-    @DisplayName("지원서 문항 조회 시 redis에 캐싱")
-    @AuthenticatedUser
-    void find_questions_cache() throws Exception {
-        // when
-        mockMvc.perform(get("/apply/questions")
-                        .param("jobFamily", "BE"))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("SUCCESS")))
-                .andDo(print());
-
-        // then
-        Long countExistingKeys = redisTemplate.countExistingKeys(List.of("cache::question::BE"));
-        Assertions.assertThat(countExistingKeys).isEqualTo(1);
-    }
+                // then
+                Long countExistingKeys = redisTemplate.countExistingKeys(List.of("cache::question::BE"));
+                Assertions.assertThat(countExistingKeys).isEqualTo(1);
+        }
 }

--- a/src/test/java/org/ject/support/domain/recruit/repository/ApplicationFormRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/repository/ApplicationFormRepositoryTest.java
@@ -26,65 +26,63 @@ import java.util.List;
 @DataJpaTest
 class ApplicationFormRepositoryTest {
 
-    @Autowired
-    RecruitRepository recruitRepository;
+        @Autowired
+        RecruitRepository recruitRepository;
 
-    @Autowired
-    MemberRepository memberRepository;
+        @Autowired
+        MemberRepository memberRepository;
 
-    @Autowired
-    ApplyRepository applyRepository;
+        @Autowired
+        ApplyRepository applyRepository;
 
-    @Autowired
-    ApplicationFormRepository applicationFormRepository;
+        @Autowired
+        ApplicationFormRepository applicationFormRepository;
 
-    @Autowired
-    SemesterRepository semesterRepository;
+        @Autowired
+        SemesterRepository semesterRepository;
 
-    @Test
-    @DisplayName("지원서 제출 여부 확인")
-    void check_apply_submit() {
-        // given
-        Semester savedSemester = semesterRepository.save(Semester.builder()
-                .name("1기")
-                .isRecruiting(true)
-                .build());
+        @Test
+        @DisplayName("지원서 제출 여부 확인")
+        void check_apply_submit() {
+                // given
+                Semester savedSemester = semesterRepository.save(Semester.builder()
+                                .name("1기")
+                                .isRecruiting(true)
+                                .build());
 
-        Recruit recruit = recruitRepository.save(Recruit.builder()
-                .startDate(LocalDateTime.now().minusDays(1))
-                .endDate(LocalDateTime.now().plusDays(1))
-                .semester(savedSemester)
-                .jobFamily(JobFamily.BE)
-                .build());
+                Recruit recruit = recruitRepository.save(Recruit.builder()
+                                .startDate(LocalDateTime.now().minusDays(1))
+                                .endDate(LocalDateTime.now().plusDays(1))
+                                .semester(savedSemester)
+                                .jobFamily(JobFamily.BE)
+                                .build());
 
-        Member member = memberRepository.save(Member.builder()
-                .email("test32@gmail.com")
-                .semesterId(savedSemester.getId())
-                .jobFamily(JobFamily.BE)
-                .name("김젝트")
-                .role(Role.SEMESTER)
-                .phoneNumber("01012345678")
-                .pin("123456") // PIN 필드 추가
-                .status(MemberStatus.ACTIVE)
-                .build());
+                Member member = memberRepository.save(Member.builder()
+                                .email("test32@gmail.com")
 
-        Apply apply = applyRepository.save(Apply.builder()
-                .member(member)
-                .recruit(recruit)
-                .status(Apply.Status.JOINED)
-                .build());
+                                .name("김젝트")
+                                .role(Role.SEMESTER)
+                                .phoneNumber("01012345678")
+                                .pin("123456") // PIN 필드 추가
+                                .status(MemberStatus.ACTIVE)
+                                .build());
 
-        applicationFormRepository.save(ApplicationForm.builder().
-                content("content")
-                .apply(apply)
-                .portfolios(List.of())
-                .build());
+                Apply apply = applyRepository.save(Apply.builder()
+                                .member(member)
+                                .recruit(recruit)
+                                .status(Apply.Status.JOINED)
+                                .build());
 
-        // when
-        boolean result = applicationFormRepository.existsByMemberId(member.getId(), LocalDateTime.now());
+                applicationFormRepository.save(ApplicationForm.builder().content("content")
+                                .apply(apply)
+                                .portfolios(List.of())
+                                .build());
 
-        // then
-        Assertions.assertThat(result).isTrue();
-    }
+                // when
+                boolean result = applicationFormRepository.existsByMemberId(member.getId(), LocalDateTime.now());
+
+                // then
+                Assertions.assertThat(result).isTrue();
+        }
 
 }


### PR DESCRIPTION


## #️⃣연관된 이슈

close #427

## 📝 작업 내용

Member 엔티티가 단일 기수(`semesterId`)와 단일 직군(`jobFamily`)만을 가지던 1:1 구조를 개선하여, 한 회원이 여러 기수와 여러 직군으로 활동할 수 있도록 리팩토링했습니다.

**주요 변경 사항:**

1.  **Member 엔티티 수정**
    - `semesterId`, `jobFamily` 필드 제거
    - 해당 정보는 이제 `TeamMember`와 `Team`을 통해 관리됩니다.

2.  **TeamMember 엔티티 확장**
    - `jobFamily` 필드 추가: 각 팀(기수) 활동 시의 직군을 저장합니다.

3.  **Service & Repository 로직 변경**
    - `MemberService`, `MemberManagementService`: 회원 등록 및 조회 시 `TeamMember`를 생성하고 조회하도록 로직을 전면 수정했습니다.
    - `MemberQueryRepositoryImpl`: `Member` 필드가 아닌 `TeamMember` 조인을 통해 기수 및 직군별 필터링을 수행합니다.
    - **미배정 팀 활용**: 기수에는 속하지만 특정 팀에 배정되지 않은 상태를 위해 '미배정' 팀을 활용하는 로직을 추가했습니다.

4.  **DTO 수정**
    - `MemberDetailResponse`, `Apply` 관련 DTO 등에서 `member.getJobFamily()`를 직접 호출하던 코드를 `recruit.getJobFamily()` 또는 `teamMember` 정보로 대체하여 올바른 컨텍스트의 데이터를 반환하도록 수정했습니다.

5.  **데이터 마이그레이션 (V18)**
    - 기존 `Member`의 기수/직군 정보를 `TeamMember`로 이관하고 컬럼을 삭제하는 Flyway 스크립트(`V18__migrate_member_semester_jobfamily.sql`)를 포함했습니다.

## 🙏 리뷰 요구사항 (선택)

- **데이터 마이그레이션**: `V18` 스크립트가 기존 데이터를 손실 없이 잘 이관하는지 중점적으로 확인 부탁드립니다.
- **DTO 매핑**: `jobFamily` 정보를 가져오는 경로가 `Recruit`나 `TeamMember`로 변경되었으므로, 의도한 데이터(지원 시점의 직군 vs 활동 시점의 직군)가 정확히 전달되는지 확인이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 팀-팀원 연결 흐름을 도입해 회원의 소속·직무 관리를 팀 단위로 통합했습니다.
* **데이터베이스**
  * 마이그레이션으로 팀-팀원 테이블에 직무 컬럼을 추가하고 회원 테이블의 관련 컬럼을 제거하며 기존 데이터가 이전됩니다.
* **변경 사항**
  * 회원 등록·수정, 조회 응답 및 내부 조회 로직이 팀 기반 직무 참조로 조정되었습니다. 테스트와 DTO 매핑도 이에 맞춰 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->