### PR TITLE
feat:관리자 로그인 API 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/admin/auth/controller/AdminAuthApiSpec.java
+++ b/src/main/java/org/ject/support/admin/auth/controller/AdminAuthApiSpec.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.ject.support.admin.auth.dto.AdminAuthSendRequest;
 import org.ject.support.admin.auth.dto.AdminAuthSendResponse;
+import org.ject.support.admin.auth.dto.AdminLoginRequest;
 import org.ject.support.admin.auth.dto.AdminVerifyRequest;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -28,4 +29,15 @@ public interface AdminAuthApiSpec {
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse
     );
+
+    @Operation(
+            summary = "관리자 로그인",
+            description = "관리자 로그인을 시도합니다."
+    )
+    boolean loginAdmin(
+            @RequestBody @Valid AdminLoginRequest request,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse
+    );
+
 }

--- a/src/main/java/org/ject/support/admin/auth/controller/AdminAuthController.java
+++ b/src/main/java/org/ject/support/admin/auth/controller/AdminAuthController.java
@@ -4,11 +4,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.ject.support.common.security.CustomSuccessHandler;
 import org.ject.support.admin.auth.dto.AdminAuthSendRequest;
 import org.ject.support.admin.auth.dto.AdminAuthSendResponse;
+import org.ject.support.admin.auth.dto.AdminLoginRequest;
 import org.ject.support.admin.auth.dto.AdminVerifyRequest;
 import org.ject.support.admin.auth.service.AdminAuthService;
+import org.ject.support.common.security.CustomSuccessHandler;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,6 +40,15 @@ public class AdminAuthController implements AdminAuthApiSpec {
     ) {
         Authentication authentication = adminAuthService.verifyAdminAuthCode(request.email(), request.code());
         customSuccessHandler.onAuthenticationSuccess(httpRequest, httpResponse, authentication);
+        return true;
+    }
+
+    @Override
+    @PostMapping("/login")
+    public boolean loginAdmin(@RequestBody @Valid AdminLoginRequest request,
+                                HttpServletRequest httpRequest, HttpServletResponse response) {
+        Authentication authentication = adminAuthService.verifyAdminAuthCode(request.email(), request.pin());
+        customSuccessHandler.onAuthenticationSuccess(httpRequest, response, authentication);
         return true;
     }
 }

--- a/src/main/java/org/ject/support/admin/auth/dto/AdminLoginRequest.java
+++ b/src/main/java/org/ject/support/admin/auth/dto/AdminLoginRequest.java
@@ -1,0 +1,16 @@
+package org.ject.support.admin.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record AdminLoginRequest(
+        @NotBlank(message = "Email은 필수 입력 값입니다.")
+        @Email(message = "유효하지 않은 이메일 형식입니다.")
+        String email,
+
+        @NotBlank(message = "PIN은 필수 입력 값입니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9]{6}$", message = "PIN 번호는 영문 대소문자와 숫자를 포함한 6자리여야 합니다.")
+        String pin
+) {
+}

--- a/src/test/java/org/ject/support/admin/auth/controller/AdminAuthControllerTest.java
+++ b/src/test/java/org/ject/support/admin/auth/controller/AdminAuthControllerTest.java
@@ -2,10 +2,14 @@ package org.ject.support.admin.auth.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import org.assertj.core.api.Assertions;
 import org.ject.support.common.security.CustomSuccessHandler;
 import org.ject.support.admin.auth.dto.AdminAuthSendRequest;
 import org.ject.support.admin.auth.dto.AdminAuthSendResponse;
+import org.ject.support.admin.auth.dto.AdminLoginRequest;
 import org.ject.support.admin.auth.dto.AdminVerifyRequest;
 import org.ject.support.admin.auth.service.AdminAuthService;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -17,6 +21,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -79,5 +87,50 @@ class AdminAuthControllerTest {
         verify(customSuccessHandler).onAuthenticationSuccess(
                 httpServletRequest, httpServletResponse, authentication
         );
+    }
+
+    @Test
+    void 관리자_로그인에_성공하면_true를_반환한다() {
+        // given
+        String email = "admin@ject.org";
+        String pin = "ABC123";
+        AdminLoginRequest request = new AdminLoginRequest(email, pin);
+        when(adminAuthService.verifyAdminAuthCode(email, pin)).thenReturn(authentication);
+
+        // when
+        boolean result = adminAuthController.loginAdmin(request, httpServletRequest, httpServletResponse);
+
+        // then
+        assertTrue(result);
+        verify(adminAuthService).verifyAdminAuthCode(email, pin);
+        verify(customSuccessHandler).onAuthenticationSuccess(httpServletRequest, httpServletResponse, authentication);
+    }
+
+    @Test
+    void 이메일_형식이_올바르지_않은_경우_유효성_검사에_실패한다() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        AdminLoginRequest request = new AdminLoginRequest("invalid-email", "ABC123");
+
+        // when
+        Set<ConstraintViolation<AdminLoginRequest>> violations = validator.validate(request);
+
+        // then
+        assertFalse(violations.isEmpty());
+        assertThat(violations).anyMatch(v -> v.getMessage().equals("유효하지 않은 이메일 형식입니다."));
+    }
+
+    @Test
+    void PIN_번호_형식이_올바르지_않은_경우_유효성_검사에_실패한다() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        AdminLoginRequest request = new AdminLoginRequest("admin@ject.org", "123");
+
+        // when
+        Set<ConstraintViolation<AdminLoginRequest>> violations = validator.validate(request);
+
+        // then
+        assertFalse(violations.isEmpty());
+        assertThat(violations).anyMatch(v -> v.getMessage().equals("PIN 번호는 영문 대소문자와 숫자를 포함한 6자리여야 합니다."));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #464

## 📝 작업 내용


### 관리자 로그인 기능 구현
 - email, PIN(대/소문자 + 숫자) 6자리
 - 테스트 코드 작성


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 로그인 기능이 추가되었습니다. 이제 이메일과 6자리 PIN 코드를 사용하여 관리자 계정에 로그인할 수 있습니다.

* **테스트**
  * 관리자 로그인 및 입력값 유효성 검사에 대한 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->