### PR TITLE
feat: 지원상태 확인 API 수정

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
@@ -42,12 +42,13 @@ public interface ApplyApiSpec {
     @Operation(
             summary = "지원 상태 확인",
             description = """
-                    지원자의 지원서 제출 여부를 확인합니다.
+                    지원자의 특정 공고에 대한 지원서 제출 여부를 확인합니다.
                     - JOINED: 프로필을 저장한 경우
                     - TEMP_SAVED: 작성 중인 지원서가 있는 경우
                     - SUBMITTED: 이미 지원서를 제출한 경우
                     """)
-    ApplyStatusResponse checkApplyStatus(@AuthPrincipal Long memberId);
+    ApplyStatusResponse checkApplyStatus(@AuthPrincipal Long memberId,
+                                         @RequestParam Long recruitId);
 
     @Operation(
             summary = "프로필 작성(저장)",

--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
@@ -59,8 +59,9 @@ public class ApplyController implements ApplyApiSpec {
     @Override
     @GetMapping("/status")
     @PreAuthorize("hasRole('ROLE_APPLY')")
-    public ApplyStatusResponse checkApplyStatus(@AuthPrincipal Long memberId) {
-        return applyUsecase.checkApplyStatus(memberId);
+    public ApplyStatusResponse checkApplyStatus(@AuthPrincipal Long memberId,
+                                                @RequestParam Long recruitId) {
+        return applyUsecase.checkApplyStatus(memberId, recruitId);
     }
 
     @Override

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -20,6 +20,11 @@ public interface ApplyRepository extends JpaRepository<Apply, Long>, ApplyQueryR
     @Query("select a from Apply a join a.recruit r where a.member.id = :memberId and r.startDate <= :now and r.endDate >= :now")
     Optional<Apply> findByMemberIdInActiveRecruit(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
 
+    @Query("select a from Apply a join a.recruit r where a.member.id = :memberId and r.id = :recruitId and r.startDate <= :now and r.endDate >= :now")
+    Optional<Apply> findByMemberIdAndRecruitIdInActiveRecruit(@Param("memberId") Long memberId,
+                                                               @Param("recruitId") Long recruitId,
+                                                               @Param("now") LocalDateTime now);
+
     @Query("select count(a) > 0 from Apply a join a.recruit r where a.member.id = :memberId and r.startDate <= :now and r.endDate >= :now")
     boolean existsByMemberIdInActiveRecruit(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
 

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -170,11 +170,11 @@ public class ApplyService implements ApplyUsecase {
 
     @Override
     @PeriodAccessible(permitAllJob = true)
-    public ApplyStatusResponse checkApplyStatus(Long memberId) {
+    public ApplyStatusResponse checkApplyStatus(Long memberId, Long recruitId) {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-        return applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
+        return applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(memberId, recruitId, LocalDateTime.now())
                 .map(ApplyStatusResponse::of)
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
     }

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
@@ -24,7 +24,7 @@ public interface ApplyUsecase {
                            Map<String, String> answers,
                            List<ApplyPortfolioDto> portfolios);
 
-    ApplyStatusResponse checkApplyStatus(Long memberId);
+    ApplyStatusResponse checkApplyStatus(Long memberId, Long recruitId);
 
     void saveProfile(Long memberId, ApplyProfileRequest request);
 }

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -198,6 +198,7 @@ class ApplyServiceTest extends UnitTestSupport {
     @Test
     void 지원상태_조회_시_프로필작성을_하지_않았을_경우_예외발생() {
         // given
+        Long recruitId = 1L;
         Member member = Member.builder()
                 .id(1L)
                 .name("지원자명")
@@ -205,11 +206,11 @@ class ApplyServiceTest extends UnitTestSupport {
                 .build();
         given(memberRepository.findById(member.getId()))
                 .willReturn(Optional.of(member));
-        given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
+        given(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(member.getId()), eq(recruitId), any()))
                 .willReturn(Optional.empty());
 
         // expected
-        assertThatThrownBy(() -> applyService.checkApplyStatus(member.getId()))
+        assertThatThrownBy(() -> applyService.checkApplyStatus(member.getId(), recruitId))
                 .isInstanceOf(ApplyException.class)
                 .extracting("errorCode")
                 .isEqualTo(ApplyErrorCode.NOT_FOUND_APPLY);
@@ -218,6 +219,7 @@ class ApplyServiceTest extends UnitTestSupport {
     @Test
     void 작성_중인_지원서가_있는_경우_TEMP_SAVED_반환() {
         // given
+        Long recruitId = 1L;
         Member member = Member.builder()
                 .id(1L)
                 .name("지원자명")
@@ -225,7 +227,7 @@ class ApplyServiceTest extends UnitTestSupport {
                 .build();
         given(memberRepository.findById(member.getId()))
                 .willReturn(Optional.of(member));
-        given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
+        given(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(member.getId()), eq(recruitId), any()))
                 .willReturn(Optional.of(
                         Apply.builder()
                                 .id(1L)
@@ -234,7 +236,7 @@ class ApplyServiceTest extends UnitTestSupport {
                 ));
 
         // when
-        ApplyStatusResponse result = applyService.checkApplyStatus(member.getId());
+        ApplyStatusResponse result = applyService.checkApplyStatus(member.getId(), recruitId);
 
         // then
         assertThat(result.status()).isEqualTo(TEMP_SAVED);
@@ -243,6 +245,7 @@ class ApplyServiceTest extends UnitTestSupport {
     @Test
     void 지원서를_제출한_지원자에_대한_제출_상태_확인_시_SUBMITTED_반환() {
         // given
+        Long recruitId = 1L;
         Member member = Member.builder()
                 .id(1L)
                 .name("지원자명")
@@ -250,7 +253,7 @@ class ApplyServiceTest extends UnitTestSupport {
                 .build();
         given(memberRepository.findById(member.getId()))
                 .willReturn(Optional.of(member));
-        given(applyRepository.findByMemberIdInActiveRecruit(eq(member.getId()), any()))
+        given(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(member.getId()), eq(recruitId), any()))
                 .willReturn(Optional.of(
                         Apply.builder()
                                 .id(1L)
@@ -259,10 +262,31 @@ class ApplyServiceTest extends UnitTestSupport {
                 ));
 
         // when
-        ApplyStatusResponse result = applyService.checkApplyStatus(member.getId());
+        ApplyStatusResponse result = applyService.checkApplyStatus(member.getId(), recruitId);
 
         // then
         assertThat(result.status()).isEqualTo(SUBMITTED);
+    }
+
+    @Test
+    void 동일_회원이라도_다른_공고ID로_조회하면_지원상태_조회_실패() {
+        // given
+        Long requestedRecruitId = 2L;
+        Member member = Member.builder()
+                .id(1L)
+                .name("지원자명")
+                .phoneNumber("01012345678")
+                .build();
+        given(memberRepository.findById(member.getId()))
+                .willReturn(Optional.of(member));
+        given(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(member.getId()), eq(requestedRecruitId), any()))
+                .willReturn(Optional.empty());
+
+        // expected
+        assertThatThrownBy(() -> applyService.checkApplyStatus(member.getId(), requestedRecruitId))
+                .isInstanceOf(ApplyException.class)
+                .extracting("errorCode")
+                .isEqualTo(ApplyErrorCode.NOT_FOUND_APPLY);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

close #446 

### 📝 작업 내용
  - GET /apply/status 요청 파라미터에 `recruitId` 추가
  - ApplyController, ApplyApiSpec 수정
  - ApplyRepository 에 `memberId + recruitId (+ active 기간)` 조회 메서드 추가
  - 상태 조회 실패 시 기존 예외 처리(`NOT_FOUND_APPLY`) 은 그대로 유지
  - ApplyServiceTest 관련 테스트 수정 및 케이스 추가
    - 기존 status 조회 테스트 시그니처 변경
    - 다른 recruitId 조회 시 실패 케이스 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 지원 상태 조회 시 특정 채용 공고 ID가 필수 입력값으로 추가되었습니다.
  * 각 공고별로 더 정확한 지원 상태 확인이 가능해졌습니다.
  * 활성 채용 기간 내의 지원 정보만 조회됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->