### PR TITLE
feat: 지원서 상세 조회 기능 추가

### DIFF
--- a/src/main/java/org/ject/support/admin/apply/dto/SubmittedApplyDetailResponse.java
+++ b/src/main/java/org/ject/support/admin/apply/dto/SubmittedApplyDetailResponse.java
@@ -21,8 +21,8 @@ public record SubmittedApplyDetailResponse(
         String experiencePeriod,
         List<String> interestedDomains,
         String createdAt,
-        String updatedAt,
-        ApplicationFormResponse applicationFormResponse
+        String updatedAt
+        // ApplicationFormResponse applicationFormResponse
 ) {
     public static SubmittedApplyDetailResponse from(Apply apply,
                                                     Map<String, String> answers,
@@ -46,8 +46,8 @@ public record SubmittedApplyDetailResponse(
                         .orElse(""),
                 apply.getMember().getInterestedDomains() == null ? List.of() : apply.getMember().getInterestedDomains(),
                 DateTimeUtil.formatWithDayOfWeek(apply.getCreatedAt()),
-                DateTimeUtil.formatWithDayOfWeek(apply.getUpdatedAt()),
-                ApplicationFormResponse.from(answers, portfolios)
+                DateTimeUtil.formatWithDayOfWeek(apply.getUpdatedAt())
+                // ApplicationFormResponse.from(answers, portfolios)
         );
     }
 }

--- a/src/main/java/org/ject/support/admin/apply/dto/SubmittedApplyDetailResponse.java
+++ b/src/main/java/org/ject/support/admin/apply/dto/SubmittedApplyDetailResponse.java
@@ -2,6 +2,7 @@ package org.ject.support.admin.apply.dto;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.ject.support.common.util.DateTimeUtil;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
@@ -13,6 +14,12 @@ public record SubmittedApplyDetailResponse(
         String phoneNumber,
         String email,
         JobFamily jobFamily,
+        String careerDetails,
+        String recruitType,
+        String note,
+        String region,
+        String experiencePeriod,
+        List<String> interestedDomains,
         String createdAt,
         String updatedAt,
         ApplicationFormResponse applicationFormResponse
@@ -26,6 +33,18 @@ public record SubmittedApplyDetailResponse(
                 apply.getMember().getPhoneNumber(),
                 apply.getMember().getEmail(),
                 apply.getMember().getJobFamily(),
+                Optional.ofNullable(apply.getMember().getCareerDetails())
+                        .map(org.ject.support.domain.member.CareerDetails::getDescription)
+                        .orElse(""),
+                apply.getRecruit().getRecruitType().name(),
+                apply.getNote(),
+                Optional.ofNullable(apply.getMember().getRegion())
+                        .map(org.ject.support.domain.member.Region::getDescription)
+                        .orElse(""),
+                Optional.ofNullable(apply.getMember().getExperiencePeriod())
+                        .map(org.ject.support.domain.member.ExperiencePeriod::getDescription)
+                        .orElse(""),
+                apply.getMember().getInterestedDomains() == null ? List.of() : apply.getMember().getInterestedDomains(),
                 DateTimeUtil.formatWithDayOfWeek(apply.getCreatedAt()),
                 DateTimeUtil.formatWithDayOfWeek(apply.getUpdatedAt()),
                 ApplicationFormResponse.from(answers, portfolios)

--- a/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
@@ -65,6 +65,13 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         var applyId = 1L;
         var member = Member.builder()
                 .name("김젝트")
+                .phoneNumber("010-1234-5678")
+                .email("test@mail.com")
+                .jobFamily(JobFamily.BE)
+                .careerDetails(org.ject.support.domain.member.CareerDetails.STUDENT)
+                .region(org.ject.support.domain.member.Region.SEOUL)
+                .experiencePeriod(org.ject.support.domain.member.ExperiencePeriod.NONE)
+                .interestedDomains(new java.util.ArrayList<>(List.of("AI", "Backend")))
                 .build();
         var semester = Semester.builder()
                 .name("1")
@@ -80,6 +87,7 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         var recruit = Recruit.builder()
                 .semester(semester)
                 .questions(List.of(question1, question2))
+                .recruitType(org.ject.support.domain.recruit.domain.RecruitType.REGULAR)
                 .build();
 
         submittedApply = Apply.builder()
@@ -87,6 +95,7 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
                 .member(member)
                 .recruit(recruit)
                 .status(Apply.Status.SUBMITTED)
+                .note("Test note")
                 .applicationForm(ApplicationForm.builder().build())
                 .build();
     }
@@ -391,6 +400,16 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
                 Status.SUBMITTED
         );
         assertThat(actual.applyId()).isEqualTo(submittedApply.getId());
+        assertThat(actual.name()).isEqualTo("김젝트");
+        assertThat(actual.phoneNumber()).isEqualTo("010-1234-5678");
+        assertThat(actual.email()).isEqualTo("test@mail.com");
+        assertThat(actual.jobFamily()).isEqualTo(JobFamily.BE);
+        assertThat(actual.careerDetails()).isEqualTo("대학생(재학/휴학)");
+        assertThat(actual.region()).isEqualTo("서울");
+        assertThat(actual.experiencePeriod()).isEqualTo("경험 없음");
+        assertThat(actual.interestedDomains()).containsExactly("AI", "Backend");
+        assertThat(actual.recruitType()).isEqualTo("REGULAR");
+        assertThat(actual.note()).isEqualTo("Test note");
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
@@ -379,8 +379,8 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         var actual = submittedApplyService.findSubmittedApplyDetail(applyId);
         // expected
         assertThat(actual.applyId()).isEqualTo(applyId);
-        assertThat(actual.applicationFormResponse().answers()).isEmpty();  // 빈 Map 확인
-        assertThat(actual.applicationFormResponse().portfolios()).isEmpty();
+        // assertThat(actual.applicationFormResponse().answers()).isEmpty();  // 빈 Map 확인
+        // assertThat(actual.applicationFormResponse().portfolios()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

close #454

## 📝 작업 내용

이슈 #454 [FUNC_APL_MGT_02] 제출 완료된 지원서 상세 조회 기능 구현 이슈 처리를 완료했습니다.

### 기능 요구사항 구현
- `SubmittedApplyDetailResponse` DTO에 세부 조회 시 필요한 추가 필드 정의 
 - 기존 필드: 이름, 전화번호, 포지션, 포트폴리오(주석처리)
 - `careerDetails`: 지원자 신분
 - `recruitType`: 모집 단위
 - `note`: 비고
 - `region`: 거주 지역
 - `experiencePeriod`: 직무 관련 경험
 - `interestedDomains`: 관심 도메인
- 신규 필드 맵핑 검증을 위한 `SubmittedApplyServiceTest` 단위 테스트 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 지원서 상세정보 조회 응답에 경력 상세정보, 채용 유형, 메모, 지역, 경력 기간, 관심 분야를 추가
* **테스트**
  * 제출 조회 관련 테스트들이 확장된 필드(전화번호, 이메일, 직무군, 경력 상세, 지역, 경력 기간, 관심 분야, 채용 유형, 메모)를 검증하도록 업데이트됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->