### PR TITLE
chore: VPC 내부망 통신을 위한 Redis SSL 설정 제거

### DIFF
--- a/src/main/java/org/ject/support/common/data/redis/RedisConnectionConfig.java
+++ b/src/main/java/org/ject/support/common/data/redis/RedisConnectionConfig.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
 @Configuration
@@ -39,11 +38,6 @@ public class RedisConnectionConfig {
             return new LettuceConnectionFactory(redisConfig);
         }
 
-        LettuceClientConfiguration clientConfig =
-                LettuceClientConfiguration.builder()
-                        .useSsl()
-                        .build();
-
-        return new LettuceConnectionFactory(redisConfig, clientConfig);
+        return new LettuceConnectionFactory(redisConfig);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #442

## 📝 작업 내용

- 프리티어가 만료됨에 따른 클라우드 지출 비용 증가로 상대적으로 저렴한 EC2로 마이그레이션 작업 진행
- 운영 환경(EC2)은 VPC 내부망 통신이므로 SSL이 불필요
- ElastiCache가 SSL 없이 실행 중인 상태에서 SSL 핸드셰이크를 시도하면
연결이 거부되는 문제가 발생하여 평문 연결로 전환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이번 업데이트는 내부 인프라 코드 최적화에 집중되어 있습니다.

* **리팩토링**
  * Redis 연결 구성을 간소화하여 코드 복잡성을 감소시켰습니다.

사용자에게 직접적인 영향을 미치는 변경사항은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->