### PR TITLE
feat: 다직군/다기수 지원을 위한 TeamMember 기반 리팩토링

### DIFF
--- a/.github/workflows/continuous-intergration.yml
+++ b/.github/workflows/continuous-intergration.yml
@@ -68,8 +68,8 @@ jobs:
           title: "📊테스트 커버리지"
           paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 10
-          min-coverage-changed-files: 10
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           update-comment: true
 
       - name: Get the Coverage info

--- a/build.gradle
+++ b/build.gradle
@@ -186,7 +186,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = "LINE" // 라인 커버리지
                 value = "COVEREDRATIO"
-                minimum = 0.10  // 최소 10% 이상 만족 (CI 통과를 위해 임시 하향)
+                minimum = 0.70
             }
 
             excludes = jacocoExcludes

--- a/src/main/java/org/ject/support/SupportApplication.java
+++ b/src/main/java/org/ject/support/SupportApplication.java
@@ -13,7 +13,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class SupportApplication {
-    // 테스트 주석: CI/CD 파이프라인 동작 확인용
     public static void main(String[] args) {
         SpringApplication.run(SupportApplication.class, args);
     }

--- a/src/main/java/org/ject/support/domain/admin/service/MemberManagementService.java
+++ b/src/main/java/org/ject/support/domain/admin/service/MemberManagementService.java
@@ -13,9 +13,11 @@ import org.ject.support.domain.admin.dto.MemberResponse;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.entity.MemberEditor;
 import org.ject.support.domain.member.entity.MemberEditor.MemberEditorBuilder;
+import org.ject.support.domain.member.entity.TeamMember;
 import org.ject.support.domain.member.exception.MemberErrorCode;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.member.repository.TeamMemberRepository;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
 import org.springframework.data.domain.Page;
@@ -29,6 +31,7 @@ public class MemberManagementService {
 
     private final MemberRepository memberRepository;
     private final SemesterRepository semesterRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
     @Transactional(readOnly = true)
     public Page<MemberResponse> findMembers(
@@ -89,6 +92,21 @@ public class MemberManagementService {
                 .build();
 
         member.edit(editor);
+
+        // TeamMember.jobFamily 동기화 (프로젝트 조회 일관성 유지)
+        if (request.jobFamily() != null) {
+            syncTeamMemberJobFamily(memberId, request.jobFamily());
+        }
+    }
+
+    /**
+     * 멤버의 직군 변경 시 해당 멤버가 속한 모든 TeamMember의 jobFamily를 동기화합니다.
+     * 단, 향후 기수별 직군 분리가 완료되면 이 로직은 제거될 수 있습니다.
+     */
+    @Deprecated
+    private void syncTeamMemberJobFamily(final Long memberId, final JobFamily jobFamily) {
+        List<TeamMember> teamMembers = teamMemberRepository.findByMemberId(memberId);
+        teamMembers.forEach(teamMember -> teamMember.updateJobFamily(jobFamily));
     }
 
     @Transactional

--- a/src/main/java/org/ject/support/domain/member/entity/TeamMember.java
+++ b/src/main/java/org/ject/support/domain/member/entity/TeamMember.java
@@ -40,4 +40,8 @@ public class TeamMember extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(45)")
     private JobFamily jobFamily;
+
+    public void updateJobFamily(JobFamily jobFamily) {
+        this.jobFamily = jobFamily;
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/entity/TeamMember.java
+++ b/src/main/java/org/ject/support/domain/member/entity/TeamMember.java
@@ -1,6 +1,9 @@
 package org.ject.support.domain.member.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -10,10 +13,13 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.ject.support.domain.base.BaseTimeEntity;
+import org.ject.support.domain.member.JobFamily;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,4 +36,8 @@ public class TeamMember extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)
     private Team team;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(45)")
+    private JobFamily jobFamily;
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
@@ -43,19 +43,23 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
                         member.isDeleted.eq(false))
                 .transform(GroupBy.groupBy(teamMember.team.id).as(new QTeamMemberNames(
                         GroupBy.list(new CaseBuilder()
-                                .when(member.jobFamily.eq(PM))
+                                .when(teamMember.jobFamily.eq(PM)
+                                        .or(teamMember.jobFamily.isNull().and(member.jobFamily.eq(PM))))
                                 .then(member.name)
                                 .otherwise((String) null)),
                         GroupBy.list(new CaseBuilder()
-                                .when(member.jobFamily.eq(PD))
+                                .when(teamMember.jobFamily.eq(PD)
+                                        .or(teamMember.jobFamily.isNull().and(member.jobFamily.eq(PD))))
                                 .then(member.name)
                                 .otherwise((String) null)),
                         GroupBy.list(new CaseBuilder()
-                                .when(member.jobFamily.eq(FE))
+                                .when(teamMember.jobFamily.eq(FE)
+                                        .or(teamMember.jobFamily.isNull().and(member.jobFamily.eq(FE))))
                                 .then(member.name)
                                 .otherwise((String) null)),
                         GroupBy.list(new CaseBuilder()
-                                .when(member.jobFamily.eq(BE))
+                                .when(teamMember.jobFamily.eq(BE)
+                                        .or(teamMember.jobFamily.isNull().and(member.jobFamily.eq(BE))))
                                 .then(member.name)
                                 .otherwise((String) null))
                 ))).get(teamId);

--- a/src/main/java/org/ject/support/domain/member/repository/TeamMemberRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/TeamMemberRepository.java
@@ -3,5 +3,8 @@ package org.ject.support.domain.member.repository;
 import org.ject.support.domain.member.entity.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+    List<TeamMember> findByMemberId(Long memberId);
 }

--- a/src/main/resources/db/migration/V18__add_job_family_to_team_member.sql
+++ b/src/main/resources/db/migration/V18__add_job_family_to_team_member.sql
@@ -1,0 +1,3 @@
+-- team_member 테이블에 job_family 컬럼 추가
+ALTER TABLE team_member ADD COLUMN job_family VARCHAR(45) NULL;
+

--- a/src/main/resources/db/migration/V19__populate_team_member_job_family.sql
+++ b/src/main/resources/db/migration/V19__populate_team_member_job_family.sql
@@ -1,0 +1,5 @@
+-- 기존 member.job_family 데이터를 team_member.job_family로 마이그레이션
+UPDATE team_member tm
+JOIN member m ON tm.member_id = m.id
+SET tm.job_family = m.job_family
+WHERE tm.job_family IS NULL AND m.job_family IS NOT NULL;

--- a/src/test/java/org/ject/support/domain/admin/service/MemberManagementServiceTest.java
+++ b/src/test/java/org/ject/support/domain/admin/service/MemberManagementServiceTest.java
@@ -17,9 +17,11 @@ import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.entity.TeamMember;
 import org.ject.support.domain.member.exception.MemberErrorCode;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.member.repository.TeamMemberRepository;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
 import org.junit.jupiter.api.Test;
@@ -38,6 +40,9 @@ class MemberManagementServiceTest extends UnitTestSupport {
 
     @Mock
     private SemesterRepository semesterRepository;
+
+    @Mock
+    private TeamMemberRepository teamMemberRepository;
 
     private final String TEST_NAME = "홍길동";
     private final String TEST_EMAIL = "test@example.com";
@@ -280,17 +285,73 @@ class MemberManagementServiceTest extends UnitTestSupport {
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
         given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
+        given(teamMemberRepository.findByMemberId(memberId)).willReturn(List.of());
 
         // when
         memberManagementService.editMember(memberId, request);
 
         // then
         verify(memberRepository).findById(memberId);
+        verify(teamMemberRepository).findByMemberId(memberId);
         assertThat(member.getName()).isEqualTo(request.name());
         assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
         assertThat(member.getEmail()).isEqualTo(request.email());
         assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
         assertThat(member.getSemesterId()).isEqualTo(semester.getId());
+    }
+
+    @Test
+    void 회원_정보_수정_시_TeamMember_jobFamily_동기화() {
+        // given
+        var memberId = 1L;
+        var request = MemberEditRequest.builder()
+                .role(Role.SEMESTER)
+                .name("수정된이름")
+                .phoneNumber("01087654321")
+                .email("updated@test.com")
+                .jobFamily(JobFamily.PM)  // BE -> PM으로 변경
+                .semesterName("1기")
+                .build();
+
+        var member = Member.builder()
+                .id(memberId)
+                .name(TEST_NAME)
+                .phoneNumber(TEST_PHONE_NUMBER)
+                .email(TEST_EMAIL)
+                .jobFamily(JobFamily.BE)
+                .role(Role.SEMESTER)
+                .semesterId(1L)
+                .build();
+
+        var semester = Semester.builder()
+                .id(1L)
+                .name("1기")
+                .build();
+
+        // 해당 멤버가 속한 TeamMember 목록
+        var teamMember1 = TeamMember.builder()
+                .id(1L)
+                .member(member)
+                .jobFamily(JobFamily.BE)
+                .build();
+        var teamMember2 = TeamMember.builder()
+                .id(2L)
+                .member(member)
+                .jobFamily(JobFamily.BE)
+                .build();
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(semesterRepository.findByName("1기")).willReturn(Optional.of(semester));
+        given(teamMemberRepository.findByMemberId(memberId)).willReturn(List.of(teamMember1, teamMember2));
+
+        // when
+        memberManagementService.editMember(memberId, request);
+
+        // then
+        verify(teamMemberRepository).findByMemberId(memberId);
+        // TeamMember의 jobFamily도 PM으로 변경되어야 함
+        assertThat(teamMember1.getJobFamily()).isEqualTo(JobFamily.PM);
+        assertThat(teamMember2.getJobFamily()).isEqualTo(JobFamily.PM);
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
@@ -120,7 +120,7 @@ class MemberQueryRepositoryTest {
         // then
         // 2기 팀에서는 PM으로 조회
         assertThat(team2ndMemberNames.productManagers()).hasSize(1);
-        assertThat(team2ndMemberNames.productManagers()).contains("ject");
+        assertThat(team2ndMemberNames.productManagers()).contains("김젝트");
         assertThat(team2ndMemberNames.backendDevelopers()).isEmpty();
 
         // when

--- a/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
@@ -129,7 +129,7 @@ class MemberQueryRepositoryTest {
 
         // then
         // 1기 팀에서는 BE로 조회되어야 함
-        assertThat(teamAMemberNames.backendDevelopers()).contains("ject");
+        assertThat(teamAMemberNames.backendDevelopers()).contains("김젝트");
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
@@ -76,10 +76,11 @@ class MemberQueryRepositoryTest {
         be2 = createMember("왕젝트", "01011112226", "be2Email", BE);
         memberRepository.saveAll(List.of(pd1, fe1, be1, be2));
 
-        teamApd1 = createTeamMember(teamA, pd1);
-        teamAfe1 = createTeamMember(teamA, fe1);
-        teamAbe1 = createTeamMember(teamA, be1);
-        teamAbe2 = createTeamMember(teamA, be2);
+        // TeamMember 생성 시 해당 팀에서의 jobFamily 설정
+        teamApd1 = createTeamMember(teamA, pd1, PD);
+        teamAfe1 = createTeamMember(teamA, fe1, FE);
+        teamAbe1 = createTeamMember(teamA, be1, BE);
+        teamAbe2 = createTeamMember(teamA, be2, BE);
         teamMemberRepository.saveAll(List.of(teamApd1, teamAfe1, teamAbe1, teamAbe2));
     }
 
@@ -93,6 +94,60 @@ class MemberQueryRepositoryTest {
         assertThat(teamMemberNames.productDesigners()).hasSize(1);
         assertThat(teamMemberNames.frontendDevelopers()).hasSize(1);
         assertThat(teamMemberNames.backendDevelopers()).hasSize(2);
+    }
+
+    @Test
+    void TeamMember_jobFamily_기반_직군별_팀원_이름_조회() {
+        // given
+        // 1기에는 BE로, 2기에는 PM으로 활동
+        // 1기 팀 (teamA는 setUp에서 생성됨, semesterId=1)
+        // 2기 팀 생성
+        Team otherTeam = teamRepository.save(Team.builder().name("otherTeam").semesterId(2L).build());
+
+        // Member.jobFamily는 점진적 적용으로 유지되는 값
+        Member member = memberRepository.save(createMember("김젝트", "01099998888", "ject@test.com", BE));
+
+        // 1기 팀A에서는 BE로 참여
+        teamMemberRepository.save(createTeamMember(teamA, member, BE));
+
+        // 2기 팀에서는 PM으로 참여
+        teamMemberRepository.save(createTeamMember(otherTeam, member, PM));
+
+        // when
+        // 2기 팀 조회
+        TeamMemberNames team2ndMemberNames = memberRepository.findMemberNamesByTeamId(otherTeam.getId());
+
+        // then
+        // 2기 팀에서는 PM으로 조회
+        assertThat(team2ndMemberNames.productManagers()).hasSize(1);
+        assertThat(team2ndMemberNames.productManagers()).contains("ject");
+        assertThat(team2ndMemberNames.backendDevelopers()).isEmpty();
+
+        // when
+        // 1기 팀 조회
+        TeamMemberNames teamAMemberNames = memberRepository.findMemberNamesByTeamId(teamA.getId());
+
+        // then
+        // 1기 팀에서는 BE로 조회되어야 함
+        assertThat(teamAMemberNames.backendDevelopers()).contains("ject");
+    }
+
+    @Test
+    void TeamMember_jobFamily가_null이면_Member_jobFamily로_fallback() {
+        // given - TeamMember.jobFamily가 null인 경우 (기존 데이터 호환성)
+        Team teamC = teamRepository.save(createTeam("teamC"));
+
+        Member fallbackMember = memberRepository.save(createMember("폴백", "01088887777", "fallback@test.com", FE));
+
+        // TeamMember에 jobFamily를 설정하지 않음 (null)
+        TeamMember teamCMember = teamMemberRepository.save(createTeamMember(teamC, fallbackMember));
+
+        // when
+        TeamMemberNames teamMemberNames = memberRepository.findMemberNamesByTeamId(teamC.getId());
+
+        // then - Member.jobFamily 기준으로 FE에 속해야 함
+        assertThat(teamMemberNames.frontendDevelopers()).hasSize(1);
+        assertThat(teamMemberNames.frontendDevelopers()).contains("폴백");
     }
 
     @Test
@@ -340,6 +395,14 @@ class MemberQueryRepositoryTest {
         return TeamMember.builder()
                 .team(team)
                 .member(member)
+                .build();
+    }
+
+    private TeamMember createTeamMember(Team team, Member member, JobFamily jobFamily) {
+        return TeamMember.builder()
+                .team(team)
+                .member(member)
+                .jobFamily(jobFamily)
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #427

## 📝 작업 내용

### 기능 추가
- `TeamMember` 엔티티에 `jobFamily` 필드 추가
- 프로젝트 조회 시 `TeamMember.jobFamily` 기준으로 멤버 직군 표시
- `TeamMember.jobFamily`가 null인 경우 `Member.jobFamily`로 fallback
- 멤버 정보 수정 시 `TeamMember.jobFamily` 동기화 로직 추가

### DB 마이그레이션
- `V18__add_job_family_to_team_member.sql`: team_member 테이블에 job_family 컬럼 추가
- `V19__populate_team_member_job_family.sql`: 기존 데이터 마이그레이션

### CI 설정
- 테스트 커버리지 최소 기준 복구 (10% → 70%)

### 테스트
- `TeamMember_jobFamily_기반_직군별_팀원_이름_조회` 테스트 추가
- `TeamMember_jobFamily가_null이면_Member_jobFamily로_fallback` 테스트 추가
- `회원_정보_수정_시_TeamMember_jobFamily_동기화` 테스트 추가

## 📌 참고 사항

### 도메인 구조
```
Semester (기수) → Team (팀) → TeamMember (팀원) → Member (사람)
                    ↓
                 Project (프로젝트)
```

### 점진적 적용 전략
- `Member.jobFamily`, `Member.semesterId`는 **유지** (기존 로직 영향 없음)
- 프로젝트 조회에서만 `TeamMember.jobFamily` 우선 사용
- 향후 팀 관리 기능 완성 후 Phase 2, 3 진행 예정

### 데이터 일관성 유지
- 백오피스에서 `Member.jobFamily` 수정 시 → 해당 멤버의 **모든** `TeamMember.jobFamily`가 동기화됨
- 이는 현재 점진적 적용 기간 동안의 임시 조치이며, 향후 기수별 직군 분리가 완료되면 제거 예정 (`@Deprecated` 표시됨)

### 지원 흐름과 팀 조회 흐름의 분리
| 상황 | 기수/직군 파악 방법 |
|------|-------------------|
| **지원 시** | `Apply` → `Recruit.semester` (기수) / `Recruit.jobFamily` (직군) |
| **프로젝트 조회 시** | `Team.semesterId` (기수) / `TeamMember.jobFamily` (직군) |

### Team/TeamMember CRUD 미구현
- 현재 `Team`, `TeamMember`를 생성/관리하는 서비스 로직이 **없음**
- 향후 팀 관리 기능 구현 시 `TeamMember.jobFamily` 설정 로직 필요