### PR TITLE
feat: Admin 패키지 TeamMember 기반 jobFamily 리팩토링

### DIFF
--- a/.github/workflows/continuous-intergration.yml
+++ b/.github/workflows/continuous-intergration.yml
@@ -17,8 +17,25 @@ jobs:
   check-application:
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        image: redis:8.0-M03-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Verify Docker
+        run: docker --version
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/continuous-intergration.yml
+++ b/.github/workflows/continuous-intergration.yml
@@ -17,25 +17,8 @@ jobs:
   check-application:
     runs-on: ubuntu-latest
 
-    services:
-      redis:
-        image: redis:8.0-M03-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Docker
-        uses: docker/setup-buildx-action@v3
-
-      - name: Verify Docker
-        run: docker --version
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/src/main/java/org/ject/support/domain/admin/dto/MemberDetailResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/MemberDetailResponse.java
@@ -9,27 +9,29 @@ import org.ject.support.domain.recruit.domain.Semester;
 
 @Builder
 public record MemberDetailResponse(
-                Long id,
-                Role role,
-                String name,
-                String phoneNumber,
-                String email,
-                JobFamily jobFamily,
-                Region region,
-                String semesterName) {
-        public static MemberDetailResponse toResponse(
-                        Member member,
-                        Semester semester,
-                        JobFamily jobFamily) {
-                return MemberDetailResponse.builder()
-                                .id(member.getId())
-                                .role(member.getRole())
-                                .name(member.getName())
-                                .phoneNumber(member.getPhoneNumber())
-                                .email(member.getEmail())
-                                .jobFamily(jobFamily)
-                                .region(member.getRegion())
-                                .semesterName(semester.getName().replaceAll("\\D", ""))
-                                .build();
-        }
+        Long id,
+        Role role,
+        String name,
+        String phoneNumber,
+        String email,
+        JobFamily jobFamily,
+        Region region,
+        String semesterName
+) {
+    public static MemberDetailResponse toResponse(
+            Member member,
+            Semester semester,
+            JobFamily jobFamily
+    ) {
+        return MemberDetailResponse.builder()
+                .id(member.getId())
+                .role(member.getRole())
+                .name(member.getName())
+                .phoneNumber(member.getPhoneNumber())
+                .email(member.getEmail())
+                .jobFamily(jobFamily)
+                .region(member.getRegion())
+                .semesterName(semester.getName().replaceAll("\\D", ""))
+                .build();
+    }
 }

--- a/src/main/java/org/ject/support/domain/admin/dto/MemberDetailResponse.java
+++ b/src/main/java/org/ject/support/domain/admin/dto/MemberDetailResponse.java
@@ -9,28 +9,27 @@ import org.ject.support.domain.recruit.domain.Semester;
 
 @Builder
 public record MemberDetailResponse(
-        Long id,
-        Role role,
-        String name,
-        String phoneNumber,
-        String email,
-        JobFamily jobFamily,
-        Region region,
-        String semesterName
-) {
-    public static MemberDetailResponse toResponse(
-            Member member,
-            Semester semester
-    ) {
-        return MemberDetailResponse.builder()
-                .id(member.getId())
-                .role(member.getRole())
-                .name(member.getName())
-                .phoneNumber(member.getPhoneNumber())
-                .email(member.getEmail())
-                .jobFamily(member.getJobFamily())
-                .region(member.getRegion())
-                .semesterName(semester.getName().replaceAll("\\D", ""))
-                .build();
-    }
+                Long id,
+                Role role,
+                String name,
+                String phoneNumber,
+                String email,
+                JobFamily jobFamily,
+                Region region,
+                String semesterName) {
+        public static MemberDetailResponse toResponse(
+                        Member member,
+                        Semester semester,
+                        JobFamily jobFamily) {
+                return MemberDetailResponse.builder()
+                                .id(member.getId())
+                                .role(member.getRole())
+                                .name(member.getName())
+                                .phoneNumber(member.getPhoneNumber())
+                                .email(member.getEmail())
+                                .jobFamily(jobFamily)
+                                .region(member.getRegion())
+                                .semesterName(semester.getName().replaceAll("\\D", ""))
+                                .build();
+        }
 }

--- a/src/main/java/org/ject/support/domain/admin/service/MemberManagementService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/MemberManagementService.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.admin.service;
 
 import static org.ject.support.domain.member.exception.MemberErrorCode.ALREADY_EXIST_MEMBER;
 
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.member.JobFamily;
@@ -13,9 +14,13 @@ import org.ject.support.domain.admin.dto.MemberResponse;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.entity.MemberEditor;
 import org.ject.support.domain.member.entity.MemberEditor.MemberEditorBuilder;
+import org.ject.support.domain.member.entity.Team;
+import org.ject.support.domain.member.entity.TeamMember;
 import org.ject.support.domain.member.exception.MemberErrorCode;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.member.repository.TeamMemberRepository;
+import org.ject.support.domain.member.repository.TeamRepository;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
 import org.springframework.data.domain.Page;
@@ -29,14 +34,15 @@ public class MemberManagementService {
 
     private final MemberRepository memberRepository;
     private final SemesterRepository semesterRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
     @Transactional(readOnly = true)
     public Page<MemberResponse> findMembers(
             final Role role,
             final JobFamily jobFamily,
             final Long semesterId,
-            final Pageable pageable
-    ) {
+            final Pageable pageable) {
         return memberRepository.findMembers(role, jobFamily, semesterId, pageable);
     }
 
@@ -44,10 +50,15 @@ public class MemberManagementService {
     public MemberDetailResponse findMemberDetail(final Long memberId) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
-        final Long semesterId = member.getSemesterId();
-        final Semester semester = semesterRepository.findById(semesterId)
+
+        final TeamMember latestTeamMember = teamMemberRepository.findByMemberId(memberId).stream()
+                .max(Comparator.comparing(tm -> tm.getTeam().getSemesterId()))
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER));
-        return MemberDetailResponse.toResponse(member, semester);
+
+        final Semester semester = semesterRepository.findById(latestTeamMember.getTeam().getSemesterId())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER));
+
+        return MemberDetailResponse.toResponse(member, semester, latestTeamMember.getJobFamily());
     }
 
     @Transactional
@@ -61,11 +72,20 @@ public class MemberManagementService {
 
         final Member member = request.toEntity(semester);
         memberRepository.save(member);
+
+        final Team unassignedTeam = findOrCreateUnassignedTeam(semester.getId());
+
+        final TeamMember teamMember = TeamMember.builder()
+                .member(member)
+                .team(unassignedTeam)
+                .jobFamily(request.jobFamily())
+                .build();
+        teamMemberRepository.save(teamMember);
     }
 
     @Transactional
     public void editMember(final Long memberId,
-                           final MemberEditRequest request) {
+            final MemberEditRequest request) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
 
@@ -73,10 +93,36 @@ public class MemberManagementService {
 
         MemberEditorBuilder editorBuilder = member.toEditor();
 
+        // 대상 학기 결정
+        Long targetSemesterId = member.getSemesterId();
         if (request.semesterName() != null) {
             final Semester semester = semesterRepository.findByName(request.semesterName())
                     .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER));
+            targetSemesterId = semester.getId();
             editorBuilder.semesterId(semester.getId());
+        }
+
+        // TeamMember 관리 (semester 또는 jobFamily 변경 시)
+        if (request.semesterName() != null || request.jobFamily() != null) {
+            final Long semesterId = targetSemesterId;
+            teamMemberRepository.findByMemberIdAndTeamSemesterId(memberId, semesterId)
+                    .ifPresentOrElse(
+                            tm -> {
+                                if (request.jobFamily() != null) {
+                                    tm.updateJobFamily(request.jobFamily());
+                                }
+                            },
+                            () -> {
+                                final Team unassignedTeam = findOrCreateUnassignedTeam(semesterId);
+                                final TeamMember newTeamMember = TeamMember.builder()
+                                        .member(member)
+                                        .team(unassignedTeam)
+                                        .jobFamily(request.jobFamily() != null
+                                                ? request.jobFamily()
+                                                : member.getJobFamily())
+                                        .build();
+                                teamMemberRepository.save(newTeamMember);
+                            });
         }
 
         final MemberEditor editor = editorBuilder
@@ -121,5 +167,13 @@ public class MemberManagementService {
         if (memberRepository.existsByEmail(newEmail)) {
             throw new MemberException(MemberErrorCode.DUPLICATE_EMAIL);
         }
+    }
+
+    private Team findOrCreateUnassignedTeam(final Long semesterId) {
+        return teamRepository.findByNameAndSemesterId("미배정", semesterId)
+                .orElseGet(() -> teamRepository.save(Team.builder()
+                        .name("미배정")
+                        .semesterId(semesterId)
+                        .build()));
     }
 }

--- a/src/main/java/org/ject/support/domain/admin/service/MemberManagementService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/MemberManagementService.java
@@ -93,7 +93,7 @@ public class MemberManagementService {
 
         MemberEditorBuilder editorBuilder = member.toEditor();
 
-        // 대상 학기 결정
+        // 기수 설정
         Long targetSemesterId = member.getSemesterId();
         if (request.semesterName() != null) {
             final Semester semester = semesterRepository.findByName(request.semesterName())
@@ -102,7 +102,7 @@ public class MemberManagementService {
             editorBuilder.semesterId(semester.getId());
         }
 
-        // TeamMember 관리 (semester 또는 jobFamily 변경 시)
+        // semester 또는 jobFamily 변경 시
         if (request.semesterName() != null || request.jobFamily() != null) {
             final Long semesterId = targetSemesterId;
             teamMemberRepository.findByMemberIdAndTeamSemesterId(memberId, semesterId)

--- a/src/main/java/org/ject/support/domain/member/entity/TeamMember.java
+++ b/src/main/java/org/ject/support/domain/member/entity/TeamMember.java
@@ -1,6 +1,9 @@
 package org.ject.support.domain.member.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -10,10 +13,13 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;
+import org.ject.support.domain.member.JobFamily;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,4 +36,12 @@ public class TeamMember extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)
     private Team team;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(45)")
+    private JobFamily jobFamily;
+
+    public void updateJobFamily(JobFamily jobFamily) {
+        this.jobFamily = jobFamily;
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
@@ -33,99 +33,100 @@ import static org.ject.support.domain.recruit.domain.QSemester.semester;
 @RequiredArgsConstructor
 public class MemberQueryRepositoryImpl implements MemberQueryRepository {
 
-        private final JPQLQueryFactory queryFactory;
+    private final JPQLQueryFactory queryFactory;
 
-        @Override
-        public TeamMemberNames findMemberNamesByTeamId(Long teamId) {
-                return queryFactory.selectFrom(member)
-                                .join(member.teamMembers, teamMember)
-                                .where(teamMember.team.id.eq(teamId),
-                                                member.isDeleted.eq(false))
-                                .transform(GroupBy.groupBy(teamMember.team.id).as(new QTeamMemberNames(
-                                                GroupBy.list(new CaseBuilder()
-                                                                .when(teamMember.jobFamily.eq(PM))
-                                                                .then(member.name)
-                                                                .otherwise((String) null)),
-                                                GroupBy.list(new CaseBuilder()
-                                                                .when(teamMember.jobFamily.eq(PD))
-                                                                .then(member.name)
-                                                                .otherwise((String) null)),
-                                                GroupBy.list(new CaseBuilder()
-                                                                .when(teamMember.jobFamily.eq(FE))
-                                                                .then(member.name)
-                                                                .otherwise((String) null)),
-                                                GroupBy.list(new CaseBuilder()
-                                                                .when(teamMember.jobFamily.eq(BE))
-                                                                .then(member.name)
-                                                                .otherwise((String) null)))))
-                                .get(teamId);
-        }
+    @Override
+    public TeamMemberNames findMemberNamesByTeamId(Long teamId) {
+        return queryFactory.selectFrom(member)
+                .join(member.teamMembers, teamMember)
+                .where(teamMember.team.id.eq(teamId),
+                        member.isDeleted.eq(false))
+                .transform(GroupBy.groupBy(teamMember.team.id).as(new QTeamMemberNames(
+                        GroupBy.list(new CaseBuilder()
+                                .when(teamMember.jobFamily.eq(PM))
+                                .then(member.name)
+                                .otherwise((String) null)),
+                        GroupBy.list(new CaseBuilder()
+                                .when(teamMember.jobFamily.eq(PD))
+                                .then(member.name)
+                                .otherwise((String) null)),
+                        GroupBy.list(new CaseBuilder()
+                                .when(teamMember.jobFamily.eq(FE))
+                                .then(member.name)
+                                .otherwise((String) null)),
+                        GroupBy.list(new CaseBuilder()
+                                .when(teamMember.jobFamily.eq(BE))
+                                .then(member.name)
+                                .otherwise((String) null))
+                ))).get(teamId);
+    }
 
-        @Override
-        public List<String> findEmailsByIdsAndNotSubmitted(List<Long> applicantIds) {
-                return queryFactory.select(member.email)
-                                .from(member)
-                                .join(apply)
-                                .on(member.id.eq(apply.member.id))
-                                .where(member.id.in(applicantIds),
-                                                member.isDeleted.eq(false),
-                                                apply.status.eq(SUBMITTED).not())
-                                .fetch();
-        }
+    @Override
+    public List<String> findEmailsByIdsAndNotSubmitted(List<Long> applicantIds) {
+        return queryFactory.select(member.email)
+                .from(member)
+                .join(apply)
+                .on(member.id.eq(apply.member.id))
+                .where(member.id.in(applicantIds),
+                        member.isDeleted.eq(false),
+                        apply.status.eq(SUBMITTED).not())
+                .fetch();
+    }
 
-        @Override
-        public Page<MemberResponse> findMembers(
-                        final Role role,
-                        final JobFamily jobFamily,
-                        final Long semesterId,
-                        final Pageable pageable) {
-                final List<MemberResponse> content = queryFactory
-                                .select(new QMemberResponse(
-                                                member.id,
-                                                member.name,
-                                                member.phoneNumber,
-                                                member.email,
-                                                teamMember.jobFamily,
-                                                semester.name.as("semesterName")))
-                                .from(member)
-                                .leftJoin(member.teamMembers, teamMember)
-                                .leftJoin(semester)
-                                .on(semester.id.eq(teamMember.team.semesterId))
-                                .where(
-                                                member.role.eq(role),
-                                                eqJobFamily(jobFamily),
-                                                eqSemesterId(semesterId),
-                                                member.isDeleted.eq(false))
-                                .orderBy(member.createdAt.desc())
-                                .offset(pageable.getOffset())
-                                .limit(pageable.getPageSize())
-                                .fetch();
+    @Override
+    public Page<MemberResponse> findMembers(
+            final Role role,
+            final JobFamily jobFamily,
+            final Long semesterId,
+            final Pageable pageable
+    ) {
+        final List<MemberResponse> content = queryFactory
+                .select(new QMemberResponse(
+                        member.id,
+                        member.name,
+                        member.phoneNumber,
+                        member.email,
+                        teamMember.jobFamily,
+                        semester.name.as("semesterName")))
+                .from(member)
+                .leftJoin(member.teamMembers, teamMember)
+                .leftJoin(semester)
+                .on(semester.id.eq(teamMember.team.semesterId))
+                .where(
+                        member.role.eq(role),
+                        eqJobFamily(jobFamily),
+                        eqSemesterId(semesterId),
+                        member.isDeleted.eq(false))
+                .orderBy(member.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
 
-                final Long total = queryFactory
-                                .select(member.count())
-                                .from(member)
-                                .leftJoin(member.teamMembers, teamMember)
-                                .leftJoin(semester)
-                                .on(semester.id.eq(teamMember.team.semesterId))
-                                .where(
-                                                member.role.eq(role),
-                                                eqJobFamily(jobFamily),
-                                                eqSemesterId(semesterId),
-                                                member.isDeleted.eq(false))
-                                .fetchOne();
+        final Long total = queryFactory
+                .select(member.count())
+                .from(member)
+                .leftJoin(member.teamMembers, teamMember)
+                .leftJoin(semester)
+                .on(semester.id.eq(teamMember.team.semesterId))
+                .where(
+                        member.role.eq(role),
+                        eqJobFamily(jobFamily),
+                        eqSemesterId(semesterId),
+                        member.isDeleted.eq(false))
+                .fetchOne();
 
-                return PageResponse.from(content, pageable, total);
-        }
+        return PageResponse.from(content, pageable, total);
+    }
 
-        private BooleanExpression eqJobFamily(final JobFamily jobFamily) {
-                return Optional.ofNullable(jobFamily)
-                                .map(teamMember.jobFamily::eq)
-                                .orElse(null);
-        }
+    private BooleanExpression eqJobFamily(final JobFamily jobFamily) {
+        return Optional.ofNullable(jobFamily)
+                .map(teamMember.jobFamily::eq)
+                .orElse(null);
+    }
 
-        private BooleanExpression eqSemesterId(final Long semesterId) {
-                return Optional.ofNullable(semesterId)
-                                .map(semester.id::eq)
-                                .orElse(null);
-        }
+    private BooleanExpression eqSemesterId(final Long semesterId) {
+        return Optional.ofNullable(semesterId)
+                .map(semester.id::eq)
+                .orElse(null);
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
@@ -33,99 +33,99 @@ import static org.ject.support.domain.recruit.domain.QSemester.semester;
 @RequiredArgsConstructor
 public class MemberQueryRepositoryImpl implements MemberQueryRepository {
 
-    private final JPQLQueryFactory queryFactory;
+        private final JPQLQueryFactory queryFactory;
 
-    @Override
-    public TeamMemberNames findMemberNamesByTeamId(Long teamId) {
-        return queryFactory.selectFrom(member)
-                .join(member.teamMembers, teamMember)
-                .where(teamMember.team.id.eq(teamId),
-                        member.isDeleted.eq(false))
-                .transform(GroupBy.groupBy(teamMember.team.id).as(new QTeamMemberNames(
-                        GroupBy.list(new CaseBuilder()
-                                .when(member.jobFamily.eq(PM))
-                                .then(member.name)
-                                .otherwise((String) null)),
-                        GroupBy.list(new CaseBuilder()
-                                .when(member.jobFamily.eq(PD))
-                                .then(member.name)
-                                .otherwise((String) null)),
-                        GroupBy.list(new CaseBuilder()
-                                .when(member.jobFamily.eq(FE))
-                                .then(member.name)
-                                .otherwise((String) null)),
-                        GroupBy.list(new CaseBuilder()
-                                .when(member.jobFamily.eq(BE))
-                                .then(member.name)
-                                .otherwise((String) null))
-                ))).get(teamId);
-    }
+        @Override
+        public TeamMemberNames findMemberNamesByTeamId(Long teamId) {
+                return queryFactory.selectFrom(member)
+                                .join(member.teamMembers, teamMember)
+                                .where(teamMember.team.id.eq(teamId),
+                                                member.isDeleted.eq(false))
+                                .transform(GroupBy.groupBy(teamMember.team.id).as(new QTeamMemberNames(
+                                                GroupBy.list(new CaseBuilder()
+                                                                .when(member.jobFamily.eq(PM))
+                                                                .then(member.name)
+                                                                .otherwise((String) null)),
+                                                GroupBy.list(new CaseBuilder()
+                                                                .when(member.jobFamily.eq(PD))
+                                                                .then(member.name)
+                                                                .otherwise((String) null)),
+                                                GroupBy.list(new CaseBuilder()
+                                                                .when(member.jobFamily.eq(FE))
+                                                                .then(member.name)
+                                                                .otherwise((String) null)),
+                                                GroupBy.list(new CaseBuilder()
+                                                                .when(member.jobFamily.eq(BE))
+                                                                .then(member.name)
+                                                                .otherwise((String) null)))))
+                                .get(teamId);
+        }
 
-    @Override
-    public List<String> findEmailsByIdsAndNotSubmitted(List<Long> applicantIds) {
-        return queryFactory.select(member.email)
-                .from(member)
-                .join(apply)
-                .on(member.id.eq(apply.member.id))
-                .where(member.id.in(applicantIds),
-                        member.isDeleted.eq(false),
-                        apply.status.eq(SUBMITTED).not())
-                .fetch();
-    }
+        @Override
+        public List<String> findEmailsByIdsAndNotSubmitted(List<Long> applicantIds) {
+                return queryFactory.select(member.email)
+                                .from(member)
+                                .join(apply)
+                                .on(member.id.eq(apply.member.id))
+                                .where(member.id.in(applicantIds),
+                                                member.isDeleted.eq(false),
+                                                apply.status.eq(SUBMITTED).not())
+                                .fetch();
+        }
 
-    @Override
-    public Page<MemberResponse> findMembers(
-            final Role role,
-            final JobFamily jobFamily,
-            final Long semesterId,
-            final Pageable pageable
-    ) {
-        final List<MemberResponse> content = queryFactory
-                .select(new QMemberResponse(
-                        member.id,
-                        member.name,
-                        member.phoneNumber,
-                        member.email,
-                        member.jobFamily,
-                        semester.name.as("semesterName")))
-                .from(member)
-                .leftJoin(semester)
-                .on(semester.id.eq(member.semesterId))
-                .where(
-                        member.role.eq(role),
-                        eqJobFamily(jobFamily),
-                        eqSemesterId(semesterId),
-                        member.isDeleted.eq(false))
-                .orderBy(member.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+        @Override
+        public Page<MemberResponse> findMembers(
+                        final Role role,
+                        final JobFamily jobFamily,
+                        final Long semesterId,
+                        final Pageable pageable) {
+                final List<MemberResponse> content = queryFactory
+                                .select(new QMemberResponse(
+                                                member.id,
+                                                member.name,
+                                                member.phoneNumber,
+                                                member.email,
+                                                teamMember.jobFamily,
+                                                semester.name.as("semesterName")))
+                                .from(member)
+                                .leftJoin(member.teamMembers, teamMember)
+                                .leftJoin(semester)
+                                .on(semester.id.eq(teamMember.team.semesterId))
+                                .where(
+                                                member.role.eq(role),
+                                                eqJobFamily(jobFamily),
+                                                eqSemesterId(semesterId),
+                                                member.isDeleted.eq(false))
+                                .orderBy(member.createdAt.desc())
+                                .offset(pageable.getOffset())
+                                .limit(pageable.getPageSize())
+                                .fetch();
 
-        final Long total = queryFactory
-                .select(member.count())
-                .from(member)
-                .leftJoin(semester)
-                .on(semester.id.eq(member.semesterId))
-                .where(
-                        member.role.eq(role),
-                        eqJobFamily(jobFamily),
-                        eqSemesterId(semesterId),
-                        member.isDeleted.eq(false))
-                .fetchOne();
+                final Long total = queryFactory
+                                .select(member.count())
+                                .from(member)
+                                .leftJoin(member.teamMembers, teamMember)
+                                .leftJoin(semester)
+                                .on(semester.id.eq(teamMember.team.semesterId))
+                                .where(
+                                                member.role.eq(role),
+                                                eqJobFamily(jobFamily),
+                                                eqSemesterId(semesterId),
+                                                member.isDeleted.eq(false))
+                                .fetchOne();
 
+                return PageResponse.from(content, pageable, total);
+        }
 
-        return PageResponse.from(content, pageable, total);
-    }
+        private BooleanExpression eqJobFamily(final JobFamily jobFamily) {
+                return Optional.ofNullable(jobFamily)
+                                .map(teamMember.jobFamily::eq)
+                                .orElse(null);
+        }
 
-    private BooleanExpression eqJobFamily(final JobFamily jobFamily) {
-        return Optional.ofNullable(jobFamily)
-                .map(member.jobFamily::eq)
-                .orElse(null);
-    }
-
-    private BooleanExpression eqSemesterId(final Long semesterId) {
-        return Optional.ofNullable(semesterId)
-                .map(semester.id::eq)
-                .orElse(null);
-    }
+        private BooleanExpression eqSemesterId(final Long semesterId) {
+                return Optional.ofNullable(semesterId)
+                                .map(semester.id::eq)
+                                .orElse(null);
+        }
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
@@ -43,19 +43,19 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
                                                 member.isDeleted.eq(false))
                                 .transform(GroupBy.groupBy(teamMember.team.id).as(new QTeamMemberNames(
                                                 GroupBy.list(new CaseBuilder()
-                                                                .when(member.jobFamily.eq(PM))
+                                                                .when(teamMember.jobFamily.eq(PM))
                                                                 .then(member.name)
                                                                 .otherwise((String) null)),
                                                 GroupBy.list(new CaseBuilder()
-                                                                .when(member.jobFamily.eq(PD))
+                                                                .when(teamMember.jobFamily.eq(PD))
                                                                 .then(member.name)
                                                                 .otherwise((String) null)),
                                                 GroupBy.list(new CaseBuilder()
-                                                                .when(member.jobFamily.eq(FE))
+                                                                .when(teamMember.jobFamily.eq(FE))
                                                                 .then(member.name)
                                                                 .otherwise((String) null)),
                                                 GroupBy.list(new CaseBuilder()
-                                                                .when(member.jobFamily.eq(BE))
+                                                                .when(teamMember.jobFamily.eq(BE))
                                                                 .then(member.name)
                                                                 .otherwise((String) null)))))
                                 .get(teamId);

--- a/src/main/java/org/ject/support/domain/member/repository/TeamMemberRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/TeamMemberRepository.java
@@ -1,7 +1,13 @@
 package org.ject.support.domain.member.repository;
 
+import java.util.List;
+import java.util.Optional;
 import org.ject.support.domain.member.entity.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+    List<TeamMember> findByMemberId(Long memberId);
+
+    Optional<TeamMember> findByMemberIdAndTeamSemesterId(Long memberId, Long semesterId);
 }

--- a/src/main/java/org/ject/support/domain/member/repository/TeamRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/TeamRepository.java
@@ -1,7 +1,10 @@
 package org.ject.support.domain.member.repository;
 
+import java.util.Optional;
 import org.ject.support.domain.member.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    Optional<Team> findByNameAndSemesterId(String name, Long semesterId);
 }

--- a/src/main/resources/db/migration/V18__add_job_family_to_team_member.sql
+++ b/src/main/resources/db/migration/V18__add_job_family_to_team_member.sql
@@ -1,0 +1,9 @@
+-- team_member 테이블에 job_family 컬럼 추가
+ALTER TABLE team_member
+    ADD COLUMN job_family VARCHAR(45) NULL;
+
+-- 기존 member의 job_family 데이터를 team_member로 마이그레이션
+UPDATE team_member tm
+    JOIN member m ON tm.member_id = m.id
+SET tm.job_family = m.job_family
+WHERE m.job_family IS NOT NULL;

--- a/src/test/java/org/ject/support/domain/admin/service/MemberManagementServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/MemberManagementServiceTest.java
@@ -3,6 +3,7 @@ package org.ject.support.domain.admin.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -17,9 +18,13 @@ import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.entity.Team;
+import org.ject.support.domain.member.entity.TeamMember;
 import org.ject.support.domain.member.exception.MemberErrorCode;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.member.repository.TeamMemberRepository;
+import org.ject.support.domain.member.repository.TeamRepository;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
 import org.junit.jupiter.api.Test;
@@ -38,6 +43,12 @@ class MemberManagementServiceTest extends UnitTestSupport {
 
     @Mock
     private SemesterRepository semesterRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private TeamMemberRepository teamMemberRepository;
 
     private final String TEST_NAME = "홍길동";
     private final String TEST_EMAIL = "test@example.com";
@@ -130,12 +141,26 @@ class MemberManagementServiceTest extends UnitTestSupport {
                 .semesterId(semesterId)
                 .build();
 
+        var team = Team.builder()
+                .id(1L)
+                .name("미배정")
+                .semesterId(semesterId)
+                .build();
+
+        var teamMember = TeamMember.builder()
+                .id(1L)
+                .member(member)
+                .team(team)
+                .jobFamily(JobFamily.BE)
+                .build();
+
         var semester = Semester.builder()
                 .id(semesterId)
                 .name("1기")
                 .build();
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(teamMemberRepository.findByMemberId(memberId)).willReturn(List.of(teamMember));
         given(semesterRepository.findById(semesterId)).willReturn(Optional.of(semester));
 
         // when
@@ -151,6 +176,7 @@ class MemberManagementServiceTest extends UnitTestSupport {
         assertThat(result.semesterName()).isEqualTo("1");
 
         verify(memberRepository).findById(memberId);
+        verify(teamMemberRepository).findByMemberId(memberId);
         verify(semesterRepository).findById(semesterId);
     }
 
@@ -171,19 +197,18 @@ class MemberManagementServiceTest extends UnitTestSupport {
     }
 
     @Test
-    void 회원_상세_조회_실패_존재하지_않는_기수() {
+    void 회원_상세_조회_실패_팀멤버_없음() {
         // given
         var memberId = 1L;
-        var semesterId = 999L;
 
         var member = Member.builder()
                 .id(memberId)
                 .name(TEST_NAME)
-                .semesterId(semesterId)
+                .semesterId(999L)
                 .build();
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(semesterRepository.findById(semesterId)).willReturn(Optional.empty());
+        given(teamMemberRepository.findByMemberId(memberId)).willReturn(List.of());
 
         // expected
         assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
@@ -192,7 +217,7 @@ class MemberManagementServiceTest extends UnitTestSupport {
                 .isEqualTo(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER);
 
         verify(memberRepository).findById(memberId);
-        verify(semesterRepository).findById(semesterId);
+        verify(teamMemberRepository).findByMemberId(memberId);
     }
 
     @Test
@@ -213,9 +238,28 @@ class MemberManagementServiceTest extends UnitTestSupport {
                 .name("1기")
                 .build();
 
+        var savedMember = Member.builder()
+                .id(1L)
+                .name(TEST_NAME)
+                .phoneNumber(TEST_PHONE_NUMBER)
+                .email(TEST_EMAIL)
+                .jobFamily(JobFamily.BE)
+                .role(Role.SEMESTER)
+                .region(Region.SEOUL)
+                .semesterId(1L)
+                .build();
+
+        var unassignedTeam = Team.builder()
+                .id(1L)
+                .name("미배정")
+                .semesterId(1L)
+                .build();
+
         given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
         given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
-        given(memberRepository.save(any(Member.class))).willReturn(any(Member.class));
+        given(memberRepository.save(any(Member.class))).willReturn(savedMember);
+        given(teamRepository.findByNameAndSemesterId("미배정", 1L)).willReturn(Optional.of(unassignedTeam));
+        given(teamMemberRepository.save(any(TeamMember.class))).willReturn(any(TeamMember.class));
 
         // when
         memberManagementService.registerMember(request);
@@ -224,6 +268,8 @@ class MemberManagementServiceTest extends UnitTestSupport {
         verify(memberRepository).existsByEmail(TEST_EMAIL);
         verify(semesterRepository).findByName("1기");
         verify(memberRepository).save(any(Member.class));
+        verify(teamRepository).findByNameAndSemesterId("미배정", 1L);
+        verify(teamMemberRepository).save(any(TeamMember.class));
     }
 
     @Test
@@ -236,7 +282,7 @@ class MemberManagementServiceTest extends UnitTestSupport {
                 TEST_EMAIL,
                 JobFamily.BE,
                 Region.SEOUL,
-                "1"
+                "1기"
         );
 
         given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(true);
@@ -278,8 +324,23 @@ class MemberManagementServiceTest extends UnitTestSupport {
                 .name("1기")
                 .build();
 
+        var team = Team.builder()
+                .id(1L)
+                .name("미배정")
+                .semesterId(1L)
+                .build();
+
+        var existingTeamMember = TeamMember.builder()
+                .id(1L)
+                .member(member)
+                .team(team)
+                .jobFamily(JobFamily.BE)
+                .build();
+
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
         given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
+        given(teamMemberRepository.findByMemberIdAndTeamSemesterId(memberId, 1L))
+                .willReturn(Optional.of(existingTeamMember));
 
         // when
         memberManagementService.editMember(memberId, request);
@@ -303,7 +364,7 @@ class MemberManagementServiceTest extends UnitTestSupport {
                 .phoneNumber("01087654321")
                 .email("updated@test.com")
                 .jobFamily(JobFamily.FE)
-                .semesterName("2")
+                .semesterName("2기")
                 .build();
 
         given(memberRepository.findById(memberId)).willReturn(Optional.empty());

--- a/src/test/java/org/ject/support/domain/admin/service/MemberManagementServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/MemberManagementServiceTest.java
@@ -17,13 +17,9 @@ import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
-import org.ject.support.domain.member.entity.Team;
-import org.ject.support.domain.member.entity.TeamMember;
 import org.ject.support.domain.member.exception.MemberErrorCode;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberRepository;
-import org.ject.support.domain.member.repository.TeamMemberRepository;
-import org.ject.support.domain.member.repository.TeamRepository;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
 import org.junit.jupiter.api.Test;
@@ -34,424 +30,385 @@ import org.springframework.data.domain.PageRequest;
 
 class MemberManagementServiceTest extends UnitTestSupport {
 
-        @InjectMocks
-        private MemberManagementService memberManagementService;
-
-        @Mock
-        private MemberRepository memberRepository;
-
-        @Mock
-        private SemesterRepository semesterRepository;
-
-        @Mock
-        private TeamRepository teamRepository;
-
-        @Mock
-        private TeamMemberRepository teamMemberRepository;
-
-        private final String TEST_NAME = "홍길동";
-        private final String TEST_EMAIL = "test@example.com";
-        private final String TEST_PHONE_NUMBER = "01012345678";
-
-        @Test
-        void 회원_목록_조회_성공() {
-                // given
-                var role = Role.SEMESTER;
-                var jobFamily = JobFamily.BE;
-                var semesterId = 1L;
-                var pageable = PageRequest.of(0, 15);
-
-                var memberList = List.of(
-                                MemberResponse.builder()
-                                                .id(1L)
-                                                .name("회원1")
-                                                .phoneNumber("01012345678")
-                                                .email("member1@test.com")
-                                                .jobFamily(jobFamily)
-                                                .semesterName("1기")
-                                                .build(),
-                                MemberResponse.builder()
-                                                .id(2L)
-                                                .name("회원2")
-                                                .phoneNumber("01012345679")
-                                                .email("member2@test.com")
-                                                .jobFamily(jobFamily)
-                                                .semesterName("1기")
-                                                .build());
-                var expectedPage = new PageImpl<>(memberList, pageable, 2);
-
-                given(memberRepository.findMembers(role, jobFamily, semesterId, pageable))
-                                .willReturn(expectedPage);
-
-                // when
-                var result = memberManagementService.findMembers(role, jobFamily, semesterId, pageable);
-
-                // then
-                assertThat(result).isEqualTo(expectedPage);
-                assertThat(result.getContent()).hasSize(2);
-                assertThat(result.getTotalElements()).isEqualTo(2);
-                verify(memberRepository).findMembers(role, jobFamily, semesterId, pageable);
-        }
-
-        @Test
-        void 회원_목록_조회_필터_없이_성공() {
-                // given
-                var role = Role.ADMIN;
-                var pageable = PageRequest.of(0, 15);
-
-                var memberList = List.of(
-                                MemberResponse.builder()
-                                                .id(1L)
-                                                .name("관리자1")
-                                                .phoneNumber("01012345678")
-                                                .email("admin1@test.com")
-                                                .jobFamily(JobFamily.BE)
-                                                .semesterName("1기")
-                                                .build());
-                var expectedPage = new PageImpl<>(memberList, pageable, 1);
-
-                given(memberRepository.findMembers(role, null, null, pageable))
-                                .willReturn(expectedPage);
-
-                // when
-                var result = memberManagementService.findMembers(role, null, null, pageable);
-
-                // then
-                assertThat(result).isEqualTo(expectedPage);
-                assertThat(result.getContent()).hasSize(1);
-                verify(memberRepository).findMembers(role, null, null, pageable);
-        }
-
-        @Test
-        void 회원_상세_조회_성공() {
-                // given
-                var memberId = 1L;
-                var semesterId = 1L;
-
-                var member = Member.builder()
-                                .id(memberId)
-                                .name(TEST_NAME)
-                                .phoneNumber(TEST_PHONE_NUMBER)
-                                .email(TEST_EMAIL)
-                                .jobFamily(JobFamily.BE)
-                                .role(Role.SEMESTER)
-                                .semesterId(semesterId)
-                                .build();
-
-                var semester = Semester.builder()
-                                .id(semesterId)
-                                .name("1기")
-                                .build();
-
-                var team = Team.builder()
-                                .id(1L)
-                                .name("미배정")
-                                .semesterId(semesterId)
-                                .build();
-
-                var teamMember = TeamMember.builder()
-                                .id(1L)
-                                .member(member)
-                                .team(team)
-                                .jobFamily(JobFamily.BE)
-                                .build();
-
-                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-                given(teamMemberRepository.findByMemberId(memberId)).willReturn(List.of(teamMember));
-                given(semesterRepository.findById(semesterId)).willReturn(Optional.of(semester));
-
-                // when
-                var result = memberManagementService.findMemberDetail(memberId);
-
-                // then
-                assertThat(result.id()).isEqualTo(memberId);
-                assertThat(result.name()).isEqualTo(TEST_NAME);
-                assertThat(result.email()).isEqualTo(TEST_EMAIL);
-                assertThat(result.phoneNumber()).isEqualTo(TEST_PHONE_NUMBER);
-                assertThat(result.jobFamily()).isEqualTo(JobFamily.BE);
-                assertThat(result.role()).isEqualTo(Role.SEMESTER);
-                assertThat(result.semesterName()).isEqualTo("1");
-
-                verify(memberRepository).findById(memberId);
-                verify(teamMemberRepository).findByMemberId(memberId);
-                verify(semesterRepository).findById(semesterId);
-        }
-
-        @Test
-        void 회원_상세_조회_실패_존재하지_않는_회원() {
-                // given
-                var memberId = 999L;
-
-                given(memberRepository.findById(memberId)).willReturn(Optional.empty());
-
-                // expected
-                assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
-                                .isInstanceOf(MemberException.class)
-                                .extracting(e -> ((MemberException) e).getErrorCode())
-                                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
-
-                verify(memberRepository).findById(memberId);
-        }
-
-        @Test
-        void 회원_상세_조회_실패_TeamMember가_없는_경우() {
-                // given
-                var memberId = 1L;
-
-                var member = Member.builder()
-                                .id(memberId)
-                                .name(TEST_NAME)
-                                .semesterId(1L)
-                                .build();
-
-                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-                given(teamMemberRepository.findByMemberId(memberId)).willReturn(List.of());
-
-                // expected
-                assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
-                                .isInstanceOf(MemberException.class)
-                                .extracting(e -> ((MemberException) e).getErrorCode())
-                                .isEqualTo(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER);
-
-                verify(memberRepository).findById(memberId);
-                verify(teamMemberRepository).findByMemberId(memberId);
-        }
-
-        @Test
-        void 관리자용_회원_등록_성공() {
-                // given
-                var request = new MemberRegisterRequest(
-                                Role.SEMESTER,
-                                TEST_NAME,
-                                TEST_PHONE_NUMBER,
-                                TEST_EMAIL,
-                                JobFamily.BE,
-                                Region.SEOUL,
-                                "1기");
-
-                var semester = Semester.builder()
-                                .id(1L)
-                                .name("1기")
-                                .build();
-
-                var unassignedTeam = Team.builder()
-                                .id(1L)
-                                .name("미배정")
-                                .semesterId(1L)
-                                .build();
-
-                given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
-                given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
-                given(teamRepository.findByNameAndSemesterId("미배정", 1L)).willReturn(Optional.of(unassignedTeam));
-
-                // when
-                memberManagementService.registerMember(request);
-
-                // then
-                verify(memberRepository).existsByEmail(TEST_EMAIL);
-                verify(semesterRepository).findByName("1기");
-                verify(memberRepository).save(any(Member.class));
-                verify(teamRepository).findByNameAndSemesterId("미배정", 1L);
-                verify(teamMemberRepository).save(any(TeamMember.class));
-        }
-
-        @Test
-        void 관리자용_회원_등록_실패_이미_존재하는_이메일() {
-                // given
-                var request = new MemberRegisterRequest(
-                                Role.SEMESTER,
-                                TEST_NAME,
-                                TEST_PHONE_NUMBER,
-                                TEST_EMAIL,
-                                JobFamily.BE,
-                                Region.SEOUL,
-                                "1");
-
-                given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(true);
-
-                // expected
-                assertThatThrownBy(() -> memberManagementService.registerMember(request))
-                                .isInstanceOf(MemberException.class)
-                                .extracting(e -> ((MemberException) e).getErrorCode())
-                                .isEqualTo(MemberErrorCode.ALREADY_EXIST_MEMBER);
-
-                verify(memberRepository).existsByEmail(TEST_EMAIL);
-        }
-
-        @Test
-        void 회원_정보_수정_성공() {
-                // given
-                var memberId = 1L;
-                var request = MemberEditRequest.builder()
-                                .role(Role.SEMESTER)
-                                .name("수정된이름")
-                                .phoneNumber("01087654321")
-                                .email("updated@test.com")
-                                .jobFamily(JobFamily.FE)
-                                .semesterName("1기")
-                                .build();
-
-                var member = Member.builder()
-                                .id(memberId)
-                                .name(TEST_NAME)
-                                .phoneNumber(TEST_PHONE_NUMBER)
-                                .email(TEST_EMAIL)
-                                .jobFamily(JobFamily.BE)
-                                .role(Role.SEMESTER)
-                                .semesterId(1L)
-                                .build();
-
-                var semester = Semester.builder()
-                                .id(1L)
-                                .name("1기")
-                                .build();
-
-                var team = Team.builder()
-                                .id(1L)
-                                .name("미배정")
-                                .semesterId(1L)
-                                .build();
-
-                var existingTeamMember = TeamMember.builder()
-                                .id(1L)
-                                .member(member)
-                                .team(team)
-                                .jobFamily(JobFamily.BE)
-                                .build();
-
-                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-                given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
-                given(teamMemberRepository.findByMemberIdAndTeamSemesterId(memberId, 1L))
-                                .willReturn(Optional.of(existingTeamMember));
-
-                // when
-                memberManagementService.editMember(memberId, request);
-
-                // then
-                verify(memberRepository).findById(memberId);
-                assertThat(member.getName()).isEqualTo(request.name());
-                assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
-                assertThat(member.getEmail()).isEqualTo(request.email());
-                assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
-                assertThat(member.getSemesterId()).isEqualTo(semester.getId());
-                assertThat(existingTeamMember.getJobFamily()).isEqualTo(JobFamily.FE);
-        }
-
-        @Test
-        void 회원_정보_수정_실패_존재하지_않는_회원() {
-                // given
-                var memberId = 999L;
-                var request = MemberEditRequest.builder()
-                                .role(Role.SEMESTER)
-                                .name("수정된이름")
-                                .phoneNumber("01087654321")
-                                .email("updated@test.com")
-                                .jobFamily(JobFamily.FE)
-                                .semesterName("2")
-                                .build();
-
-                given(memberRepository.findById(memberId)).willReturn(Optional.empty());
-
-                // expected
-                assertThatThrownBy(() -> memberManagementService.editMember(memberId, request))
-                                .isInstanceOf(MemberException.class)
-                                .extracting(e -> ((MemberException) e).getErrorCode())
-                                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
-
-                verify(memberRepository).findById(memberId);
-        }
-
-        @Test
-        void 단일_회원_삭제_성공() {
-                // given
-                var memberId = 1L;
-                var member = Member.builder()
-                                .id(memberId)
-                                .name(TEST_NAME)
-                                .email(TEST_EMAIL)
-                                .build();
-
-                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-                doNothing().when(memberRepository).delete(member);
-
-                // when
-                memberManagementService.deleteMember(memberId);
-
-                // then
-                verify(memberRepository).findById(memberId);
-                verify(memberRepository).delete(member);
-        }
-
-        @Test
-        void 단일_회원_삭제_실패_존재하지_않는_회원() {
-                // given
-                var memberId = 999L;
-
-                given(memberRepository.findById(memberId)).willReturn(Optional.empty());
-
-                // expected
-                assertThatThrownBy(() -> memberManagementService.deleteMember(memberId))
-                                .isInstanceOf(MemberException.class)
-                                .extracting(e -> ((MemberException) e).getErrorCode())
-                                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
-
-                verify(memberRepository).findById(memberId);
-        }
-
-        @Test
-        void 다중_회원_삭제_성공() {
-                // given
-                var memberIds = List.of(1L, 2L, 3L);
-                var members = List.of(
-                                Member.builder().id(1L).name("가젝트").email("member1@test.com").build(),
-                                Member.builder().id(2L).name("나젝트").email("member2@test.com").build(),
-                                Member.builder().id(3L).name("다젝트").email("member3@test.com").build());
-
-                given(memberRepository.findAllById(memberIds)).willReturn(members);
-                doNothing().when(memberRepository).deleteAll(members);
-
-                // when
-                memberManagementService.deleteMembers(memberIds);
-
-                // then
-                verify(memberRepository).findAllById(memberIds);
-                verify(memberRepository).deleteAll(members);
-        }
-
-        @Test
-        void 다중_회원_삭제_실패_일부_회원이_존재하지_않음() {
-                // given
-                var memberIds = List.of(1L, 2L, 999L); // 999L은 존재하지 않는 회원
-                var members = List.of(
-                                Member.builder().id(1L).name("가젝트").email("member1@test.com").build(),
-                                Member.builder().id(2L).name("나젝트").email("member2@test.com").build()
+    @InjectMocks
+    private MemberManagementService memberManagementService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private SemesterRepository semesterRepository;
+
+    private final String TEST_NAME = "홍길동";
+    private final String TEST_EMAIL = "test@example.com";
+    private final String TEST_PHONE_NUMBER = "01012345678";
+
+    @Test
+    void 회원_목록_조회_성공() {
+        // given
+        var role = Role.SEMESTER;
+        var jobFamily = JobFamily.BE;
+        var semesterId = 1L;
+        var pageable = PageRequest.of(0, 15);
+
+        var memberList = List.of(
+                MemberResponse.builder()
+                        .id(1L)
+                        .name("회원1")
+                        .phoneNumber("01012345678")
+                        .email("member1@test.com")
+                        .jobFamily(jobFamily)
+                        .semesterName("1기")
+                        .build(),
+                MemberResponse.builder()
+                        .id(2L)
+                        .name("회원2")
+                        .phoneNumber("01012345679")
+                        .email("member2@test.com")
+                        .jobFamily(jobFamily)
+                        .semesterName("1기")
+                        .build()
+        );
+        var expectedPage = new PageImpl<>(memberList, pageable, 2);
+
+        given(memberRepository.findMembers(role, jobFamily, semesterId, pageable))
+                .willReturn(expectedPage);
+
+        // when
+        var result = memberManagementService.findMembers(role, jobFamily, semesterId, pageable);
+
+        // then
+        assertThat(result).isEqualTo(expectedPage);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        verify(memberRepository).findMembers(role, jobFamily, semesterId, pageable);
+    }
+
+    @Test
+    void 회원_목록_조회_필터_없이_성공() {
+        // given
+        var role = Role.ADMIN;
+        var pageable = PageRequest.of(0, 15);
+
+        var memberList = List.of(
+                MemberResponse.builder()
+                        .id(1L)
+                        .name("관리자1")
+                        .phoneNumber("01012345678")
+                        .email("admin1@test.com")
+                        .jobFamily(JobFamily.BE)
+                        .semesterName("1기")
+                        .build()
+        );
+        var expectedPage = new PageImpl<>(memberList, pageable, 1);
+
+        given(memberRepository.findMembers(role, null, null, pageable))
+                .willReturn(expectedPage);
+
+        // when
+        var result = memberManagementService.findMembers(role, null, null, pageable);
+
+        // then
+        assertThat(result).isEqualTo(expectedPage);
+        assertThat(result.getContent()).hasSize(1);
+        verify(memberRepository).findMembers(role, null, null, pageable);
+    }
+
+    @Test
+    void 회원_상세_조회_성공() {
+        // given
+        var memberId = 1L;
+        var semesterId = 1L;
+
+        var member = Member.builder()
+                .id(memberId)
+                .name(TEST_NAME)
+                .phoneNumber(TEST_PHONE_NUMBER)
+                .email(TEST_EMAIL)
+                .jobFamily(JobFamily.BE)
+                .role(Role.SEMESTER)
+                .semesterId(semesterId)
+                .build();
+
+        var semester = Semester.builder()
+                .id(semesterId)
+                .name("1기")
+                .build();
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(semesterRepository.findById(semesterId)).willReturn(Optional.of(semester));
+
+        // when
+        var result = memberManagementService.findMemberDetail(memberId);
+
+        // then
+        assertThat(result.id()).isEqualTo(memberId);
+        assertThat(result.name()).isEqualTo(TEST_NAME);
+        assertThat(result.email()).isEqualTo(TEST_EMAIL);
+        assertThat(result.phoneNumber()).isEqualTo(TEST_PHONE_NUMBER);
+        assertThat(result.jobFamily()).isEqualTo(JobFamily.BE);
+        assertThat(result.role()).isEqualTo(Role.SEMESTER);
+        assertThat(result.semesterName()).isEqualTo("1");
+
+        verify(memberRepository).findById(memberId);
+        verify(semesterRepository).findById(semesterId);
+    }
+
+    @Test
+    void 회원_상세_조회_실패_존재하지_않는_회원() {
+        // given
+        var memberId = 999L;
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // expected
+        assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
+                .isInstanceOf(MemberException.class)
+                .extracting(e -> ((MemberException) e).getErrorCode())
+                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+
+        verify(memberRepository).findById(memberId);
+    }
+
+    @Test
+    void 회원_상세_조회_실패_존재하지_않는_기수() {
+        // given
+        var memberId = 1L;
+        var semesterId = 999L;
+
+        var member = Member.builder()
+                .id(memberId)
+                .name(TEST_NAME)
+                .semesterId(semesterId)
+                .build();
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(semesterRepository.findById(semesterId)).willReturn(Optional.empty());
+
+        // expected
+        assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
+                .isInstanceOf(MemberException.class)
+                .extracting(e -> ((MemberException) e).getErrorCode())
+                .isEqualTo(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER);
+
+        verify(memberRepository).findById(memberId);
+        verify(semesterRepository).findById(semesterId);
+    }
+
+    @Test
+    void 관리자용_회원_등록_성공() {
+        // given
+        var request = new MemberRegisterRequest(
+                Role.SEMESTER,
+                TEST_NAME,
+                TEST_PHONE_NUMBER,
+                TEST_EMAIL,
+                JobFamily.BE,
+                Region.SEOUL,
+                "1기"
+        );
+
+        var semester = Semester.builder()
+                .id(1L)
+                .name("1기")
+                .build();
+
+        given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
+        given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
+        given(memberRepository.save(any(Member.class))).willReturn(any(Member.class));
+
+        // when
+        memberManagementService.registerMember(request);
+
+        // then
+        verify(memberRepository).existsByEmail(TEST_EMAIL);
+        verify(semesterRepository).findByName("1기");
+        verify(memberRepository).save(any(Member.class));
+    }
+
+    @Test
+    void 관리자용_회원_등록_실패_이미_존재하는_이메일() {
+        // given
+        var request = new MemberRegisterRequest(
+                Role.SEMESTER,
+                TEST_NAME,
+                TEST_PHONE_NUMBER,
+                TEST_EMAIL,
+                JobFamily.BE,
+                Region.SEOUL,
+                "1"
+        );
+
+        given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(true);
+
+        // expected
+        assertThatThrownBy(() -> memberManagementService.registerMember(request))
+                .isInstanceOf(MemberException.class)
+                .extracting(e -> ((MemberException) e).getErrorCode())
+                .isEqualTo(MemberErrorCode.ALREADY_EXIST_MEMBER);
+
+        verify(memberRepository).existsByEmail(TEST_EMAIL);
+    }
+
+    @Test
+    void 회원_정보_수정_성공() {
+        // given
+        var memberId = 1L;
+        var request = MemberEditRequest.builder()
+                .role(Role.SEMESTER)
+                .name("수정된이름")
+                .phoneNumber("01087654321")
+                .email("updated@test.com")
+                .jobFamily(JobFamily.FE)
+                .semesterName("1기")
+                .build();
+
+        var member = Member.builder()
+                .id(memberId)
+                .name(TEST_NAME)
+                .phoneNumber(TEST_PHONE_NUMBER)
+                .email(TEST_EMAIL)
+                .jobFamily(JobFamily.BE)
+                .role(Role.SEMESTER)
+                .semesterId(1L)
+                .build();
+
+        var semester = Semester.builder()
+                .id(1L)
+                .name("1기")
+                .build();
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
+
+        // when
+        memberManagementService.editMember(memberId, request);
+
+        // then
+        verify(memberRepository).findById(memberId);
+        assertThat(member.getName()).isEqualTo(request.name());
+        assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
+        assertThat(member.getEmail()).isEqualTo(request.email());
+        assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
+        assertThat(member.getSemesterId()).isEqualTo(semester.getId());
+    }
+
+    @Test
+    void 회원_정보_수정_실패_존재하지_않는_회원() {
+        // given
+        var memberId = 999L;
+        var request = MemberEditRequest.builder()
+                .role(Role.SEMESTER)
+                .name("수정된이름")
+                .phoneNumber("01087654321")
+                .email("updated@test.com")
+                .jobFamily(JobFamily.FE)
+                .semesterName("2")
+                .build();
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // expected
+        assertThatThrownBy(() -> memberManagementService.editMember(memberId, request))
+                .isInstanceOf(MemberException.class)
+                .extracting(e -> ((MemberException) e).getErrorCode())
+                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+
+        verify(memberRepository).findById(memberId);
+    }
+
+    @Test
+    void 단일_회원_삭제_성공() {
+        // given
+        var memberId = 1L;
+        var member = Member.builder()
+                .id(memberId)
+                .name(TEST_NAME)
+                .email(TEST_EMAIL)
+                .build();
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        doNothing().when(memberRepository).delete(member);
+
+        // when
+        memberManagementService.deleteMember(memberId);
+
+        // then
+        verify(memberRepository).findById(memberId);
+        verify(memberRepository).delete(member);
+    }
+
+    @Test
+    void 단일_회원_삭제_실패_존재하지_않는_회원() {
+        // given
+        var memberId = 999L;
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // expected
+        assertThatThrownBy(() -> memberManagementService.deleteMember(memberId))
+                .isInstanceOf(MemberException.class)
+                .extracting(e -> ((MemberException) e).getErrorCode())
+                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+
+        verify(memberRepository).findById(memberId);
+    }
+
+    @Test
+    void 다중_회원_삭제_성공() {
+        // given
+        var memberIds = List.of(1L, 2L, 3L);
+        var members = List.of(
+                Member.builder().id(1L).name("가젝트").email("member1@test.com").build(),
+                Member.builder().id(2L).name("나젝트").email("member2@test.com").build(),
+                Member.builder().id(3L).name("다젝트").email("member3@test.com").build()
+        );
+
+        given(memberRepository.findAllById(memberIds)).willReturn(members);
+        doNothing().when(memberRepository).deleteAll(members);
+
+        // when
+        memberManagementService.deleteMembers(memberIds);
+
+        // then
+        verify(memberRepository).findAllById(memberIds);
+        verify(memberRepository).deleteAll(members);
+    }
+
+    @Test
+    void 다중_회원_삭제_실패_일부_회원이_존재하지_않음() {
+        // given
+        var memberIds = List.of(1L, 2L, 999L); // 999L은 존재하지 않는 회원
+        var members = List.of(
+                Member.builder().id(1L).name("가젝트").email("member1@test.com").build(),
+                Member.builder().id(2L).name("나젝트").email("member2@test.com").build()
                 // 999L에 해당하는 회원은 없음
-                );
+        );
 
-                given(memberRepository.findAllById(memberIds)).willReturn(members);
+        given(memberRepository.findAllById(memberIds)).willReturn(members);
 
-                // expected
-                assertThatThrownBy(() -> memberManagementService.deleteMembers(memberIds))
-                                .isInstanceOf(MemberException.class)
-                                .extracting(e -> ((MemberException) e).getErrorCode())
-                                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+        // expected
+        assertThatThrownBy(() -> memberManagementService.deleteMembers(memberIds))
+                .isInstanceOf(MemberException.class)
+                .extracting(e -> ((MemberException) e).getErrorCode())
+                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
 
-                verify(memberRepository).findAllById(memberIds);
-        }
+        verify(memberRepository).findAllById(memberIds);
+    }
 
-        @Test
-        void 다중_회원_삭제_실패_빈_목록() {
-                // given
-                List<Long> emptyMemberIds = List.of();
-                List<Member> emptyMembers = List.of();
+    @Test
+    void 다중_회원_삭제_실패_빈_목록() {
+        // given
+        List<Long> emptyMemberIds = List.of();
+        List<Member> emptyMembers = List.of();
 
-                given(memberRepository.findAllById(emptyMemberIds)).willReturn(emptyMembers);
+        given(memberRepository.findAllById(emptyMemberIds)).willReturn(emptyMembers);
 
-                // when
-                memberManagementService.deleteMembers(emptyMemberIds);
+        // when
+        memberManagementService.deleteMembers(emptyMemberIds);
 
-                // then
-                verify(memberRepository).findAllById(emptyMemberIds);
-                verify(memberRepository).deleteAll(emptyMembers);
-        }
+        // then
+        verify(memberRepository).findAllById(emptyMemberIds);
+        verify(memberRepository).deleteAll(emptyMembers);
+    }
 }

--- a/src/test/java/org/ject/support/domain/admin/service/MemberManagementServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/MemberManagementServiceTest.java
@@ -17,9 +17,13 @@ import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.entity.Team;
+import org.ject.support.domain.member.entity.TeamMember;
 import org.ject.support.domain.member.exception.MemberErrorCode;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.member.repository.TeamMemberRepository;
+import org.ject.support.domain.member.repository.TeamRepository;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
 import org.junit.jupiter.api.Test;
@@ -30,385 +34,424 @@ import org.springframework.data.domain.PageRequest;
 
 class MemberManagementServiceTest extends UnitTestSupport {
 
-    @InjectMocks
-    private MemberManagementService memberManagementService;
+        @InjectMocks
+        private MemberManagementService memberManagementService;
 
-    @Mock
-    private MemberRepository memberRepository;
+        @Mock
+        private MemberRepository memberRepository;
 
-    @Mock
-    private SemesterRepository semesterRepository;
+        @Mock
+        private SemesterRepository semesterRepository;
 
-    private final String TEST_NAME = "홍길동";
-    private final String TEST_EMAIL = "test@example.com";
-    private final String TEST_PHONE_NUMBER = "01012345678";
+        @Mock
+        private TeamRepository teamRepository;
 
-    @Test
-    void 회원_목록_조회_성공() {
-        // given
-        var role = Role.SEMESTER;
-        var jobFamily = JobFamily.BE;
-        var semesterId = 1L;
-        var pageable = PageRequest.of(0, 15);
+        @Mock
+        private TeamMemberRepository teamMemberRepository;
 
-        var memberList = List.of(
-                MemberResponse.builder()
-                        .id(1L)
-                        .name("회원1")
-                        .phoneNumber("01012345678")
-                        .email("member1@test.com")
-                        .jobFamily(jobFamily)
-                        .semesterName("1기")
-                        .build(),
-                MemberResponse.builder()
-                        .id(2L)
-                        .name("회원2")
-                        .phoneNumber("01012345679")
-                        .email("member2@test.com")
-                        .jobFamily(jobFamily)
-                        .semesterName("1기")
-                        .build()
-        );
-        var expectedPage = new PageImpl<>(memberList, pageable, 2);
+        private final String TEST_NAME = "홍길동";
+        private final String TEST_EMAIL = "test@example.com";
+        private final String TEST_PHONE_NUMBER = "01012345678";
 
-        given(memberRepository.findMembers(role, jobFamily, semesterId, pageable))
-                .willReturn(expectedPage);
+        @Test
+        void 회원_목록_조회_성공() {
+                // given
+                var role = Role.SEMESTER;
+                var jobFamily = JobFamily.BE;
+                var semesterId = 1L;
+                var pageable = PageRequest.of(0, 15);
 
-        // when
-        var result = memberManagementService.findMembers(role, jobFamily, semesterId, pageable);
+                var memberList = List.of(
+                                MemberResponse.builder()
+                                                .id(1L)
+                                                .name("회원1")
+                                                .phoneNumber("01012345678")
+                                                .email("member1@test.com")
+                                                .jobFamily(jobFamily)
+                                                .semesterName("1기")
+                                                .build(),
+                                MemberResponse.builder()
+                                                .id(2L)
+                                                .name("회원2")
+                                                .phoneNumber("01012345679")
+                                                .email("member2@test.com")
+                                                .jobFamily(jobFamily)
+                                                .semesterName("1기")
+                                                .build());
+                var expectedPage = new PageImpl<>(memberList, pageable, 2);
 
-        // then
-        assertThat(result).isEqualTo(expectedPage);
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getTotalElements()).isEqualTo(2);
-        verify(memberRepository).findMembers(role, jobFamily, semesterId, pageable);
-    }
+                given(memberRepository.findMembers(role, jobFamily, semesterId, pageable))
+                                .willReturn(expectedPage);
 
-    @Test
-    void 회원_목록_조회_필터_없이_성공() {
-        // given
-        var role = Role.ADMIN;
-        var pageable = PageRequest.of(0, 15);
+                // when
+                var result = memberManagementService.findMembers(role, jobFamily, semesterId, pageable);
 
-        var memberList = List.of(
-                MemberResponse.builder()
-                        .id(1L)
-                        .name("관리자1")
-                        .phoneNumber("01012345678")
-                        .email("admin1@test.com")
-                        .jobFamily(JobFamily.BE)
-                        .semesterName("1기")
-                        .build()
-        );
-        var expectedPage = new PageImpl<>(memberList, pageable, 1);
+                // then
+                assertThat(result).isEqualTo(expectedPage);
+                assertThat(result.getContent()).hasSize(2);
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                verify(memberRepository).findMembers(role, jobFamily, semesterId, pageable);
+        }
 
-        given(memberRepository.findMembers(role, null, null, pageable))
-                .willReturn(expectedPage);
+        @Test
+        void 회원_목록_조회_필터_없이_성공() {
+                // given
+                var role = Role.ADMIN;
+                var pageable = PageRequest.of(0, 15);
 
-        // when
-        var result = memberManagementService.findMembers(role, null, null, pageable);
+                var memberList = List.of(
+                                MemberResponse.builder()
+                                                .id(1L)
+                                                .name("관리자1")
+                                                .phoneNumber("01012345678")
+                                                .email("admin1@test.com")
+                                                .jobFamily(JobFamily.BE)
+                                                .semesterName("1기")
+                                                .build());
+                var expectedPage = new PageImpl<>(memberList, pageable, 1);
 
-        // then
-        assertThat(result).isEqualTo(expectedPage);
-        assertThat(result.getContent()).hasSize(1);
-        verify(memberRepository).findMembers(role, null, null, pageable);
-    }
+                given(memberRepository.findMembers(role, null, null, pageable))
+                                .willReturn(expectedPage);
 
-    @Test
-    void 회원_상세_조회_성공() {
-        // given
-        var memberId = 1L;
-        var semesterId = 1L;
+                // when
+                var result = memberManagementService.findMembers(role, null, null, pageable);
 
-        var member = Member.builder()
-                .id(memberId)
-                .name(TEST_NAME)
-                .phoneNumber(TEST_PHONE_NUMBER)
-                .email(TEST_EMAIL)
-                .jobFamily(JobFamily.BE)
-                .role(Role.SEMESTER)
-                .semesterId(semesterId)
-                .build();
+                // then
+                assertThat(result).isEqualTo(expectedPage);
+                assertThat(result.getContent()).hasSize(1);
+                verify(memberRepository).findMembers(role, null, null, pageable);
+        }
 
-        var semester = Semester.builder()
-                .id(semesterId)
-                .name("1기")
-                .build();
+        @Test
+        void 회원_상세_조회_성공() {
+                // given
+                var memberId = 1L;
+                var semesterId = 1L;
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(semesterRepository.findById(semesterId)).willReturn(Optional.of(semester));
+                var member = Member.builder()
+                                .id(memberId)
+                                .name(TEST_NAME)
+                                .phoneNumber(TEST_PHONE_NUMBER)
+                                .email(TEST_EMAIL)
+                                .jobFamily(JobFamily.BE)
+                                .role(Role.SEMESTER)
+                                .semesterId(semesterId)
+                                .build();
 
-        // when
-        var result = memberManagementService.findMemberDetail(memberId);
+                var semester = Semester.builder()
+                                .id(semesterId)
+                                .name("1기")
+                                .build();
 
-        // then
-        assertThat(result.id()).isEqualTo(memberId);
-        assertThat(result.name()).isEqualTo(TEST_NAME);
-        assertThat(result.email()).isEqualTo(TEST_EMAIL);
-        assertThat(result.phoneNumber()).isEqualTo(TEST_PHONE_NUMBER);
-        assertThat(result.jobFamily()).isEqualTo(JobFamily.BE);
-        assertThat(result.role()).isEqualTo(Role.SEMESTER);
-        assertThat(result.semesterName()).isEqualTo("1");
+                var team = Team.builder()
+                                .id(1L)
+                                .name("미배정")
+                                .semesterId(semesterId)
+                                .build();
 
-        verify(memberRepository).findById(memberId);
-        verify(semesterRepository).findById(semesterId);
-    }
+                var teamMember = TeamMember.builder()
+                                .id(1L)
+                                .member(member)
+                                .team(team)
+                                .jobFamily(JobFamily.BE)
+                                .build();
 
-    @Test
-    void 회원_상세_조회_실패_존재하지_않는_회원() {
-        // given
-        var memberId = 999L;
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+                given(teamMemberRepository.findByMemberId(memberId)).willReturn(List.of(teamMember));
+                given(semesterRepository.findById(semesterId)).willReturn(Optional.of(semester));
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+                // when
+                var result = memberManagementService.findMemberDetail(memberId);
 
-        // expected
-        assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+                // then
+                assertThat(result.id()).isEqualTo(memberId);
+                assertThat(result.name()).isEqualTo(TEST_NAME);
+                assertThat(result.email()).isEqualTo(TEST_EMAIL);
+                assertThat(result.phoneNumber()).isEqualTo(TEST_PHONE_NUMBER);
+                assertThat(result.jobFamily()).isEqualTo(JobFamily.BE);
+                assertThat(result.role()).isEqualTo(Role.SEMESTER);
+                assertThat(result.semesterName()).isEqualTo("1");
 
-        verify(memberRepository).findById(memberId);
-    }
+                verify(memberRepository).findById(memberId);
+                verify(teamMemberRepository).findByMemberId(memberId);
+                verify(semesterRepository).findById(semesterId);
+        }
 
-    @Test
-    void 회원_상세_조회_실패_존재하지_않는_기수() {
-        // given
-        var memberId = 1L;
-        var semesterId = 999L;
+        @Test
+        void 회원_상세_조회_실패_존재하지_않는_회원() {
+                // given
+                var memberId = 999L;
 
-        var member = Member.builder()
-                .id(memberId)
-                .name(TEST_NAME)
-                .semesterId(semesterId)
-                .build();
+                given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(semesterRepository.findById(semesterId)).willReturn(Optional.empty());
+                // expected
+                assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
+                                .isInstanceOf(MemberException.class)
+                                .extracting(e -> ((MemberException) e).getErrorCode())
+                                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
 
-        // expected
-        assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER);
+                verify(memberRepository).findById(memberId);
+        }
 
-        verify(memberRepository).findById(memberId);
-        verify(semesterRepository).findById(semesterId);
-    }
+        @Test
+        void 회원_상세_조회_실패_TeamMember가_없는_경우() {
+                // given
+                var memberId = 1L;
 
-    @Test
-    void 관리자용_회원_등록_성공() {
-        // given
-        var request = new MemberRegisterRequest(
-                Role.SEMESTER,
-                TEST_NAME,
-                TEST_PHONE_NUMBER,
-                TEST_EMAIL,
-                JobFamily.BE,
-                Region.SEOUL,
-                "1기"
-        );
+                var member = Member.builder()
+                                .id(memberId)
+                                .name(TEST_NAME)
+                                .semesterId(1L)
+                                .build();
 
-        var semester = Semester.builder()
-                .id(1L)
-                .name("1기")
-                .build();
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+                given(teamMemberRepository.findByMemberId(memberId)).willReturn(List.of());
 
-        given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
-        given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
-        given(memberRepository.save(any(Member.class))).willReturn(any(Member.class));
+                // expected
+                assertThatThrownBy(() -> memberManagementService.findMemberDetail(memberId))
+                                .isInstanceOf(MemberException.class)
+                                .extracting(e -> ((MemberException) e).getErrorCode())
+                                .isEqualTo(MemberErrorCode.NOT_FOUND_SEMESTER_OF_MEMBER);
 
-        // when
-        memberManagementService.registerMember(request);
+                verify(memberRepository).findById(memberId);
+                verify(teamMemberRepository).findByMemberId(memberId);
+        }
 
-        // then
-        verify(memberRepository).existsByEmail(TEST_EMAIL);
-        verify(semesterRepository).findByName("1기");
-        verify(memberRepository).save(any(Member.class));
-    }
+        @Test
+        void 관리자용_회원_등록_성공() {
+                // given
+                var request = new MemberRegisterRequest(
+                                Role.SEMESTER,
+                                TEST_NAME,
+                                TEST_PHONE_NUMBER,
+                                TEST_EMAIL,
+                                JobFamily.BE,
+                                Region.SEOUL,
+                                "1기");
 
-    @Test
-    void 관리자용_회원_등록_실패_이미_존재하는_이메일() {
-        // given
-        var request = new MemberRegisterRequest(
-                Role.SEMESTER,
-                TEST_NAME,
-                TEST_PHONE_NUMBER,
-                TEST_EMAIL,
-                JobFamily.BE,
-                Region.SEOUL,
-                "1"
-        );
+                var semester = Semester.builder()
+                                .id(1L)
+                                .name("1기")
+                                .build();
 
-        given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(true);
+                var unassignedTeam = Team.builder()
+                                .id(1L)
+                                .name("미배정")
+                                .semesterId(1L)
+                                .build();
 
-        // expected
-        assertThatThrownBy(() -> memberManagementService.registerMember(request))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.ALREADY_EXIST_MEMBER);
+                given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
+                given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
+                given(teamRepository.findByNameAndSemesterId("미배정", 1L)).willReturn(Optional.of(unassignedTeam));
 
-        verify(memberRepository).existsByEmail(TEST_EMAIL);
-    }
+                // when
+                memberManagementService.registerMember(request);
 
-    @Test
-    void 회원_정보_수정_성공() {
-        // given
-        var memberId = 1L;
-        var request = MemberEditRequest.builder()
-                .role(Role.SEMESTER)
-                .name("수정된이름")
-                .phoneNumber("01087654321")
-                .email("updated@test.com")
-                .jobFamily(JobFamily.FE)
-                .semesterName("1기")
-                .build();
+                // then
+                verify(memberRepository).existsByEmail(TEST_EMAIL);
+                verify(semesterRepository).findByName("1기");
+                verify(memberRepository).save(any(Member.class));
+                verify(teamRepository).findByNameAndSemesterId("미배정", 1L);
+                verify(teamMemberRepository).save(any(TeamMember.class));
+        }
 
-        var member = Member.builder()
-                .id(memberId)
-                .name(TEST_NAME)
-                .phoneNumber(TEST_PHONE_NUMBER)
-                .email(TEST_EMAIL)
-                .jobFamily(JobFamily.BE)
-                .role(Role.SEMESTER)
-                .semesterId(1L)
-                .build();
+        @Test
+        void 관리자용_회원_등록_실패_이미_존재하는_이메일() {
+                // given
+                var request = new MemberRegisterRequest(
+                                Role.SEMESTER,
+                                TEST_NAME,
+                                TEST_PHONE_NUMBER,
+                                TEST_EMAIL,
+                                JobFamily.BE,
+                                Region.SEOUL,
+                                "1");
 
-        var semester = Semester.builder()
-                .id(1L)
-                .name("1기")
-                .build();
+                given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(true);
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
+                // expected
+                assertThatThrownBy(() -> memberManagementService.registerMember(request))
+                                .isInstanceOf(MemberException.class)
+                                .extracting(e -> ((MemberException) e).getErrorCode())
+                                .isEqualTo(MemberErrorCode.ALREADY_EXIST_MEMBER);
 
-        // when
-        memberManagementService.editMember(memberId, request);
+                verify(memberRepository).existsByEmail(TEST_EMAIL);
+        }
 
-        // then
-        verify(memberRepository).findById(memberId);
-        assertThat(member.getName()).isEqualTo(request.name());
-        assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
-        assertThat(member.getEmail()).isEqualTo(request.email());
-        assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
-        assertThat(member.getSemesterId()).isEqualTo(semester.getId());
-    }
+        @Test
+        void 회원_정보_수정_성공() {
+                // given
+                var memberId = 1L;
+                var request = MemberEditRequest.builder()
+                                .role(Role.SEMESTER)
+                                .name("수정된이름")
+                                .phoneNumber("01087654321")
+                                .email("updated@test.com")
+                                .jobFamily(JobFamily.FE)
+                                .semesterName("1기")
+                                .build();
 
-    @Test
-    void 회원_정보_수정_실패_존재하지_않는_회원() {
-        // given
-        var memberId = 999L;
-        var request = MemberEditRequest.builder()
-                .role(Role.SEMESTER)
-                .name("수정된이름")
-                .phoneNumber("01087654321")
-                .email("updated@test.com")
-                .jobFamily(JobFamily.FE)
-                .semesterName("2")
-                .build();
+                var member = Member.builder()
+                                .id(memberId)
+                                .name(TEST_NAME)
+                                .phoneNumber(TEST_PHONE_NUMBER)
+                                .email(TEST_EMAIL)
+                                .jobFamily(JobFamily.BE)
+                                .role(Role.SEMESTER)
+                                .semesterId(1L)
+                                .build();
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+                var semester = Semester.builder()
+                                .id(1L)
+                                .name("1기")
+                                .build();
 
-        // expected
-        assertThatThrownBy(() -> memberManagementService.editMember(memberId, request))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+                var team = Team.builder()
+                                .id(1L)
+                                .name("미배정")
+                                .semesterId(1L)
+                                .build();
 
-        verify(memberRepository).findById(memberId);
-    }
+                var existingTeamMember = TeamMember.builder()
+                                .id(1L)
+                                .member(member)
+                                .team(team)
+                                .jobFamily(JobFamily.BE)
+                                .build();
 
-    @Test
-    void 단일_회원_삭제_성공() {
-        // given
-        var memberId = 1L;
-        var member = Member.builder()
-                .id(memberId)
-                .name(TEST_NAME)
-                .email(TEST_EMAIL)
-                .build();
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+                given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
+                given(teamMemberRepository.findByMemberIdAndTeamSemesterId(memberId, 1L))
+                                .willReturn(Optional.of(existingTeamMember));
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        doNothing().when(memberRepository).delete(member);
+                // when
+                memberManagementService.editMember(memberId, request);
 
-        // when
-        memberManagementService.deleteMember(memberId);
+                // then
+                verify(memberRepository).findById(memberId);
+                assertThat(member.getName()).isEqualTo(request.name());
+                assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
+                assertThat(member.getEmail()).isEqualTo(request.email());
+                assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
+                assertThat(member.getSemesterId()).isEqualTo(semester.getId());
+                assertThat(existingTeamMember.getJobFamily()).isEqualTo(JobFamily.FE);
+        }
 
-        // then
-        verify(memberRepository).findById(memberId);
-        verify(memberRepository).delete(member);
-    }
+        @Test
+        void 회원_정보_수정_실패_존재하지_않는_회원() {
+                // given
+                var memberId = 999L;
+                var request = MemberEditRequest.builder()
+                                .role(Role.SEMESTER)
+                                .name("수정된이름")
+                                .phoneNumber("01087654321")
+                                .email("updated@test.com")
+                                .jobFamily(JobFamily.FE)
+                                .semesterName("2")
+                                .build();
 
-    @Test
-    void 단일_회원_삭제_실패_존재하지_않는_회원() {
-        // given
-        var memberId = 999L;
+                given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+                // expected
+                assertThatThrownBy(() -> memberManagementService.editMember(memberId, request))
+                                .isInstanceOf(MemberException.class)
+                                .extracting(e -> ((MemberException) e).getErrorCode())
+                                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
 
-        // expected
-        assertThatThrownBy(() -> memberManagementService.deleteMember(memberId))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+                verify(memberRepository).findById(memberId);
+        }
 
-        verify(memberRepository).findById(memberId);
-    }
+        @Test
+        void 단일_회원_삭제_성공() {
+                // given
+                var memberId = 1L;
+                var member = Member.builder()
+                                .id(memberId)
+                                .name(TEST_NAME)
+                                .email(TEST_EMAIL)
+                                .build();
 
-    @Test
-    void 다중_회원_삭제_성공() {
-        // given
-        var memberIds = List.of(1L, 2L, 3L);
-        var members = List.of(
-                Member.builder().id(1L).name("가젝트").email("member1@test.com").build(),
-                Member.builder().id(2L).name("나젝트").email("member2@test.com").build(),
-                Member.builder().id(3L).name("다젝트").email("member3@test.com").build()
-        );
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+                doNothing().when(memberRepository).delete(member);
 
-        given(memberRepository.findAllById(memberIds)).willReturn(members);
-        doNothing().when(memberRepository).deleteAll(members);
+                // when
+                memberManagementService.deleteMember(memberId);
 
-        // when
-        memberManagementService.deleteMembers(memberIds);
+                // then
+                verify(memberRepository).findById(memberId);
+                verify(memberRepository).delete(member);
+        }
 
-        // then
-        verify(memberRepository).findAllById(memberIds);
-        verify(memberRepository).deleteAll(members);
-    }
+        @Test
+        void 단일_회원_삭제_실패_존재하지_않는_회원() {
+                // given
+                var memberId = 999L;
 
-    @Test
-    void 다중_회원_삭제_실패_일부_회원이_존재하지_않음() {
-        // given
-        var memberIds = List.of(1L, 2L, 999L); // 999L은 존재하지 않는 회원
-        var members = List.of(
-                Member.builder().id(1L).name("가젝트").email("member1@test.com").build(),
-                Member.builder().id(2L).name("나젝트").email("member2@test.com").build()
+                given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+                // expected
+                assertThatThrownBy(() -> memberManagementService.deleteMember(memberId))
+                                .isInstanceOf(MemberException.class)
+                                .extracting(e -> ((MemberException) e).getErrorCode())
+                                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+
+                verify(memberRepository).findById(memberId);
+        }
+
+        @Test
+        void 다중_회원_삭제_성공() {
+                // given
+                var memberIds = List.of(1L, 2L, 3L);
+                var members = List.of(
+                                Member.builder().id(1L).name("가젝트").email("member1@test.com").build(),
+                                Member.builder().id(2L).name("나젝트").email("member2@test.com").build(),
+                                Member.builder().id(3L).name("다젝트").email("member3@test.com").build());
+
+                given(memberRepository.findAllById(memberIds)).willReturn(members);
+                doNothing().when(memberRepository).deleteAll(members);
+
+                // when
+                memberManagementService.deleteMembers(memberIds);
+
+                // then
+                verify(memberRepository).findAllById(memberIds);
+                verify(memberRepository).deleteAll(members);
+        }
+
+        @Test
+        void 다중_회원_삭제_실패_일부_회원이_존재하지_않음() {
+                // given
+                var memberIds = List.of(1L, 2L, 999L); // 999L은 존재하지 않는 회원
+                var members = List.of(
+                                Member.builder().id(1L).name("가젝트").email("member1@test.com").build(),
+                                Member.builder().id(2L).name("나젝트").email("member2@test.com").build()
                 // 999L에 해당하는 회원은 없음
-        );
+                );
 
-        given(memberRepository.findAllById(memberIds)).willReturn(members);
+                given(memberRepository.findAllById(memberIds)).willReturn(members);
 
-        // expected
-        assertThatThrownBy(() -> memberManagementService.deleteMembers(memberIds))
-                .isInstanceOf(MemberException.class)
-                .extracting(e -> ((MemberException) e).getErrorCode())
-                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+                // expected
+                assertThatThrownBy(() -> memberManagementService.deleteMembers(memberIds))
+                                .isInstanceOf(MemberException.class)
+                                .extracting(e -> ((MemberException) e).getErrorCode())
+                                .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
 
-        verify(memberRepository).findAllById(memberIds);
-    }
+                verify(memberRepository).findAllById(memberIds);
+        }
 
-    @Test
-    void 다중_회원_삭제_실패_빈_목록() {
-        // given
-        List<Long> emptyMemberIds = List.of();
-        List<Member> emptyMembers = List.of();
+        @Test
+        void 다중_회원_삭제_실패_빈_목록() {
+                // given
+                List<Long> emptyMemberIds = List.of();
+                List<Member> emptyMembers = List.of();
 
-        given(memberRepository.findAllById(emptyMemberIds)).willReturn(emptyMembers);
+                given(memberRepository.findAllById(emptyMemberIds)).willReturn(emptyMembers);
 
-        // when
-        memberManagementService.deleteMembers(emptyMemberIds);
+                // when
+                memberManagementService.deleteMembers(emptyMemberIds);
 
-        // then
-        verify(memberRepository).findAllById(emptyMemberIds);
-        verify(memberRepository).deleteAll(emptyMembers);
-    }
+                // then
+                verify(memberRepository).findAllById(emptyMemberIds);
+                verify(memberRepository).deleteAll(emptyMembers);
+        }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #427 

## 📝 작업 내용

Admin 패키지에서 `jobFamily` 정보를 `Member` 엔티티 대신 `TeamMember` 엔티티를 통해 관리하도록 수정했습니다.

- `TeamMember` 엔티티에 `jobFamily` 필드, `@Getter`, `updateJobFamily()` 추가
- `TeamMemberRepository` 클래스에 `findByMemberId()`, `findByMemberIdAndTeamSemesterId()` 메서드 추가
- `TeamRepository`: 클래스에 `findByNameAndSemesterId()` 메서드 추가
- `MemberDetailResponse.toResponse()`에 `JobFamily` 파라미터 추가 (TeamMember에서 조회)
- `findMemberDetail()`를 TeamMember에서 최신 기수의 jobFamily 조회하게 수정
- `registerMember()`에서 Member 저장 후 TeamMember(미배정 팀)도 생성하게 수정
- `editMember()`에서 TeamMember의 jobFamily도 업데이트하도록 수정 (없으면 새로 생성)
- `MemberQueryRepositoryImpl.findMembers()`: `member.jobFamily` → `teamMember.jobFamily` JOIN 기반 변경

## 🙏 리뷰 요청 사항

- `Member`의 `semesterId`, `jobFamily` 필드는 다른 패키지(apply 등)의 하위 호환성을 위해 제거하지 않았습니다.
- 전체 제거는 관련 패키지 리팩토링 완료 후 별도 이슈에서 진행 예정입니다.
- 팀 배정 방식에 대해서도 정의가 필요합니다.
- 멤버 생성할 때 팀 미배정에 대해 어떻게 할 지 정의가 필요합니다.
- 추후 추가될 운영진, 메이커스 멤버 모집에 대한 확장성도 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 팀 기반으로 멤버의 직무(잡패밀리) 관리 도입 및 멤버 상세/등록/편집 흐름에 반영
  * 멤버 상세 조회 시 팀 소속 기준 학기 연동 처리 추가

* **Chores**
  * 미할당 팀 자동 생성 및 팀-멤버 연동 로직 추가
  * 팀멤버용 직무 컬럼 추가를 포함한 DB 마이그레이션 적용

* **Tests**
  * 팀 관련 시나리오 및 연동 검증 테스트 대폭 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->