### PR TITLE
refactor: 제출 완료된 지원서 삭제 로직 품질 개선

### DIFF
--- a/src/main/java/org/ject/support/admin/apply/controller/SubmittedApplyController.java
+++ b/src/main/java/org/ject/support/admin/apply/controller/SubmittedApplyController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.apply.dto.SubmittedApplyBulkDeleteRequest;
 import org.ject.support.admin.apply.dto.SubmittedApplyCountResponse;
+import org.ject.support.admin.apply.dto.SubmittedApplyCountResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyDetailResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.dto.SubmittedApplyResponse;

--- a/src/main/java/org/ject/support/admin/apply/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/SubmittedApplyService.java
@@ -50,7 +50,7 @@ public class SubmittedApplyService {
         Page<Apply> applyPage = adminApplyQueryRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, recruitType, pageable);
 
         List<SubmittedApplyResponse> content = applyPage.getContent().stream()
-                .map(this::toSubmittedApplyResponse)
+                .map(SubmittedApplyResponse::from)
                 .toList();
 
         return PageResponse.from(content, pageable, applyPage.getTotalElements());
@@ -74,7 +74,6 @@ public class SubmittedApplyService {
                                      final SubmittedApplyEditRequest request) {
         Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED)
                 .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
-        ensureSubmitted(apply);
 
         Member member = apply.getMember();
         MemberEditor memberEditor = member.toEditor()
@@ -103,7 +102,8 @@ public class SubmittedApplyService {
         Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED)
                 .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
 
-        deleteProfileAndApplicationForm(apply);
+        apply.deleteApplicationForm();
+        apply.getMember().deleteProfile();
     }
 
     @Transactional
@@ -115,20 +115,21 @@ public class SubmittedApplyService {
             throw new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY);
         }
 
-        applies.forEach(this::deleteProfileAndApplicationForm);
+        applies.forEach(apply -> {
+            apply.deleteApplicationForm();
+            apply.getMember().deleteProfile();
+        });
         return applies.size();
     }
 
     private SubmittedApplyDetailResponse toSubmittedApplyDetailResponse(final Apply apply) {
+        // 지원서가 없을 수가 있나? 그리고 그렇다고 하더라도
         ApplicationForm submittedApplicationForm = apply.getApplicationForm();
         Map<String, String> content = extractContent(submittedApplicationForm);
         List<ApplyPortfolioDto> portfolios = extractPortfolios(submittedApplicationForm);
         return SubmittedApplyDetailResponse.from(apply, content, portfolios);
     }
 
-    private SubmittedApplyResponse toSubmittedApplyResponse(final Apply apply) {
-        return SubmittedApplyResponse.from(apply);
-    }
 
     private Map<String, String> extractContent(final ApplicationForm applicationForm) {
         return Optional.ofNullable(applicationForm)
@@ -146,30 +147,13 @@ public class SubmittedApplyService {
                 .toList();
     }
 
-    private void ensureSubmitted(final Apply apply) {
-        if (apply.isNotSubmitted()) {
-            throw new ApplyException(ApplyErrorCode.NOT_FOUND_SUBMITTED_APPLICATION_FORM);
-        }
-    }
-
     private void validateQuestions(final Map<String, String> answers, final Recruit recruit) {
         answers.keySet().stream()
                 .map(Long::parseLong)
                 .filter(recruit::isInvalidQuestionId)
-                .forEach(key -> {
+                .findAny()
+                .ifPresent(key -> {
                     throw new QuestionException(QuestionErrorCode.NOT_FOUND_QUESTION);
                 });
-    }
-
-    private void deleteProfileAndApplicationForm(final Apply apply) {
-        // 제출된 지원서인지 검증
-        ensureSubmitted(apply);
-
-        //  제출된 지원서 제거
-        apply.deleteApplicationForm();
-
-        // 프로필 제거
-        Member applicant = apply.getMember();
-        applicant.deleteProfile();
     }
 }

--- a/src/main/java/org/ject/support/admin/apply/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/SubmittedApplyService.java
@@ -102,7 +102,7 @@ public class SubmittedApplyService {
         Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED)
                 .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
 
-        apply.deleteApplicationForm();
+        apply.reject();
         apply.getMember().deleteProfile();
     }
 
@@ -116,7 +116,7 @@ public class SubmittedApplyService {
         }
 
         applies.forEach(apply -> {
-            apply.deleteApplicationForm();
+            apply.reject();
             apply.getMember().deleteProfile();
         });
         return applies.size();

--- a/src/main/java/org/ject/support/domain/apply/domain/Apply.java
+++ b/src/main/java/org/ject/support/domain/apply/domain/Apply.java
@@ -91,6 +91,11 @@ public class Apply extends BaseTimeEntity {
         }
     }
 
+    public void reject() {
+        this.applicationForm = null;
+        this.status = Status.REJECTED;
+    }
+
     public boolean isTempSaved() {
         return status.equals(Status.TEMP_SAVED);
     }
@@ -113,6 +118,6 @@ public class Apply extends BaseTimeEntity {
     }
 
     public enum Status {
-        JOINED, TEMP_SAVED, SUBMITTED
+        JOINED, TEMP_SAVED, SUBMITTED, REJECTED
     }
 }

--- a/src/main/resources/db/migration/V22__add_rejected_status_to_apply.sql
+++ b/src/main/resources/db/migration/V22__add_rejected_status_to_apply.sql
@@ -1,0 +1,4 @@
+-- apply.status 컬럼은 VARCHAR(50) 타입이므로 DDL 변경 없이 REJECTED 값을 사용할 수 있음
+-- 기존 허용 값: JOINED, TEMP_SAVED, SUBMITTED
+-- 추가 허용 값: REJECTED (불합격 처리 시 지원서 내용 및 개인정보 파기 후 상태 전환)
+

--- a/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
@@ -104,6 +104,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
 
         // then
         verify(applyRepository).findByIdAndStatusWithMember(applyId, Status.SUBMITTED);
+        assertThat(submittedApply.getStatus()).isEqualTo(Status.REJECTED);
         assertThat(submittedApply.getApplicationForm()).isNull();
         assertThat(submittedApply.getMember().getName()).isNull();
     }
@@ -155,9 +156,12 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         // then
         verify(applyRepository).findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED);
         assertThat(deleted).isEqualTo(3);
+        assertThat(submittedApply.getStatus()).isEqualTo(Status.REJECTED);
         assertThat(submittedApply.getApplicationForm()).isNull();
         assertThat(submittedApply.getMember().getName()).isNull();
+        assertThat(apply2.getStatus()).isEqualTo(Status.REJECTED);
         assertThat(apply2.getApplicationForm()).isNull();
+        assertThat(apply3.getStatus()).isEqualTo(Status.REJECTED);
         assertThat(apply3.getApplicationForm()).isNull();
     }
 

--- a/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
@@ -4,6 +4,7 @@ import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.util.Map2JsonSerializer;
 import org.ject.support.common.util.String2MapSerializer;
 import org.ject.support.admin.apply.dto.SubmittedApplyCountResponse;
+import org.ject.support.admin.apply.dto.SubmittedApplyDetailResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.dto.SubmittedApplyResponse;
 import org.ject.support.domain.apply.domain.ApplicationForm;
@@ -41,7 +42,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-class SubmittedApplyServiceTest  extends UnitTestSupport {
+class SubmittedApplyServiceTest extends UnitTestSupport {
 
     @InjectMocks
     private SubmittedApplyService submittedApplyService;
@@ -149,10 +150,11 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
                 .willReturn(applies);
 
         // when
-        submittedApplyService.deleteSubmittedApplies(applyIds);
+        int deleted = submittedApplyService.deleteSubmittedApplies(applyIds);
 
         // then
         verify(applyRepository).findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED);
+        assertThat(deleted).isEqualTo(3);
         assertThat(submittedApply.getApplicationForm()).isNull();
         assertThat(submittedApply.getMember().getName()).isNull();
         assertThat(apply2.getApplicationForm()).isNull();
@@ -186,6 +188,23 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         assertThatThrownBy(() -> submittedApplyService.deleteSubmittedApplies(applyIds))
                 .isInstanceOf(ApplyException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
+    }
+
+    @Test
+    void 제출된_지원서_여러건_삭제시_중복_ID는_한_번만_처리() {
+        // given
+        var applyIds = List.of(1L, 1L, 1L);
+        var distinctIds = List.of(1L);
+
+        given(applyRepository.findAllByIdAndStatusWithMember(distinctIds, Status.SUBMITTED))
+                .willReturn(List.of(submittedApply));
+
+        // when
+        int deleted = submittedApplyService.deleteSubmittedApplies(applyIds);
+
+        // then
+        assertThat(deleted).isEqualTo(1);
+        verify(applyRepository).findAllByIdAndStatusWithMember(distinctIds, Status.SUBMITTED);
     }
 
     @Test
@@ -349,7 +368,7 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
     }
 
     @Test
-    void 상세조회하려는_제출된_지원서가_null인_경우_빈_응답을_반환() {
+    void 상세조회하려는_제출된_지원서의_ApplicationForm이_null이면_빈_응답을_반환() {
         // given
         var applyId = submittedApply.getId() + 1L;
         var member2 = Member.builder()
@@ -367,10 +386,11 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
                 .willReturn(Optional.of(apply2));
 
         // when
-        var actual = submittedApplyService.findSubmittedApplyDetail(applyId);
-        // expected
+        SubmittedApplyDetailResponse actual = submittedApplyService.findSubmittedApplyDetail(applyId);
+
+        // then
         assertThat(actual.applyId()).isEqualTo(applyId);
-        assertThat(actual.applicationFormResponse().answers()).isEmpty();  // 빈 Map 확인
+        assertThat(actual.applicationFormResponse().answers()).isEmpty();
         assertThat(actual.applicationFormResponse().portfolios()).isEmpty();
     }
 
@@ -383,13 +403,10 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         )).willReturn(Optional.of(submittedApply));
 
         // when
-        var actual = submittedApplyService.findSubmittedApplyDetail(submittedApply.getId());
+        SubmittedApplyDetailResponse actual = submittedApplyService.findSubmittedApplyDetail(submittedApply.getId());
 
         // then
-        verify(applyRepository).findByIdAndStatusWithMember(
-                submittedApply.getId(),
-                Status.SUBMITTED
-        );
+        verify(applyRepository).findByIdAndStatusWithMember(submittedApply.getId(), Status.SUBMITTED);
         assertThat(actual.applyId()).isEqualTo(submittedApply.getId());
     }
 
@@ -432,7 +449,6 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         // then
         verify(applyRepository).findByIdAndStatusWithMember(applyId, Status.SUBMITTED);
         verify(map2JsonSerializer).serializeAsString(newAnswers);
-
         assertThat(submittedApply.getMember().getName()).isEqualTo(newName);
         assertThat(submittedApply.getMember().getPhoneNumber()).isEqualTo(newPhoneNumber);
         assertThat(submittedApply.getMember().getEmail()).isEqualTo(newEmail);
@@ -483,35 +499,5 @@ class SubmittedApplyServiceTest  extends UnitTestSupport {
         assertThatThrownBy(() -> submittedApplyService.updateSubmittedApply(applyId, request))
                 .isInstanceOf(QuestionException.class)
                 .hasFieldOrPropertyWithValue("errorCode", QuestionErrorCode.NOT_FOUND_QUESTION);
-    }
-
-    @Test
-    void 제출되지_않은_지원서_수정시_예외_발생() {
-        // given
-        var applyId = submittedApply.getId();
-        var tempSavedApply = Apply.builder()
-                .id(applyId)
-                .member(submittedApply.getMember())
-                .recruit(submittedApply.getRecruit())
-                .status(Status.TEMP_SAVED)
-                .applicationForm(ApplicationForm.builder().build())
-                .build();
-
-        var request = new SubmittedApplyEditRequest(
-                "이름",
-                "01012345678",
-                "test@example.com",
-                JobFamily.BE,
-                Map.of("1", "답변"),
-                List.of()
-        );
-
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
-                .willReturn(Optional.of(tempSavedApply));
-
-        // expected
-        assertThatThrownBy(() -> submittedApplyService.updateSubmittedApply(applyId, request))
-                .isInstanceOf(ApplyException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_SUBMITTED_APPLICATION_FORM);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #455

## 📝 작업 내용

기존 제출 완료된 지원서 삭제 엔트포인트 로직을 개선
- `toSubmittedApplyResponse` 위임 메서드 제거 → `SubmittedApplyResponse::from` 메서드 참조로 인라이닝
- `validateQuestions`의 `forEach` 내 예외 throw 안티패턴 수정
  - `forEach` → `findAny().ifPresent()` 로 교체
- repository에서 Status.SUBMITTED 조건으로 이미 필터링하므로 중복 검증을 피하기 위한 ensureSubmitted() 제거

불합격 처리 시 REJECTED 상태 전환 기능 추가
- Apply.Status에 REJECTED 추가
- Apply.reject() 도메인 메서드 추가
- applicationForm null 처리 + status → REJECTED 전환을 엔티티에 캡슐화
- SubmittedApplyService: 불합격 처리 시 reject() 호출로 교체

### 테스트 케이스 업데이트
- 중복 import 및 중복 테스트 메서드 제거
- `ensureSubmitted` 제거로 인해 불가능해진 시나리오 테스트 제거
- 신규 테스트 추가
  - 제출된 지원서 여러 건 삭제 시 중복 ID는 한 번만 처리 검증
  - `ApplicationForm`이 null인 경우 빈 응답 반환 검증
  - 삭제 성공 시 반환값(`deleted`) 검증 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 신청 상태에 REJECTED가 추가되어, 신청 거부 흐름이 명확히 반영됩니다.

* **변경사항**
  * 일괄 삭제 기능이 삭제된 항목의 개수를 반환하도록 개선되었으며, 중복 ID는 한 번만 처리됩니다.
  * 신청 거부 시 관련 신청서 내용과 개인 프로필이 정리(삭제/초기화)되고 상태가 REJECTED로 변경됩니다.

* **코드 개선**
  * 내부 중복 로직을 정리하여 구현을 간소화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->