### PR TITLE
feat: 임시 지원서 지원서 조회 기능 개선 및 요구사항 적용

### DIFF
--- a/src/main/java/org/ject/support/admin/apply/controller/AdminApplyController.java
+++ b/src/main/java/org/ject/support/admin/apply/controller/AdminApplyController.java
@@ -8,7 +8,7 @@ import org.ject.support.admin.apply.dto.AdminApplyResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyBulkDeleteRequest;
 import org.ject.support.admin.apply.dto.SubmittedApplyDetailResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
-import org.ject.support.admin.apply.service.SubmittedApplyService;
+import org.ject.support.admin.apply.service.AdminApplyService;
 import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.RecruitType;
@@ -27,11 +27,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin/submitted-applies")
-@Tag(name = "Submitted Apply", description = "[관리자] 제출된 지원서 관리 API")
-public class SubmittedApplyController {
+@RequestMapping("/admin/applies")
+@Tag(name = "Admin Apply", description = "[관리자] 제출된 지원서 관리 API")
+public class AdminApplyController {
 
-    private final SubmittedApplyService submittedApplyService;
+    private final AdminApplyService AdminApplyService;
 
     @GetMapping
     @Operation(
@@ -42,7 +42,7 @@ public class SubmittedApplyController {
                                                 @RequestParam(required = false) final JobFamily jobFamily,
                                                 @RequestParam(required = false) final RecruitType recruitType,
                                                 @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) final Pageable pageable) {
-        return submittedApplyService.findApplies(applyStatus, semesterId, jobFamily, recruitType, pageable);
+        return AdminApplyService.findApplies(applyStatus, semesterId, jobFamily, recruitType, pageable);
     }
 
     @GetMapping("/{applyId}")
@@ -50,7 +50,7 @@ public class SubmittedApplyController {
             summary = "제출된 지원서 상세 조회",
             description = "전달한 ID에 해당하는 제출된 지원서의 상세 정보를 조회합니다.")
     public SubmittedApplyDetailResponse findSubmittedApplyDetail(@PathVariable("applyId") final Long applyId) {
-        return submittedApplyService.findSubmittedApplyDetail(applyId);
+        return AdminApplyService.findSubmittedApplyDetail(applyId);
     }
 
     @PutMapping("/{applyId}")
@@ -59,7 +59,7 @@ public class SubmittedApplyController {
             description = "전달한 ID에 해당하는 제출된 지원서의 정보를 수정 합니다.")
     public void editSubmittedApply(@PathVariable("applyId") final Long applyId,
                                    @RequestBody @Valid final SubmittedApplyEditRequest request) {
-        submittedApplyService.updateSubmittedApply(applyId, request);
+        AdminApplyService.updateSubmittedApply(applyId, request);
     }
 
     @DeleteMapping("/{applyId}")
@@ -67,7 +67,7 @@ public class SubmittedApplyController {
             summary = "제출된 지원서 삭제",
             description = "선택한 제출된 지원서를 삭제합니다.")
     public void deleteSubmittedApply(@PathVariable("applyId") final Long applyId) {
-        submittedApplyService.deleteSubmittedApply(applyId);
+        AdminApplyService.deleteSubmittedApply(applyId);
     }
 
     @DeleteMapping
@@ -75,6 +75,6 @@ public class SubmittedApplyController {
             summary = "제출된 지원서 다수 삭제",
             description = "선택한 다수의 제출된 지원서들을 삭제합니다. 삭제한 수를 반환합니다.")
     public int deleteSubmittedApplies(@RequestBody @Valid final SubmittedApplyBulkDeleteRequest request) {
-        return submittedApplyService.deleteSubmittedApplies(request.applyIds());
+        return AdminApplyService.deleteSubmittedApplies(request.applyIds());
     }
 }

--- a/src/main/java/org/ject/support/admin/apply/controller/AdminApplyController.java
+++ b/src/main/java/org/ject/support/admin/apply/controller/AdminApplyController.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin/applies")
-@Tag(name = "Admin Apply", description = "[관리자] 제출된 지원서 관리 API")
+@Tag(name = "Admin Apply", description = "[관리자] 지원서 관리 API")
 public class AdminApplyController {
 
     private final AdminApplyService AdminApplyService;

--- a/src/main/java/org/ject/support/admin/apply/controller/AdminTempApplyApiSpec.java
+++ b/src/main/java/org/ject/support/admin/apply/controller/AdminTempApplyApiSpec.java
@@ -4,14 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.ject.support.admin.apply.dto.TempApplyDetailResponse;
 import org.ject.support.admin.apply.dto.TempSavedApplyCountResponse;
-import org.ject.support.admin.apply.dto.TempSavedApplyResponse;
-import org.ject.support.domain.member.JobFamily;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Temporary Apply", description = "임시 저장된 지원서 관리")
 public interface AdminTempApplyApiSpec {
@@ -32,13 +25,4 @@ public interface AdminTempApplyApiSpec {
             description = "임시 저장된 지원서를 삭제합니다.")
     void deleteTempApply(@PathVariable("tempApplyId") Long tempApplyId);
 
-    @Operation(
-            summary = "임시 저장된 지원서 목록 조회",
-            description = "관리자가 임시 저장된 지원서 목록을 조회합니다."
-    )
-    Page<TempSavedApplyResponse> getTempApplies(
-            @RequestParam(required = false) JobFamily jobFamily,
-            @RequestParam(required = false) final Long semesterId,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable
-    );
 }

--- a/src/main/java/org/ject/support/admin/apply/controller/AdminTempApplyController.java
+++ b/src/main/java/org/ject/support/admin/apply/controller/AdminTempApplyController.java
@@ -3,18 +3,11 @@ package org.ject.support.admin.apply.controller;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.apply.dto.TempApplyDetailResponse;
 import org.ject.support.admin.apply.dto.TempSavedApplyCountResponse;
-import org.ject.support.admin.apply.dto.TempSavedApplyResponse;
 import org.ject.support.admin.apply.service.AdminTempApplyService;
-import org.ject.support.domain.member.JobFamily;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -39,10 +32,4 @@ public class AdminTempApplyController implements AdminTempApplyApiSpec {
         adminTempApplyService.deleteTempApply(tempApplyId);
     }
 
-    @GetMapping()
-    public Page<TempSavedApplyResponse> getTempApplies(@RequestParam(required = false) JobFamily jobFamily,
-                                                       @RequestParam(required = false) final Long semesterId,
-                                                       @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return adminTempApplyService.getTempApplies(jobFamily, semesterId, pageable);
-    }
 }

--- a/src/main/java/org/ject/support/admin/apply/controller/SubmittedApplyController.java
+++ b/src/main/java/org/ject/support/admin/apply/controller/SubmittedApplyController.java
@@ -6,7 +6,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.apply.dto.AdminApplyResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyBulkDeleteRequest;
-import org.ject.support.admin.apply.dto.SubmittedApplyCountResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyDetailResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.service.SubmittedApplyService;
@@ -33,14 +32,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class SubmittedApplyController {
 
     private final SubmittedApplyService submittedApplyService;
-
-    @GetMapping("/count")
-    @Operation(
-            summary = "제출된 지원서 수 조회",
-            description = "제출된 상태의 지원서 총 개수를 조회합니다.")
-    public SubmittedApplyCountResponse getSubmittedApplyCount() {
-        return submittedApplyService.countSubmittedApply();
-    }
 
     @GetMapping
     @Operation(

--- a/src/main/java/org/ject/support/admin/apply/controller/SubmittedApplyController.java
+++ b/src/main/java/org/ject/support/admin/apply/controller/SubmittedApplyController.java
@@ -10,11 +10,12 @@ import org.ject.support.admin.apply.dto.SubmittedApplyCountResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyDetailResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.service.SubmittedApplyService;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.RecruitType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,11 +46,12 @@ public class SubmittedApplyController {
     @Operation(
             summary = "제출된 지원서 목록 조회",
             description = "제출된 지원서들의 목록을 조회합니다.")
-    public Page<AdminApplyResponse> findSubmittedApplies(@RequestParam(required = false) final Long semesterId,
-                                                         @RequestParam(required = false) final JobFamily jobFamily,
-                                                         @RequestParam(required = false) final RecruitType recruitType,
-                                                         @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
-        return submittedApplyService.findSubmittedApplies(jobFamily, semesterId, recruitType, pageable);
+    public Page<AdminApplyResponse> findApplies(@RequestParam(required = false) final ApplyStatus applyStatus,
+                                                @RequestParam(required = false) final Long semesterId,
+                                                @RequestParam(required = false) final JobFamily jobFamily,
+                                                @RequestParam(required = false) final RecruitType recruitType,
+                                                @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) final Pageable pageable) {
+        return submittedApplyService.findApplies(applyStatus, semesterId, jobFamily, recruitType, pageable);
     }
 
     @GetMapping("/{applyId}")

--- a/src/main/java/org/ject/support/admin/apply/controller/SubmittedApplyController.java
+++ b/src/main/java/org/ject/support/admin/apply/controller/SubmittedApplyController.java
@@ -1,13 +1,14 @@
 package org.ject.support.admin.apply.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.apply.dto.AdminApplyResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyBulkDeleteRequest;
-import org.ject.support.admin.apply.dto.SubmittedApplyCountResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyCountResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyDetailResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
-import org.ject.support.admin.apply.dto.SubmittedApplyResponse;
 import org.ject.support.admin.apply.service.SubmittedApplyService;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.RecruitType;
@@ -23,9 +24,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,10 +45,10 @@ public class SubmittedApplyController {
     @Operation(
             summary = "제출된 지원서 목록 조회",
             description = "제출된 지원서들의 목록을 조회합니다.")
-    public Page<SubmittedApplyResponse> findSubmittedApplies(@RequestParam(required = false) final Long semesterId,
-                                                             @RequestParam(required = false) final JobFamily jobFamily,
-                                                             @RequestParam(required = false) final RecruitType recruitType,
-                                                             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+    public Page<AdminApplyResponse> findSubmittedApplies(@RequestParam(required = false) final Long semesterId,
+                                                         @RequestParam(required = false) final JobFamily jobFamily,
+                                                         @RequestParam(required = false) final RecruitType recruitType,
+                                                         @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
         return submittedApplyService.findSubmittedApplies(jobFamily, semesterId, recruitType, pageable);
     }
 

--- a/src/main/java/org/ject/support/admin/apply/dto/AdminApplyResponse.java
+++ b/src/main/java/org/ject/support/admin/apply/dto/AdminApplyResponse.java
@@ -1,12 +1,11 @@
 package org.ject.support.admin.apply.dto;
 
+import java.util.Optional;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.JobFamily;
 
-import java.util.Optional;
-
-public record SubmittedApplyResponse(
+public record AdminApplyResponse(
         Long applyId,
         String name,
         String phoneNumber,
@@ -16,8 +15,8 @@ public record SubmittedApplyResponse(
         String recruitType,
         String note
 ) {
-    public static SubmittedApplyResponse from(Apply apply) {
-        return new SubmittedApplyResponse(
+    public static AdminApplyResponse from(Apply apply) {
+        return new AdminApplyResponse(
                 apply.getId(),
                 apply.getMember().getName(),
                 apply.getMember().getPhoneNumber(),

--- a/src/main/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepository.java
+++ b/src/main/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepository.java
@@ -1,6 +1,7 @@
 package org.ject.support.admin.apply.repository;
 
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.RecruitType;
 import org.springframework.data.domain.Page;
@@ -8,7 +9,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface AdminApplyQueryRepository {
     Page<Apply> findAppliesByStatus(final JobFamily jobFamily,
-                                    final Apply.Status status,
+                                    final ApplyStatus status,
                                     final Long semesterId,
                                     final RecruitType recruitType,
                                     final Pageable pageable);

--- a/src/main/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepository.java
+++ b/src/main/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepository.java
@@ -8,9 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface AdminApplyQueryRepository {
-    Page<Apply> findAppliesByStatus(final JobFamily jobFamily,
-                                    final ApplyStatus status,
-                                    final Long semesterId,
+    Page<Apply> findAppliesByStatus(final ApplyStatus status, final Long semesterId, final JobFamily jobFamily,
                                     final RecruitType recruitType,
                                     final Pageable pageable);
 }

--- a/src/main/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.data.PageResponse;
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.RecruitType;
 import org.springframework.data.domain.Page;
@@ -28,7 +29,7 @@ public class AdminApplyQueryRepositoryImpl implements AdminApplyQueryRepository 
 
     @Override
     public Page<Apply> findAppliesByStatus(final JobFamily jobFamily,
-                                           final Apply.Status status,
+                                           final ApplyStatus status,
                                            final Long semesterId,
                                            final RecruitType recruitType,
                                            final Pageable pageable) {
@@ -74,7 +75,7 @@ public class AdminApplyQueryRepositoryImpl implements AdminApplyQueryRepository 
                 .orElse(null);
     }
 
-    private BooleanExpression eqApplyStatus(final Apply.Status status) {
+    private BooleanExpression eqApplyStatus(final ApplyStatus status) {
         return Optional.ofNullable(status)
                 .map(apply.status::eq)
                 .orElse(null);

--- a/src/main/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryImpl.java
@@ -1,7 +1,15 @@
 package org.ject.support.admin.apply.repository;
 
+import static org.ject.support.domain.apply.domain.QApplicationForm.applicationForm;
+import static org.ject.support.domain.apply.domain.QApply.apply;
+import static org.ject.support.domain.apply.domain.QPortfolio.portfolio;
+import static org.ject.support.domain.member.entity.QMember.member;
+import static org.ject.support.domain.recruit.domain.QRecruit.recruit;
+
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.data.PageResponse;
 import org.ject.support.domain.apply.domain.Apply;
@@ -12,15 +20,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
-import static org.ject.support.domain.apply.domain.QApplicationForm.applicationForm;
-import static org.ject.support.domain.apply.domain.QApply.apply;
-import static org.ject.support.domain.apply.domain.QPortfolio.portfolio;
-import static org.ject.support.domain.member.entity.QMember.member;
-import static org.ject.support.domain.recruit.domain.QRecruit.recruit;
-
 @Repository
 @RequiredArgsConstructor
 public class AdminApplyQueryRepositoryImpl implements AdminApplyQueryRepository {
@@ -28,9 +27,9 @@ public class AdminApplyQueryRepositoryImpl implements AdminApplyQueryRepository 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Apply> findAppliesByStatus(final JobFamily jobFamily,
-                                           final ApplyStatus status,
+    public Page<Apply> findAppliesByStatus(final ApplyStatus status,
                                            final Long semesterId,
+                                           final JobFamily jobFamily,
                                            final RecruitType recruitType,
                                            final Pageable pageable) {
 

--- a/src/main/java/org/ject/support/admin/apply/service/AdminApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/AdminApplyService.java
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class SubmittedApplyService {
+public class AdminApplyService {
 
     private final ApplyRepository applyRepository;
     private final AdminApplyQueryRepository adminApplyQueryRepository;

--- a/src/main/java/org/ject/support/admin/apply/service/AdminApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/AdminApplyService.java
@@ -46,7 +46,7 @@ public class AdminApplyService {
                                                 final JobFamily jobFamily,
                                                 final RecruitType recruitType,
                                                 final Pageable pageable) {
-        Page<Apply> applyPage = adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, recruitType, pageable);
+        Page<Apply> applyPage = adminApplyQueryRepository.findAppliesByStatus(applyStatus, semesterId, jobFamily, recruitType, pageable);
 
         List<AdminApplyResponse> content = applyPage.getContent().stream()
                 .map(AdminApplyResponse::from)

--- a/src/main/java/org/ject/support/admin/apply/service/AdminTempApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/AdminTempApplyService.java
@@ -8,6 +8,7 @@ import org.ject.support.admin.apply.dto.TempSavedApplyCountResponse;
 import org.ject.support.admin.apply.dto.TempSavedApplyResponse;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.exception.ApplyErrorCode;
 import org.ject.support.domain.apply.exception.ApplyException;
@@ -33,7 +34,7 @@ public class AdminTempApplyService {
     private final String2MapSerializer string2MapSerializer;
 
     public TempApplyDetailResponse getTempApplyDetail(Long tempApplyId) {
-        Apply apply = applyRepository.findByIdAndStatusWithMember(tempApplyId, Apply.Status.TEMP_SAVED)
+        Apply apply = applyRepository.findByIdAndStatusWithMember(tempApplyId, ApplyStatus.TEMP_SAVED)
                 .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_TEMP_APPLICATION_FORM));
 
         ApplicationForm tempApplicationForm = apply.getApplicationForm();
@@ -46,20 +47,20 @@ public class AdminTempApplyService {
     }
 
     public TempSavedApplyCountResponse getTempSavedApplyCount() {
-        Long count = applyRepository.countByStatus(Apply.Status.TEMP_SAVED);
+        Long count = applyRepository.countByStatus(ApplyStatus.TEMP_SAVED);
         return new TempSavedApplyCountResponse(count);
     }
 
     @Transactional
     public void deleteTempApply(Long applyId) {
-        Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, Apply.Status.TEMP_SAVED)
+        Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.TEMP_SAVED)
                 .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
         apply.getMember().deleteProfile();
         applyRepository.delete(apply);
     }
 
     public Page<TempSavedApplyResponse> getTempApplies(JobFamily jobFamily, Long semesterId, Pageable pageable) {
-        Apply.Status tempSavedStatus = Apply.Status.TEMP_SAVED;
+        ApplyStatus tempSavedStatus = ApplyStatus.TEMP_SAVED;
         Page<Apply> applyPage = adminApplyQueryRepository.findAppliesByStatus(jobFamily, tempSavedStatus, semesterId, null, pageable);
 
         List<TempSavedApplyResponse> content = applyPage.getContent().stream()

--- a/src/main/java/org/ject/support/admin/apply/service/AdminTempApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/AdminTempApplyService.java
@@ -8,7 +8,6 @@ import org.ject.support.admin.apply.dto.TempApplyDetailResponse;
 import org.ject.support.admin.apply.dto.TempSavedApplyCountResponse;
 import org.ject.support.admin.apply.dto.TempSavedApplyResponse;
 import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
-import org.ject.support.common.data.PageResponse;
 import org.ject.support.common.util.String2MapSerializer;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
@@ -17,9 +16,6 @@ import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.exception.ApplyErrorCode;
 import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.domain.apply.repository.ApplyRepository;
-import org.ject.support.domain.member.JobFamily;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,18 +52,6 @@ public class AdminTempApplyService {
                 .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
         apply.getMember().deleteProfile();
         applyRepository.delete(apply);
-    }
-
-    public Page<TempSavedApplyResponse> getTempApplies(JobFamily jobFamily, Long semesterId, Pageable pageable) {
-        ApplyStatus tempSavedStatus = ApplyStatus.TEMP_SAVED;
-        Page<Apply> applyPage = adminApplyQueryRepository.findAppliesByStatus(tempSavedStatus, semesterId, jobFamily,
-                null, pageable);
-
-        List<TempSavedApplyResponse> content = applyPage.getContent().stream()
-                .map(this::toTempSavedApplyResponse)
-                .toList();
-
-        return PageResponse.from(content, pageable, applyPage.getTotalElements());
     }
 
     private TempSavedApplyResponse toTempSavedApplyResponse(final Apply apply) {

--- a/src/main/java/org/ject/support/admin/apply/service/AdminTempApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/AdminTempApplyService.java
@@ -1,28 +1,27 @@
 package org.ject.support.admin.apply.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.ject.support.common.data.PageResponse;
-import org.ject.support.common.util.String2MapSerializer;
 import org.ject.support.admin.apply.dto.TempApplyDetailResponse;
 import org.ject.support.admin.apply.dto.TempSavedApplyCountResponse;
 import org.ject.support.admin.apply.dto.TempSavedApplyResponse;
+import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
+import org.ject.support.common.data.PageResponse;
+import org.ject.support.common.util.String2MapSerializer;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.exception.ApplyErrorCode;
 import org.ject.support.domain.apply.exception.ApplyException;
-import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
 import org.ject.support.domain.apply.repository.ApplyRepository;
 import org.ject.support.domain.member.JobFamily;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -61,7 +60,8 @@ public class AdminTempApplyService {
 
     public Page<TempSavedApplyResponse> getTempApplies(JobFamily jobFamily, Long semesterId, Pageable pageable) {
         ApplyStatus tempSavedStatus = ApplyStatus.TEMP_SAVED;
-        Page<Apply> applyPage = adminApplyQueryRepository.findAppliesByStatus(jobFamily, tempSavedStatus, semesterId, null, pageable);
+        Page<Apply> applyPage = adminApplyQueryRepository.findAppliesByStatus(tempSavedStatus, semesterId, jobFamily,
+                null, pageable);
 
         List<TempSavedApplyResponse> content = applyPage.getContent().stream()
                 .map(this::toTempSavedApplyResponse)

--- a/src/main/java/org/ject/support/admin/apply/service/AdminTempApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/AdminTempApplyService.java
@@ -49,7 +49,7 @@ public class AdminTempApplyService {
     @Transactional
     public void deleteTempApply(Long applyId) {
         Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.TEMP_SAVED)
-                .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
+                .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_TEMP_APPLICATION_FORM));
         apply.getMember().deleteProfile();
         applyRepository.delete(apply);
     }

--- a/src/main/java/org/ject/support/admin/apply/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/SubmittedApplyService.java
@@ -42,11 +42,12 @@ public class SubmittedApplyService {
     private final Map2JsonSerializer map2JsonSerializer;
 
     @Transactional(readOnly = true)
-    public Page<AdminApplyResponse> findSubmittedApplies(final JobFamily jobFamily,
-                                                         final Long semesterId,
-                                                         final RecruitType recruitType,
-                                                         final Pageable pageable) {
-        Page<Apply> applyPage = adminApplyQueryRepository.findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, recruitType, pageable);
+    public Page<AdminApplyResponse> findApplies(final ApplyStatus applyStatus,
+                                                final Long semesterId,
+                                                final JobFamily jobFamily,
+                                                final RecruitType recruitType,
+                                                final Pageable pageable) {
+        Page<Apply> applyPage = adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, recruitType, pageable);
 
         List<AdminApplyResponse> content = applyPage.getContent().stream()
                 .map(AdminApplyResponse::from)

--- a/src/main/java/org/ject/support/admin/apply/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/SubmittedApplyService.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.apply.dto.AdminApplyResponse;
-import org.ject.support.admin.apply.dto.SubmittedApplyCountResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyDetailResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
@@ -61,12 +60,6 @@ public class SubmittedApplyService {
         return applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED)
                 .map(this::toSubmittedApplyDetailResponse)
                 .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
-    }
-
-    @Transactional(readOnly = true)
-    public SubmittedApplyCountResponse countSubmittedApply() {
-        Long count = applyRepository.countByStatus(ApplyStatus.SUBMITTED);
-        return new SubmittedApplyCountResponse(count);
     }
 
     @Transactional

--- a/src/main/java/org/ject/support/admin/apply/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/SubmittedApplyService.java
@@ -1,13 +1,17 @@
 package org.ject.support.admin.apply.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.ject.support.common.data.PageResponse;
-import org.ject.support.common.util.Map2JsonSerializer;
-import org.ject.support.common.util.String2MapSerializer;
+import org.ject.support.admin.apply.dto.AdminApplyResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyCountResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyDetailResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
-import org.ject.support.admin.apply.dto.SubmittedApplyResponse;
+import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
+import org.ject.support.common.data.PageResponse;
+import org.ject.support.common.util.Map2JsonSerializer;
+import org.ject.support.common.util.String2MapSerializer;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.ApplyStatus;
@@ -15,23 +19,18 @@ import org.ject.support.domain.apply.domain.Portfolio;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.exception.ApplyErrorCode;
 import org.ject.support.domain.apply.exception.ApplyException;
-import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
 import org.ject.support.domain.apply.repository.ApplyRepository;
 import org.ject.support.domain.member.JobFamily;
-import org.ject.support.domain.recruit.domain.RecruitType;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.entity.MemberEditor;
 import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.RecruitType;
 import org.ject.support.domain.recruit.exception.QuestionErrorCode;
 import org.ject.support.domain.recruit.exception.QuestionException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -43,14 +42,14 @@ public class SubmittedApplyService {
     private final Map2JsonSerializer map2JsonSerializer;
 
     @Transactional(readOnly = true)
-    public Page<SubmittedApplyResponse> findSubmittedApplies(final JobFamily jobFamily,
-                                                             final Long semesterId,
-                                                             final RecruitType recruitType,
-                                                             final Pageable pageable) {
+    public Page<AdminApplyResponse> findSubmittedApplies(final JobFamily jobFamily,
+                                                         final Long semesterId,
+                                                         final RecruitType recruitType,
+                                                         final Pageable pageable) {
         Page<Apply> applyPage = adminApplyQueryRepository.findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, recruitType, pageable);
 
-        List<SubmittedApplyResponse> content = applyPage.getContent().stream()
-                .map(SubmittedApplyResponse::from)
+        List<AdminApplyResponse> content = applyPage.getContent().stream()
+                .map(AdminApplyResponse::from)
                 .toList();
 
         return PageResponse.from(content, pageable, applyPage.getTotalElements());

--- a/src/main/java/org/ject/support/admin/apply/service/SubmittedApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/SubmittedApplyService.java
@@ -10,7 +10,7 @@ import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.dto.SubmittedApplyResponse;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
-import org.ject.support.domain.apply.domain.Apply.Status;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.domain.Portfolio;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.exception.ApplyErrorCode;
@@ -47,7 +47,7 @@ public class SubmittedApplyService {
                                                              final Long semesterId,
                                                              final RecruitType recruitType,
                                                              final Pageable pageable) {
-        Page<Apply> applyPage = adminApplyQueryRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, recruitType, pageable);
+        Page<Apply> applyPage = adminApplyQueryRepository.findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, recruitType, pageable);
 
         List<SubmittedApplyResponse> content = applyPage.getContent().stream()
                 .map(SubmittedApplyResponse::from)
@@ -58,21 +58,21 @@ public class SubmittedApplyService {
 
     @Transactional(readOnly = true)
     public SubmittedApplyDetailResponse findSubmittedApplyDetail(final Long applyId) {
-        return applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED)
+        return applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED)
                 .map(this::toSubmittedApplyDetailResponse)
                 .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
     }
 
     @Transactional(readOnly = true)
     public SubmittedApplyCountResponse countSubmittedApply() {
-        Long count = applyRepository.countByStatus(Status.SUBMITTED);
+        Long count = applyRepository.countByStatus(ApplyStatus.SUBMITTED);
         return new SubmittedApplyCountResponse(count);
     }
 
     @Transactional
     public void updateSubmittedApply(final Long applyId,
                                      final SubmittedApplyEditRequest request) {
-        Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED)
+        Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED)
                 .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
 
         Member member = apply.getMember();
@@ -99,7 +99,7 @@ public class SubmittedApplyService {
 
     @Transactional
     public void deleteSubmittedApply(final Long applyId) {
-        Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED)
+        Apply apply = applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED)
                 .orElseThrow(() -> new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY));
 
         apply.reject();
@@ -109,7 +109,7 @@ public class SubmittedApplyService {
     @Transactional
     public int deleteSubmittedApplies(final List<Long> applyIds) {
         final List<Long> distinctIds = applyIds.stream().distinct().toList();
-        final List<Apply> applies = applyRepository.findAllByIdAndStatusWithMember(distinctIds, Status.SUBMITTED);
+        final List<Apply> applies = applyRepository.findAllByIdAndStatusWithMember(distinctIds, ApplyStatus.SUBMITTED);
 
         if (applies.size() != distinctIds.size()) {
             throw new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY);

--- a/src/main/java/org/ject/support/domain/apply/domain/Apply.java
+++ b/src/main/java/org/ject/support/domain/apply/domain/Apply.java
@@ -47,7 +47,7 @@ public class Apply extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(50)", nullable = false)
-    private Status status;
+    private ApplyStatus status;
 
     @Column(columnDefinition = "varchar(500) default ''", nullable = false)
     @Builder.Default
@@ -57,7 +57,7 @@ public class Apply extends BaseTimeEntity {
         return Apply.builder()
                 .member(member)
                 .recruit(recruit)
-                .status(Status.JOINED)
+                .status(ApplyStatus.JOINED)
                 .build();
     }
 
@@ -69,20 +69,20 @@ public class Apply extends BaseTimeEntity {
         this.note = note != null ? note : "";
     }
 
-    public void updateStatus(Status status) {
+    public void updateStatus(ApplyStatus status) {
         this.status = status;
     }
 
     public boolean isNotTempSaved() {
-        return status.equals(Status.JOINED)
-                || status.equals(Status.SUBMITTED)
-                || (status.equals(Status.TEMP_SAVED) && applicationForm == null);
+        return status.equals(ApplyStatus.JOINED)
+                || status.equals(ApplyStatus.SUBMITTED)
+                || (status.equals(ApplyStatus.TEMP_SAVED) && applicationForm == null);
     }
 
     public boolean isNotSubmitted() {
-        return status.equals(Status.JOINED)
-                || status.equals(Status.TEMP_SAVED)
-                || (status.equals(Status.SUBMITTED) && applicationForm == null);
+        return status.equals(ApplyStatus.JOINED)
+                || status.equals(ApplyStatus.TEMP_SAVED)
+                || (status.equals(ApplyStatus.SUBMITTED) && applicationForm == null);
     }
 
     public void deleteApplicationForm() {
@@ -93,15 +93,15 @@ public class Apply extends BaseTimeEntity {
 
     public void reject() {
         this.applicationForm = null;
-        this.status = Status.REJECTED;
+        this.status = ApplyStatus.REJECTED;
     }
 
     public boolean isTempSaved() {
-        return status.equals(Status.TEMP_SAVED);
+        return status.equals(ApplyStatus.TEMP_SAVED);
     }
 
     public boolean isSubmitted() {
-        return status.equals(Status.SUBMITTED);
+        return status.equals(ApplyStatus.SUBMITTED);
     }
 
     public void submit(ApplicationForm applicationForm) {
@@ -114,10 +114,7 @@ public class Apply extends BaseTimeEntity {
         }
 
         this.applicationForm = applicationForm;
-        this.status = Status.SUBMITTED;
+        this.status = ApplyStatus.SUBMITTED;
     }
 
-    public enum Status {
-        JOINED, TEMP_SAVED, SUBMITTED, REJECTED
-    }
 }

--- a/src/main/java/org/ject/support/domain/apply/domain/ApplyStatus.java
+++ b/src/main/java/org/ject/support/domain/apply/domain/ApplyStatus.java
@@ -1,0 +1,5 @@
+package org.ject.support.domain.apply.domain;
+
+public enum ApplyStatus {
+    JOINED, TEMP_SAVED, SUBMITTED, REJECTED
+}

--- a/src/main/java/org/ject/support/domain/apply/dto/ApplyStatusResponse.java
+++ b/src/main/java/org/ject/support/domain/apply/dto/ApplyStatusResponse.java
@@ -1,10 +1,10 @@
 package org.ject.support.domain.apply.dto;
 
 import org.ject.support.domain.apply.domain.Apply;
-import org.ject.support.domain.apply.domain.Apply.Status;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 
 public record ApplyStatusResponse(
-        Status status
+        ApplyStatus status
 ) {
     public static ApplyStatusResponse of(Apply apply) {
         return new ApplyStatusResponse(apply.getStatus());

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.apply.repository;
 
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -28,16 +29,16 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
     @Query("select count(a) > 0 from Apply a join a.recruit r where a.member.id = :memberId and r.startDate <= :now and r.endDate >= :now")
     boolean existsByMemberIdInActiveRecruit(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
 
-    List<Apply> findByRecruitAndStatus(Recruit recruit, Apply.Status status);
+    List<Apply> findByRecruitAndStatus(Recruit recruit, ApplyStatus status);
 
     @Query("select a from Apply a join fetch a.member m where a.id = :applyId and a.status = :status")
-    Optional<Apply> findByIdAndStatusWithMember(@Param("applyId") Long applyId, @Param("status") Apply.Status status);
+    Optional<Apply> findByIdAndStatusWithMember(@Param("applyId") Long applyId, @Param("status") ApplyStatus status);
 
     @Query("select a from Apply a join fetch a.member m where a.id in :applyIds and a.status = :status")
-    List<Apply> findAllByIdAndStatusWithMember(@Param("applyIds") List<Long> applyIds, @Param("status") Apply.Status status);
+    List<Apply> findAllByIdAndStatusWithMember(@Param("applyIds") List<Long> applyIds, @Param("status") ApplyStatus status);
 
     @Query("select count(a) from Apply a where a.status = :status")
-    Long countByStatus(@Param("status") Apply.Status status);
+    Long countByStatus(@Param("status") ApplyStatus status);
 
     @Query("SELECT a FROM Apply a JOIN FETCH a.member WHERE a.id IN :ids")
     List<Apply> findAllByIdWithMember(@Param("ids") List<Long> ids);

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -7,6 +7,7 @@ import org.ject.support.common.util.PeriodAccessible;
 import org.ject.support.common.util.String2MapSerializer;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.domain.Portfolio;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
@@ -35,9 +36,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
-import static org.ject.support.domain.apply.domain.Apply.Status.JOINED;
-import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
-import static org.ject.support.domain.apply.domain.Apply.Status.TEMP_SAVED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.JOINED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.TEMP_SAVED;
 import static org.ject.support.domain.apply.exception.ApplyErrorCode.ALREADY_SUBMITTED;
 import static org.ject.support.domain.apply.exception.ApplyErrorCode.NOT_FOUND_APPLY;
 
@@ -83,7 +84,7 @@ public class ApplyService implements ApplyUsecase {
         Apply apply = applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
 
-        Apply.Status applyStatus = apply.getStatus();
+        ApplyStatus applyStatus = apply.getStatus();
 
         // 2. 지원서 제출 여부 검증
         if (applyStatus.equals(SUBMITTED)) {

--- a/src/main/java/org/ject/support/domain/apply/service/RemindApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/RemindApplyService.java
@@ -2,7 +2,7 @@ package org.ject.support.domain.apply.service;
 
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.util.DateTimeUtil;
-import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.repository.ApplyRepository;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.ject.support.domain.recruit.domain.Recruit;
@@ -32,7 +32,7 @@ public class RemindApplyService implements RemindApplyUsecase {
         Recruit recruit = recruitRepository.findActiveRecruitById(recruitId, LocalDateTime.now());
 
         // 모집 기간 중 지원서 임시 저장한 지원자 ID 모두 조회
-        List<Long> applicantIds = applyRepository.findByRecruitAndStatus(recruit, Apply.Status.TEMP_SAVED)
+        List<Long> applicantIds = applyRepository.findByRecruitAndStatus(recruit, ApplyStatus.TEMP_SAVED)
                 .stream()
                 .map(apply -> apply.getMember().getId())
                 .toList();

--- a/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
-import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
 import static org.ject.support.domain.apply.domain.QApply.apply;
 import static org.ject.support.domain.member.JobFamily.BE;
 import static org.ject.support.domain.member.JobFamily.FE;

--- a/src/test/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryTest.java
@@ -1,5 +1,15 @@
 package org.ject.support.admin.apply.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.TEMP_SAVED;
+import static org.ject.support.domain.member.JobFamily.BE;
+import static org.ject.support.domain.member.JobFamily.FE;
+import static org.ject.support.domain.member.JobFamily.PM;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.time.LocalDateTime;
+import java.util.List;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.ApplyStatus;
@@ -21,17 +31,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
-import static org.ject.support.domain.apply.domain.ApplyStatus.TEMP_SAVED;
-import static org.ject.support.domain.member.JobFamily.BE;
-import static org.ject.support.domain.member.JobFamily.FE;
-import static org.ject.support.domain.member.JobFamily.PM;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @Import({QueryDslTestConfig.class, AdminApplyQueryRepositoryImpl.class})
 @DataJpaTest
@@ -87,7 +86,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, null, null, pageable);
+        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(status, null, BE, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(2);
@@ -114,7 +113,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(null, status, null, null, pageable);
+        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(status, null, null, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(3);
@@ -136,7 +135,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, null, null, pageable);
+        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(status, null, BE, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
@@ -159,7 +158,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, null, null, pageable);
+        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(status, null, BE, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
@@ -180,7 +179,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, null, null, pageable);
+        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(status, null, BE, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(10);
@@ -196,7 +195,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, null, null, pageable);
+        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(status, null, BE, null, pageable);
 
 
         // then
@@ -225,7 +224,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, null, null, pageable);
+        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(status, null, BE, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(3);
@@ -268,7 +267,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, semester.getId(), null, pageable);
+        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(status, semester.getId(), BE, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
@@ -307,7 +306,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(null, status, null, org.ject.support.domain.recruit.domain.RecruitType.BACKFILL, pageable);
+        Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(status, null, null, org.ject.support.domain.recruit.domain.RecruitType.BACKFILL, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);

--- a/src/test/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryTest.java
@@ -2,6 +2,7 @@ package org.ject.support.admin.apply.repository;
 
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Role;
@@ -25,8 +26,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
-import static org.ject.support.domain.apply.domain.Apply.Status.TEMP_SAVED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.TEMP_SAVED;
 import static org.ject.support.domain.member.JobFamily.BE;
 import static org.ject.support.domain.member.JobFamily.FE;
 import static org.ject.support.domain.member.JobFamily.PM;
@@ -83,7 +84,7 @@ class AdminApplyQueryRepositoryTest {
         applyRepository.saveAll(List.of(beApply1, beApply2, feApply));
 
         Pageable pageable = PageRequest.of(0, 15);
-        Apply.Status status = SUBMITTED;
+        ApplyStatus status = SUBMITTED;
 
         // when
         Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, null, null, pageable);
@@ -110,7 +111,7 @@ class AdminApplyQueryRepositoryTest {
         applyRepository.saveAll(List.of(beApply, feApply, pmApply));
 
         Pageable pageable = PageRequest.of(0, 15);
-        Apply.Status status = SUBMITTED;
+        ApplyStatus status = SUBMITTED;
 
         // when
         Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(null, status, null, null, pageable);
@@ -132,7 +133,7 @@ class AdminApplyQueryRepositoryTest {
         applyRepository.saveAll(List.of(submittedApply, tempApply));
 
         Pageable pageable = PageRequest.of(0, 15);
-        Apply.Status status = SUBMITTED;
+        ApplyStatus status = SUBMITTED;
 
         // when
         Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, null, null, pageable);
@@ -155,7 +156,7 @@ class AdminApplyQueryRepositoryTest {
         applyRepository.saveAll(List.of(activeApply, deletedApply));
 
         Pageable pageable = PageRequest.of(0, 15);
-        Apply.Status status = SUBMITTED;
+        ApplyStatus status = SUBMITTED;
 
         // when
         Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, null, null, pageable);
@@ -176,7 +177,7 @@ class AdminApplyQueryRepositoryTest {
         }
 
         Pageable pageable = PageRequest.of(1, 10);
-        Apply.Status status = SUBMITTED;
+        ApplyStatus status = SUBMITTED;
 
         // when
         Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, null, null, pageable);
@@ -192,7 +193,7 @@ class AdminApplyQueryRepositoryTest {
     void 제출된_지원서가_없으면_빈_페이지_반환() {
         // given
         Pageable pageable = PageRequest.of(0, 15);
-        Apply.Status status = SUBMITTED;
+        ApplyStatus status = SUBMITTED;
 
         // when
         Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, null, null, pageable);
@@ -221,7 +222,7 @@ class AdminApplyQueryRepositoryTest {
         applyRepository.save(apply3);
 
         Pageable pageable = PageRequest.of(0, 15);
-        Apply.Status status = SUBMITTED;
+        ApplyStatus status = SUBMITTED;
 
         // when
         Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, null, null, pageable);
@@ -264,7 +265,7 @@ class AdminApplyQueryRepositoryTest {
         applyRepository.saveAll(List.of(apply1, apply2));
 
         Pageable pageable = PageRequest.of(0, 15);
-        Apply.Status status = SUBMITTED;
+        ApplyStatus status = SUBMITTED;
 
         // when
         Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(BE, status, semester.getId(), null, pageable);
@@ -303,7 +304,7 @@ class AdminApplyQueryRepositoryTest {
         applyRepository.saveAll(List.of(apply1, apply2));
 
         Pageable pageable = PageRequest.of(0, 15);
-        Apply.Status status = SUBMITTED;
+        ApplyStatus status = SUBMITTED;
 
         // when
         Page<Apply> result = adminApplyQueryRepository.findAppliesByStatus(null, status, null, org.ject.support.domain.recruit.domain.RecruitType.BACKFILL, pageable);
@@ -323,7 +324,7 @@ class AdminApplyQueryRepositoryTest {
                 .build();
     }
 
-    private Apply getApply(Member member, Recruit recruit, Apply.Status status) {
+    private Apply getApply(Member member, Recruit recruit, ApplyStatus status) {
         ApplicationForm applicationForm = ApplicationForm.builder()
                 .build();
 

--- a/src/test/java/org/ject/support/admin/apply/service/AdminTempApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/AdminTempApplyServiceTest.java
@@ -1,15 +1,22 @@
 package org.ject.support.admin.apply.service;
 
-import org.ject.support.base.UnitTestSupport;
-import org.ject.support.common.util.String2MapSerializer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
 import org.ject.support.admin.apply.dto.TempApplyDetailResponse;
 import org.ject.support.admin.apply.dto.TempSavedApplyCountResponse;
 import org.ject.support.admin.apply.dto.TempSavedApplyResponse;
+import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.common.util.String2MapSerializer;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.exception.ApplyException;
-import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
 import org.ject.support.domain.apply.repository.ApplyRepository;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.recruit.domain.Recruit;
@@ -21,14 +28,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 
 class AdminTempApplyServiceTest extends UnitTestSupport {
 
@@ -172,14 +171,14 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
         Long semesterId = null;
         Page<Apply> applyPage = new PageImpl<>(List.of(), pageable, 0);
 
-        given(adminApplyQueryRepository.findAppliesByStatus(null, ApplyStatus.TEMP_SAVED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable))
                 .willReturn(applyPage);
 
         // when
         Page<TempSavedApplyResponse> result = adminTempApplyService.getTempApplies(null, semesterId, pageable);
 
         // then
-        verify(adminApplyQueryRepository).findAppliesByStatus(null, ApplyStatus.TEMP_SAVED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
         assertThat(result.getTotalElements()).isEqualTo(0);
         assertThat(result.getContent()).isEmpty();
     }
@@ -217,7 +216,7 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
         List<Apply> applies = List.of(a1, a2);
         Page<Apply> applyPage = new PageImpl<>(applies, pageable, applies.size());
 
-        given(adminApplyQueryRepository.findAppliesByStatus(null, ApplyStatus.TEMP_SAVED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable))
                 .willReturn(applyPage);
 
         // applicationForm.content가 "{}" 이므로 이 호출을 stub 처리
@@ -226,7 +225,7 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
         Page<TempSavedApplyResponse> result =
                 adminTempApplyService.getTempApplies(null, semesterId, pageable);
 
-        verify(adminApplyQueryRepository).findAppliesByStatus(null, ApplyStatus.TEMP_SAVED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
         assertThat(result.getTotalElements()).isEqualTo(2);
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getContent().get(0).applyId()).isEqualTo(1L);
@@ -255,7 +254,7 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
         List<Apply> applies = List.of(apply);
         Page<Apply> applyPage = new PageImpl<>(applies, pageable, applies.size());
 
-        given(adminApplyQueryRepository.findAppliesByStatus(null, ApplyStatus.TEMP_SAVED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable))
                 .willReturn(applyPage);
         given(string2MapSerializer.serializeAsMap("{}")).willReturn(java.util.Map.of());
 
@@ -263,7 +262,7 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
         Page<TempSavedApplyResponse> result = adminTempApplyService.getTempApplies(null, semesterId, pageable);
 
         // then
-        verify(adminApplyQueryRepository).findAppliesByStatus(null, ApplyStatus.TEMP_SAVED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).applyId()).isEqualTo(1L);

--- a/src/test/java/org/ject/support/admin/apply/service/AdminTempApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/AdminTempApplyServiceTest.java
@@ -7,6 +7,7 @@ import org.ject.support.admin.apply.dto.TempSavedApplyCountResponse;
 import org.ject.support.admin.apply.dto.TempSavedApplyResponse;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
 import org.ject.support.domain.apply.repository.ApplyRepository;
@@ -47,7 +48,7 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
     void 존재하지_않는_임시_저장된_지원서를_조회하면_예외_발생() {
         // given
         Long tempApplyId = 1L;
-        given(applyRepository.findByIdAndStatusWithMember(tempApplyId, Apply.Status.TEMP_SAVED))
+        given(applyRepository.findByIdAndStatusWithMember(tempApplyId, ApplyStatus.TEMP_SAVED))
                 .willReturn(Optional.empty());
 
         // when, then
@@ -72,24 +73,24 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
                 .id(tempApplyId)
                 .member(member)
                 .recruit(recruit)
-                .status(Apply.Status.TEMP_SAVED)
+                .status(ApplyStatus.TEMP_SAVED)
                 .applicationForm(ApplicationForm.builder().build())
                 .build();
-        given(applyRepository.findByIdAndStatusWithMember(tempApplyId, Apply.Status.TEMP_SAVED))
+        given(applyRepository.findByIdAndStatusWithMember(tempApplyId, ApplyStatus.TEMP_SAVED))
                 .willReturn(Optional.of(submittedApply));
 
         // when
         TempApplyDetailResponse result = adminTempApplyService.getTempApplyDetail(tempApplyId);
 
         // then
-        verify(applyRepository).findByIdAndStatusWithMember(tempApplyId, Apply.Status.TEMP_SAVED);
+        verify(applyRepository).findByIdAndStatusWithMember(tempApplyId, ApplyStatus.TEMP_SAVED);
         assertThat(result.applyId()).isEqualTo(tempApplyId);
     }
 
     @Test
     void 임시_저장된_지원서의_총_개수를_조회한다() {
         // given
-        Apply.Status targetStatus = Apply.Status.TEMP_SAVED;
+        ApplyStatus targetStatus = ApplyStatus.TEMP_SAVED;
         Long tempSavedCount = 5L;
         given(applyRepository.countByStatus(targetStatus))
                 .willReturn(tempSavedCount);
@@ -105,7 +106,7 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
     @Test
     void 임시_저장된_지원서의_총_개수가_0개일_경우_0을_조회한다() {
         // given
-        Apply.Status targetStatus = Apply.Status.TEMP_SAVED;
+        ApplyStatus targetStatus = ApplyStatus.TEMP_SAVED;
         Long tempSavedCount = 0L;
         given(applyRepository.countByStatus(targetStatus))
                 .willReturn(tempSavedCount);
@@ -122,7 +123,7 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
     void 존재하지_않는_임시_저장_상태의_지원서를_삭제_할_경우_예외_발생() {
         // given
         Long tempApplyId = 1L;
-        given(applyRepository.findByIdAndStatusWithMember(tempApplyId, Apply.Status.TEMP_SAVED))
+        given(applyRepository.findByIdAndStatusWithMember(tempApplyId, ApplyStatus.TEMP_SAVED))
                 .willReturn(Optional.empty());
 
         // when, then
@@ -150,17 +151,17 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
                 .id(tempApplyId)
                 .member(member)
                 .recruit(recruit)
-                .status(Apply.Status.TEMP_SAVED)
+                .status(ApplyStatus.TEMP_SAVED)
                 .applicationForm(applicationForm)
                 .build();
-        given(applyRepository.findByIdAndStatusWithMember(tempApplyId, Apply.Status.TEMP_SAVED))
+        given(applyRepository.findByIdAndStatusWithMember(tempApplyId, ApplyStatus.TEMP_SAVED))
                 .willReturn(Optional.of(tempSavedApply));
 
         // when
         adminTempApplyService.deleteTempApply(tempApplyId);
 
         // then
-        verify(applyRepository).findByIdAndStatusWithMember(tempApplyId, Apply.Status.TEMP_SAVED);
+        verify(applyRepository).findByIdAndStatusWithMember(tempApplyId, ApplyStatus.TEMP_SAVED);
         verify(applyRepository).delete(tempSavedApply);
     }
 
@@ -171,14 +172,14 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
         Long semesterId = null;
         Page<Apply> applyPage = new PageImpl<>(List.of(), pageable, 0);
 
-        given(adminApplyQueryRepository.findAppliesByStatus(null, Apply.Status.TEMP_SAVED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(null, ApplyStatus.TEMP_SAVED, semesterId, null, pageable))
                 .willReturn(applyPage);
 
         // when
         Page<TempSavedApplyResponse> result = adminTempApplyService.getTempApplies(null, semesterId, pageable);
 
         // then
-        verify(adminApplyQueryRepository).findAppliesByStatus(null, Apply.Status.TEMP_SAVED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(null, ApplyStatus.TEMP_SAVED, semesterId, null, pageable);
         assertThat(result.getTotalElements()).isEqualTo(0);
         assertThat(result.getContent()).isEmpty();
     }
@@ -201,7 +202,7 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
                 .id(1L)
                 .member(m1)
                 .recruit(recruit)
-                .status(Apply.Status.TEMP_SAVED)
+                .status(ApplyStatus.TEMP_SAVED)
                 .applicationForm(form1)
                 .build();
 
@@ -209,14 +210,14 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
                 .id(2L)
                 .member(m2)
                 .recruit(recruit)
-                .status(Apply.Status.TEMP_SAVED)
+                .status(ApplyStatus.TEMP_SAVED)
                 .applicationForm(form2)
                 .build();
 
         List<Apply> applies = List.of(a1, a2);
         Page<Apply> applyPage = new PageImpl<>(applies, pageable, applies.size());
 
-        given(adminApplyQueryRepository.findAppliesByStatus(null, Apply.Status.TEMP_SAVED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(null, ApplyStatus.TEMP_SAVED, semesterId, null, pageable))
                 .willReturn(applyPage);
 
         // applicationForm.content가 "{}" 이므로 이 호출을 stub 처리
@@ -225,7 +226,7 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
         Page<TempSavedApplyResponse> result =
                 adminTempApplyService.getTempApplies(null, semesterId, pageable);
 
-        verify(adminApplyQueryRepository).findAppliesByStatus(null, Apply.Status.TEMP_SAVED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(null, ApplyStatus.TEMP_SAVED, semesterId, null, pageable);
         assertThat(result.getTotalElements()).isEqualTo(2);
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getContent().get(0).applyId()).isEqualTo(1L);
@@ -247,14 +248,14 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
                 .id(1L)
                 .member(member)
                 .recruit(recruit)
-                .status(Apply.Status.TEMP_SAVED)
+                .status(ApplyStatus.TEMP_SAVED)
                 .applicationForm(form)
                 .build();
 
         List<Apply> applies = List.of(apply);
         Page<Apply> applyPage = new PageImpl<>(applies, pageable, applies.size());
 
-        given(adminApplyQueryRepository.findAppliesByStatus(null, Apply.Status.TEMP_SAVED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(null, ApplyStatus.TEMP_SAVED, semesterId, null, pageable))
                 .willReturn(applyPage);
         given(string2MapSerializer.serializeAsMap("{}")).willReturn(java.util.Map.of());
 
@@ -262,7 +263,7 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
         Page<TempSavedApplyResponse> result = adminTempApplyService.getTempApplies(null, semesterId, pageable);
 
         // then
-        verify(adminApplyQueryRepository).findAppliesByStatus(null, Apply.Status.TEMP_SAVED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(null, ApplyStatus.TEMP_SAVED, semesterId, null, pageable);
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).applyId()).isEqualTo(1L);

--- a/src/test/java/org/ject/support/admin/apply/service/AdminTempApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/AdminTempApplyServiceTest.java
@@ -5,11 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-import java.util.List;
 import java.util.Optional;
 import org.ject.support.admin.apply.dto.TempApplyDetailResponse;
 import org.ject.support.admin.apply.dto.TempSavedApplyCountResponse;
-import org.ject.support.admin.apply.dto.TempSavedApplyResponse;
 import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.util.String2MapSerializer;
@@ -24,10 +22,6 @@ import org.ject.support.domain.recruit.domain.Semester;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
 class AdminTempApplyServiceTest extends UnitTestSupport {
 
@@ -162,109 +156,5 @@ class AdminTempApplyServiceTest extends UnitTestSupport {
         // then
         verify(applyRepository).findByIdAndStatusWithMember(tempApplyId, ApplyStatus.TEMP_SAVED);
         verify(applyRepository).delete(tempSavedApply);
-    }
-
-    @Test
-    void 임시_저장된_지원서를_조회할때_결과가_없으면_빈페이지_반환한다() {
-        // given
-        Pageable pageable = PageRequest.of(0, 10);
-        Long semesterId = null;
-        Page<Apply> applyPage = new PageImpl<>(List.of(), pageable, 0);
-
-        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable))
-                .willReturn(applyPage);
-
-        // when
-        Page<TempSavedApplyResponse> result = adminTempApplyService.getTempApplies(null, semesterId, pageable);
-
-        // then
-        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
-        assertThat(result.getTotalElements()).isEqualTo(0);
-        assertThat(result.getContent()).isEmpty();
-    }
-
-    @Test
-    void 임시_저장된_지원서를_조회_한다() {
-        // given
-        Pageable pageable = PageRequest.of(0, 10);
-        Long semesterId = null;
-
-        Member m1 = Member.builder().name("김1").build();
-        Member m2 = Member.builder().name("김2").build();
-        Semester semester = Semester.builder().name("1").build();
-        Recruit recruit = Recruit.builder().semester(semester).build();
-
-        ApplicationForm form1 = ApplicationForm.builder().content("{}").build();
-        ApplicationForm form2 = ApplicationForm.builder().content("{}").build();
-
-        Apply a1 = Apply.builder()
-                .id(1L)
-                .member(m1)
-                .recruit(recruit)
-                .status(ApplyStatus.TEMP_SAVED)
-                .applicationForm(form1)
-                .build();
-
-        Apply a2 = Apply.builder()
-                .id(2L)
-                .member(m2)
-                .recruit(recruit)
-                .status(ApplyStatus.TEMP_SAVED)
-                .applicationForm(form2)
-                .build();
-
-        List<Apply> applies = List.of(a1, a2);
-        Page<Apply> applyPage = new PageImpl<>(applies, pageable, applies.size());
-
-        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable))
-                .willReturn(applyPage);
-
-        // applicationForm.content가 "{}" 이므로 이 호출을 stub 처리
-        given(string2MapSerializer.serializeAsMap("{}")).willReturn(java.util.Map.of());
-
-        Page<TempSavedApplyResponse> result =
-                adminTempApplyService.getTempApplies(null, semesterId, pageable);
-
-        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
-        assertThat(result.getTotalElements()).isEqualTo(2);
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getContent().get(0).applyId()).isEqualTo(1L);
-        assertThat(result.getContent().get(1).applyId()).isEqualTo(2L);
-    }
-
-    @Test
-    void 임시_저장된_지원서를_semesterId로_필터링하여_조회한다() {
-        // given
-        Pageable pageable = PageRequest.of(0, 10);
-        Long semesterId = 1L;
-
-        Member member = Member.builder().name("김젝트").build();
-        Semester semester = Semester.builder().name("1").build();
-        Recruit recruit = Recruit.builder().semester(semester).build();
-        ApplicationForm form = ApplicationForm.builder().content("{}").build();
-
-        Apply apply = Apply.builder()
-                .id(1L)
-                .member(member)
-                .recruit(recruit)
-                .status(ApplyStatus.TEMP_SAVED)
-                .applicationForm(form)
-                .build();
-
-        List<Apply> applies = List.of(apply);
-        Page<Apply> applyPage = new PageImpl<>(applies, pageable, applies.size());
-
-        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable))
-                .willReturn(applyPage);
-        given(string2MapSerializer.serializeAsMap("{}")).willReturn(java.util.Map.of());
-
-        // when
-        Page<TempSavedApplyResponse> result = adminTempApplyService.getTempApplies(null, semesterId, pageable);
-
-        // then
-        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
-        assertThat(result.getTotalElements()).isEqualTo(1);
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).applyId()).isEqualTo(1L);
     }
 }

--- a/src/test/java/org/ject/support/admin/apply/service/ApplyPassServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/ApplyPassServiceTest.java
@@ -3,6 +3,7 @@ package org.ject.support.admin.apply.service;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.domain.apply.repository.ApplyRepository;
 import org.ject.support.domain.member.JobFamily;
@@ -40,9 +41,9 @@ class ApplyPassServiceTest extends UnitTestSupport {
         Member applicant2 = getApplicant(2L, "applicant2@test.com");
         Member applicant3 = getApplicant(3L, "applicant3@test.com");
 
-        Apply apply1 = getApply(1L, recruit, applicant1, getApplicationForm("content"), Apply.Status.SUBMITTED);
-        Apply apply2 = getApply(2L, recruit, applicant2, getApplicationForm("content"), Apply.Status.SUBMITTED);
-        Apply apply3 = getApply(3L, recruit, applicant3, getApplicationForm("content"), Apply.Status.SUBMITTED);
+        Apply apply1 = getApply(1L, recruit, applicant1, getApplicationForm("content"), ApplyStatus.SUBMITTED);
+        Apply apply2 = getApply(2L, recruit, applicant2, getApplicationForm("content"), ApplyStatus.SUBMITTED);
+        Apply apply3 = getApply(3L, recruit, applicant3, getApplicationForm("content"), ApplyStatus.SUBMITTED);
 
         when(applyRepository.findAllByIdWithMember(List.of(1L, 2L, 3L))).thenReturn(List.of(apply1, apply2, apply3));
 
@@ -64,9 +65,9 @@ class ApplyPassServiceTest extends UnitTestSupport {
         Member applicant2 = getApplicant(2L, "applicant2@test.com");
         Member applicant3 = getApplicant(3L, "applicant3@test.com");
 
-        Apply apply1 = getApply(1L, recruit, applicant1, getApplicationForm("content"), Apply.Status.SUBMITTED);
-        Apply apply2 = getApply(2L, recruit, applicant2, getApplicationForm("content"), Apply.Status.TEMP_SAVED);
-        Apply apply3 = getApply(3L, recruit, applicant3, getApplicationForm("content"), Apply.Status.SUBMITTED);
+        Apply apply1 = getApply(1L, recruit, applicant1, getApplicationForm("content"), ApplyStatus.SUBMITTED);
+        Apply apply2 = getApply(2L, recruit, applicant2, getApplicationForm("content"), ApplyStatus.TEMP_SAVED);
+        Apply apply3 = getApply(3L, recruit, applicant3, getApplicationForm("content"), ApplyStatus.SUBMITTED);
 
         when(applyRepository.findAllByIdWithMember(List.of(1L, 2L, 3L))).thenReturn(List.of(apply1, apply2, apply3));
 
@@ -96,7 +97,7 @@ class ApplyPassServiceTest extends UnitTestSupport {
                 .build();
     }
 
-    private Apply getApply(Long id, Recruit recruit, Member applicant, ApplicationForm applicationForm, Apply.Status status) {
+    private Apply getApply(Long id, Recruit recruit, Member applicant, ApplicationForm applicationForm, ApplyStatus status) {
         return Apply.builder()
                 .id(id)
                 .recruit(recruit)

--- a/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
@@ -3,15 +3,12 @@ package org.ject.support.admin.apply.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.ject.support.admin.apply.dto.AdminApplyResponse;
-import org.ject.support.admin.apply.dto.SubmittedApplyCountResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyDetailResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
@@ -220,36 +217,6 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
     }
 
     @Test
-    void 제출된_지원서_수_조회_성공() {
-        // given
-        Long expectedCount = 10L;
-        given(applyRepository.countByStatus(ApplyStatus.SUBMITTED))
-                .willReturn(expectedCount);
-
-        // when
-        SubmittedApplyCountResponse response = submittedApplyService.countSubmittedApply();
-
-        // then
-        assertThat(response.count()).isEqualTo(expectedCount);
-        then(applyRepository).should(times(1)).countByStatus(ApplyStatus.SUBMITTED);
-    }
-
-    @Test
-    void 제출된_지원서가_없을_때_0_반환() {
-        // given
-        Long expectedCount = 0L;
-        given(applyRepository.countByStatus(ApplyStatus.SUBMITTED))
-                .willReturn(expectedCount);
-
-        // when
-        SubmittedApplyCountResponse response = submittedApplyService.countSubmittedApply();
-
-        // then
-        assertThat(response.count()).isZero();
-        then(applyRepository).should(times(1)).countByStatus(ApplyStatus.SUBMITTED);
-    }
-
-    @Test
     void 제출된_지원서_목록_조회_성공() {
         // given
         var pageable = PageRequest.of(0, 15);
@@ -263,7 +230,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = submittedApplyService.findApplies(, semesterId, jobFamily, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
@@ -283,7 +250,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = submittedApplyService.findApplies(, semesterId, null, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(ApplyStatus.SUBMITTED, semesterId, null, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
@@ -303,7 +270,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = submittedApplyService.findApplies(, semesterId, jobFamily, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
 
         // then
         assertThat(result.getContent()).isEmpty();
@@ -334,7 +301,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = submittedApplyService.findApplies(, semesterId, jobFamily, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(2);
@@ -358,7 +325,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = submittedApplyService.findApplies(, semesterId, jobFamily, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);

--- a/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
@@ -259,16 +259,16 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         var applies = List.of(submittedApply);
         var page = new PageImpl<>(applies, pageable, 1L);
 
-        given(adminApplyQueryRepository.findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(, semesterId, jobFamily, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(adminApplyQueryRepository).findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
     }
 
     @Test
@@ -279,16 +279,16 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         var applies = List.of(submittedApply);
         var page = new PageImpl<>(applies, pageable, 1L);
 
-        given(adminApplyQueryRepository.findAppliesByStatus(null, ApplyStatus.SUBMITTED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, null, null, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = submittedApplyService.findSubmittedApplies(null, semesterId, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(, semesterId, null, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(adminApplyQueryRepository).findAppliesByStatus(null, ApplyStatus.SUBMITTED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, null, null, pageable);
     }
 
     @Test
@@ -299,16 +299,16 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         Long semesterId = null;
         var page = new PageImpl<Apply>(List.of(), pageable, 0L);
 
-        given(adminApplyQueryRepository.findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(, semesterId, jobFamily, null, pageable);
 
         // then
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
-        verify(adminApplyQueryRepository).findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
     }
 
     @Test
@@ -330,18 +330,18 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         var applies = List.of(submittedApply, apply2);
         var page = new PageImpl<>(applies, pageable, 25L);
 
-        given(adminApplyQueryRepository.findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(, semesterId, jobFamily, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(25L);
         assertThat(result.getNumber()).isEqualTo(1);
         assertThat(result.getSize()).isEqualTo(10);
-        verify(adminApplyQueryRepository).findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
     }
 
     @Test
@@ -354,16 +354,16 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         var applies = List.of(submittedApply);
         var page = new PageImpl<>(applies, pageable, 1L);
 
-        given(adminApplyQueryRepository.findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(, semesterId, jobFamily, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(adminApplyQueryRepository).findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
@@ -9,7 +9,7 @@ import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.dto.SubmittedApplyResponse;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
-import org.ject.support.domain.apply.domain.Apply.Status;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.exception.ApplyErrorCode;
 import org.ject.support.domain.apply.exception.ApplyException;
@@ -95,7 +95,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .id(applyId)
                 .member(member)
                 .recruit(recruit)
-                .status(Apply.Status.SUBMITTED)
+                .status(ApplyStatus.SUBMITTED)
                 .note("Test note")
                 .applicationForm(ApplicationForm.builder().build())
                 .build();
@@ -105,15 +105,15 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
     void 제출된_지원서_단건_삭제_성공() {
         // given
         var applyId = submittedApply.getId();
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+        given(applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED))
                 .willReturn(Optional.of(submittedApply));
 
         // when
         submittedApplyService.deleteSubmittedApply(applyId);
 
         // then
-        verify(applyRepository).findByIdAndStatusWithMember(applyId, Status.SUBMITTED);
-        assertThat(submittedApply.getStatus()).isEqualTo(Status.REJECTED);
+        verify(applyRepository).findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED);
+        assertThat(submittedApply.getStatus()).isEqualTo(ApplyStatus.REJECTED);
         assertThat(submittedApply.getApplicationForm()).isNull();
         assertThat(submittedApply.getMember().getName()).isNull();
     }
@@ -122,7 +122,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
     void 제출된_지원서_단건_삭제시_존재하지_않으면_예외_발생() {
         // given
         var applyId = submittedApply.getId();
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+        given(applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED))
                 .willReturn(Optional.empty());
 
         // expected
@@ -142,7 +142,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .id(2L)
                 .member(member2)
                 .recruit(submittedApply.getRecruit())
-                .status(Status.SUBMITTED)
+                .status(ApplyStatus.SUBMITTED)
                 .applicationForm(ApplicationForm.builder().build())
                 .build();
 
@@ -150,27 +150,27 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .id(3L)
                 .member(member3)
                 .recruit(submittedApply.getRecruit())
-                .status(Status.SUBMITTED)
+                .status(ApplyStatus.SUBMITTED)
                 .applicationForm(ApplicationForm.builder().build())
                 .build();
 
         var applies = List.of(submittedApply, apply2, apply3);
 
-        given(applyRepository.findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED))
+        given(applyRepository.findAllByIdAndStatusWithMember(applyIds, ApplyStatus.SUBMITTED))
                 .willReturn(applies);
 
         // when
         int deleted = submittedApplyService.deleteSubmittedApplies(applyIds);
 
         // then
-        verify(applyRepository).findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED);
+        verify(applyRepository).findAllByIdAndStatusWithMember(applyIds, ApplyStatus.SUBMITTED);
         assertThat(deleted).isEqualTo(3);
-        assertThat(submittedApply.getStatus()).isEqualTo(Status.REJECTED);
+        assertThat(submittedApply.getStatus()).isEqualTo(ApplyStatus.REJECTED);
         assertThat(submittedApply.getApplicationForm()).isNull();
         assertThat(submittedApply.getMember().getName()).isNull();
-        assertThat(apply2.getStatus()).isEqualTo(Status.REJECTED);
+        assertThat(apply2.getStatus()).isEqualTo(ApplyStatus.REJECTED);
         assertThat(apply2.getApplicationForm()).isNull();
-        assertThat(apply3.getStatus()).isEqualTo(Status.REJECTED);
+        assertThat(apply3.getStatus()).isEqualTo(ApplyStatus.REJECTED);
         assertThat(apply3.getApplicationForm()).isNull();
     }
 
@@ -180,7 +180,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         var applyIds = List.of(1L, 2L, 3L);
         var applies = List.of(submittedApply); // 1개만 반환
 
-        given(applyRepository.findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED))
+        given(applyRepository.findAllByIdAndStatusWithMember(applyIds, ApplyStatus.SUBMITTED))
                 .willReturn(applies);
 
         // expected
@@ -194,7 +194,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         // given
         var applyIds = List.of(1L, 2L, 3L);
 
-        given(applyRepository.findAllByIdAndStatusWithMember(applyIds, Status.SUBMITTED))
+        given(applyRepository.findAllByIdAndStatusWithMember(applyIds, ApplyStatus.SUBMITTED))
                 .willReturn(List.of());
 
         // expected
@@ -209,7 +209,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         var applyIds = List.of(1L, 1L, 1L);
         var distinctIds = List.of(1L);
 
-        given(applyRepository.findAllByIdAndStatusWithMember(distinctIds, Status.SUBMITTED))
+        given(applyRepository.findAllByIdAndStatusWithMember(distinctIds, ApplyStatus.SUBMITTED))
                 .willReturn(List.of(submittedApply));
 
         // when
@@ -217,14 +217,14 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
 
         // then
         assertThat(deleted).isEqualTo(1);
-        verify(applyRepository).findAllByIdAndStatusWithMember(distinctIds, Status.SUBMITTED);
+        verify(applyRepository).findAllByIdAndStatusWithMember(distinctIds, ApplyStatus.SUBMITTED);
     }
 
     @Test
     void 제출된_지원서_수_조회_성공() {
         // given
         Long expectedCount = 10L;
-        given(applyRepository.countByStatus(Status.SUBMITTED))
+        given(applyRepository.countByStatus(ApplyStatus.SUBMITTED))
                 .willReturn(expectedCount);
 
         // when
@@ -232,14 +232,14 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
 
         // then
         assertThat(response.count()).isEqualTo(expectedCount);
-        then(applyRepository).should(times(1)).countByStatus(Status.SUBMITTED);
+        then(applyRepository).should(times(1)).countByStatus(ApplyStatus.SUBMITTED);
     }
 
     @Test
     void 제출된_지원서가_없을_때_0_반환() {
         // given
         Long expectedCount = 0L;
-        given(applyRepository.countByStatus(Status.SUBMITTED))
+        given(applyRepository.countByStatus(ApplyStatus.SUBMITTED))
                 .willReturn(expectedCount);
 
         // when
@@ -247,7 +247,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
 
         // then
         assertThat(response.count()).isZero();
-        then(applyRepository).should(times(1)).countByStatus(Status.SUBMITTED);
+        then(applyRepository).should(times(1)).countByStatus(ApplyStatus.SUBMITTED);
     }
 
     @Test
@@ -260,7 +260,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         var applies = List.of(submittedApply);
         var page = new PageImpl<>(applies, pageable, 1L);
 
-        given(adminApplyQueryRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable))
                 .willReturn(page);
 
         // when
@@ -269,7 +269,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(adminApplyQueryRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable);
     }
 
     @Test
@@ -280,7 +280,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         var applies = List.of(submittedApply);
         var page = new PageImpl<>(applies, pageable, 1L);
 
-        given(adminApplyQueryRepository.findAppliesByStatus(null, Status.SUBMITTED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(null, ApplyStatus.SUBMITTED, semesterId, null, pageable))
                 .willReturn(page);
 
         // when
@@ -289,7 +289,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(adminApplyQueryRepository).findAppliesByStatus(null, Status.SUBMITTED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(null, ApplyStatus.SUBMITTED, semesterId, null, pageable);
     }
 
     @Test
@@ -300,7 +300,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         Long semesterId = null;
         var page = new PageImpl<Apply>(List.of(), pageable, 0L);
 
-        given(adminApplyQueryRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable))
                 .willReturn(page);
 
         // when
@@ -309,7 +309,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         // then
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
-        verify(adminApplyQueryRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable);
     }
 
     @Test
@@ -324,14 +324,14 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .id(2L)
                 .member(member2)
                 .recruit(submittedApply.getRecruit())
-                .status(Status.SUBMITTED)
+                .status(ApplyStatus.SUBMITTED)
                 .applicationForm(ApplicationForm.builder().build())
                 .build();
 
         var applies = List.of(submittedApply, apply2);
         var page = new PageImpl<>(applies, pageable, 25L);
 
-        given(adminApplyQueryRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable))
                 .willReturn(page);
 
         // when
@@ -342,7 +342,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         assertThat(result.getTotalElements()).isEqualTo(25L);
         assertThat(result.getNumber()).isEqualTo(1);
         assertThat(result.getSize()).isEqualTo(10);
-        verify(adminApplyQueryRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable);
     }
 
     @Test
@@ -355,7 +355,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         var applies = List.of(submittedApply);
         var page = new PageImpl<>(applies, pageable, 1L);
 
-        given(adminApplyQueryRepository.findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, null, pageable))
+        given(adminApplyQueryRepository.findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable))
                 .willReturn(page);
 
         // when
@@ -364,14 +364,14 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(adminApplyQueryRepository).findAppliesByStatus(jobFamily, Status.SUBMITTED, semesterId, null, pageable);
+        verify(adminApplyQueryRepository).findAppliesByStatus(jobFamily, ApplyStatus.SUBMITTED, semesterId, null, pageable);
     }
 
     @Test
     void 존재하지_않는_제출된_지원서를_상세조회할_경우_예외가_발생() {
         // given
         var applyId = submittedApply.getId() + 1L;
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+        given(applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED))
                 .willReturn(Optional.empty());
 
         // expected
@@ -389,13 +389,13 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .build();
         var apply2 = Apply.builder()
                 .id(applyId)
-                .status(Status.SUBMITTED)
+                .status(ApplyStatus.SUBMITTED)
                 .applicationForm(null)
                 .member(member2)
                 .recruit(submittedApply.getRecruit())
                 .build();
 
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+        given(applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED))
                 .willReturn(Optional.of(apply2));
 
         // when
@@ -412,14 +412,14 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         // given
         given(applyRepository.findByIdAndStatusWithMember(
                 submittedApply.getId(),
-                Status.SUBMITTED
+                ApplyStatus.SUBMITTED
         )).willReturn(Optional.of(submittedApply));
 
         // when
         SubmittedApplyDetailResponse actual = submittedApplyService.findSubmittedApplyDetail(submittedApply.getId());
 
         // then
-        verify(applyRepository).findByIdAndStatusWithMember(submittedApply.getId(), Status.SUBMITTED);
+        verify(applyRepository).findByIdAndStatusWithMember(submittedApply.getId(), ApplyStatus.SUBMITTED);
         assertThat(actual.applyId()).isEqualTo(submittedApply.getId());
         assertThat(actual.name()).isEqualTo("김젝트");
         assertThat(actual.phoneNumber()).isEqualTo("010-1234-5678");
@@ -461,7 +461,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 newPortfolios
         );
 
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+        given(applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED))
                 .willReturn(Optional.of(submittedApply));
         given(map2JsonSerializer.serializeAsString(newAnswers))
                 .willReturn("{\"1\":\"수정된 답변1\",\"2\":\"수정된 답변2\"}");
@@ -470,7 +470,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
         submittedApplyService.updateSubmittedApply(applyId, request);
 
         // then
-        verify(applyRepository).findByIdAndStatusWithMember(applyId, Status.SUBMITTED);
+        verify(applyRepository).findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED);
         verify(map2JsonSerializer).serializeAsString(newAnswers);
         assertThat(submittedApply.getMember().getName()).isEqualTo(newName);
         assertThat(submittedApply.getMember().getPhoneNumber()).isEqualTo(newPhoneNumber);
@@ -491,7 +491,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 List.of()
         );
 
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+        given(applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED))
                 .willReturn(Optional.empty());
 
         // expected
@@ -515,7 +515,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 List.of()
         );
 
-        given(applyRepository.findByIdAndStatusWithMember(applyId, Status.SUBMITTED))
+        given(applyRepository.findByIdAndStatusWithMember(applyId, ApplyStatus.SUBMITTED))
                 .willReturn(Optional.of(submittedApply));
 
         // expected

--- a/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
@@ -1,19 +1,29 @@
 package org.ject.support.admin.apply.service;
 
-import org.ject.support.base.UnitTestSupport;
-import org.ject.support.common.util.Map2JsonSerializer;
-import org.ject.support.common.util.String2MapSerializer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.ject.support.admin.apply.dto.AdminApplyResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyCountResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyDetailResponse;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
-import org.ject.support.admin.apply.dto.SubmittedApplyResponse;
+import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.common.util.Map2JsonSerializer;
+import org.ject.support.common.util.String2MapSerializer;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.exception.ApplyErrorCode;
 import org.ject.support.domain.apply.exception.ApplyException;
-import org.ject.support.admin.apply.repository.AdminApplyQueryRepository;
 import org.ject.support.domain.apply.repository.ApplyRepository;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.entity.Member;
@@ -30,17 +40,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 class SubmittedApplyServiceTest extends UnitTestSupport {
 
@@ -264,7 +263,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .willReturn(page);
 
         // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
@@ -284,7 +283,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .willReturn(page);
 
         // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(null, semesterId, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findSubmittedApplies(null, semesterId, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
@@ -304,7 +303,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .willReturn(page);
 
         // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, null, pageable);
 
         // then
         assertThat(result.getContent()).isEmpty();
@@ -335,7 +334,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .willReturn(page);
 
         // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(2);
@@ -359,7 +358,7 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .willReturn(page);
 
         // when
-        Page<SubmittedApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, null, pageable);
+        Page<AdminApplyResponse> result = submittedApplyService.findSubmittedApplies(jobFamily, semesterId, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);

--- a/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
@@ -489,4 +489,107 @@ class SubmittedApplyServiceTest extends UnitTestSupport {
                 .isInstanceOf(QuestionException.class)
                 .hasFieldOrPropertyWithValue("errorCode", QuestionErrorCode.NOT_FOUND_QUESTION);
     }
+
+    @Test
+    void 임시_저장된_지원서_목록_조회시_결과가_없으면_빈_페이지_반환() {
+        // given
+        var pageable = PageRequest.of(0, 10);
+        Long semesterId = null;
+        var page = new PageImpl<Apply>(List.of(), pageable, 0);
+
+        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable))
+                .willReturn(page);
+
+        // when
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
+
+        // then
+        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
+        assertThat(result.getTotalElements()).isEqualTo(0);
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    void 임시_저장된_지원서_목록_조회_성공() {
+        // given
+        var pageable = PageRequest.of(0, 10);
+        Long semesterId = null;
+
+        var m1 = Member.builder().name("김1").jobFamily(JobFamily.BE).build();
+        var m2 = Member.builder().name("김2").jobFamily(JobFamily.BE).build();
+        var semester = Semester.builder().name("1").build();
+        var recruit = Recruit.builder()
+                .semester(semester)
+                .recruitType(org.ject.support.domain.recruit.domain.RecruitType.REGULAR)
+                .build();
+
+        var a1 = Apply.builder()
+                .id(1L)
+                .member(m1)
+                .recruit(recruit)
+                .status(ApplyStatus.TEMP_SAVED)
+                .applicationForm(ApplicationForm.builder().build())
+                .build();
+
+        var a2 = Apply.builder()
+                .id(2L)
+                .member(m2)
+                .recruit(recruit)
+                .status(ApplyStatus.TEMP_SAVED)
+                .applicationForm(ApplicationForm.builder().build())
+                .build();
+
+        var applies = List.of(a1, a2);
+        var page = new PageImpl<>(applies, pageable, applies.size());
+
+        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable))
+                .willReturn(page);
+
+        // when
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
+
+        // then
+        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).applyId()).isEqualTo(1L);
+        assertThat(result.getContent().get(1).applyId()).isEqualTo(2L);
+    }
+
+    @Test
+    void 임시_저장된_지원서_목록을_semesterId로_필터링하여_조회() {
+        // given
+        var pageable = PageRequest.of(0, 10);
+        Long semesterId = 1L;
+
+        var member = Member.builder().name("김젝트").jobFamily(JobFamily.BE).build();
+        var semester = Semester.builder().name("1").build();
+        var recruit = Recruit.builder()
+                .semester(semester)
+                .recruitType(org.ject.support.domain.recruit.domain.RecruitType.REGULAR)
+                .build();
+
+        var apply = Apply.builder()
+                .id(1L)
+                .member(member)
+                .recruit(recruit)
+                .status(ApplyStatus.TEMP_SAVED)
+                .applicationForm(ApplicationForm.builder().build())
+                .build();
+
+        var applies = List.of(apply);
+        var page = new PageImpl<>(applies, pageable, applies.size());
+
+        given(adminApplyQueryRepository.findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable))
+                .willReturn(page);
+
+        // when
+        Page<AdminApplyResponse> result = submittedApplyService.findApplies(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
+
+        // then
+        verify(adminApplyQueryRepository).findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).applyId()).isEqualTo(1L);
+    }
 }

--- a/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/SubmittedApplyServiceTest.java
@@ -41,7 +41,7 @@ import org.springframework.data.domain.Sort;
 class SubmittedApplyServiceTest extends UnitTestSupport {
 
     @InjectMocks
-    private SubmittedApplyService submittedApplyService;
+    private AdminApplyService submittedApplyService;
 
     @Mock
     private ApplyRepository applyRepository;

--- a/src/test/java/org/ject/support/domain/apply/domain/ApplyTest.java
+++ b/src/test/java/org/ject/support/domain/apply/domain/ApplyTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
 
 class ApplyTest extends TestSupport {
 

--- a/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.apply.repository;
 
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Role;
@@ -21,8 +22,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
-import static org.ject.support.domain.apply.domain.Apply.Status.TEMP_SAVED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.TEMP_SAVED;
 import static org.ject.support.domain.member.JobFamily.BE;
 import static org.ject.support.domain.member.JobFamily.FE;
 import static org.ject.support.domain.member.JobFamily.PD;
@@ -136,7 +137,7 @@ class ApplyRepositoryTest {
                 .build();
     }
 
-    private Apply getApply(Member member, Recruit recruit, Apply.Status status) {
+    private Apply getApply(Member member, Recruit recruit, ApplyStatus status) {
         return Apply.builder()
                 .recruit(recruit)
                 .member(member)

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -5,6 +5,7 @@ import org.ject.support.common.util.Map2JsonSerializer;
 import org.ject.support.common.util.String2MapSerializer;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
 import org.ject.support.domain.apply.dto.ApplyStatusResponse;
@@ -40,9 +41,9 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.ject.support.domain.apply.domain.Apply.Status.JOINED;
-import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
-import static org.ject.support.domain.apply.domain.Apply.Status.TEMP_SAVED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.JOINED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.TEMP_SAVED;
 import static org.ject.support.domain.member.JobFamily.BE;
 import static org.ject.support.domain.member.JobFamily.PD;
 import static org.mockito.ArgumentMatchers.any;
@@ -626,7 +627,7 @@ class ApplyServiceTest extends UnitTestSupport {
                 .build();
     }
 
-    private Apply getApply(Long id, Recruit recruit, Member applicant, ApplicationForm applicationForm, Apply.Status status) {
+    private Apply getApply(Long id, Recruit recruit, Member applicant, ApplicationForm applicationForm, ApplyStatus status) {
         return Apply.builder()
                 .id(id)
                 .recruit(recruit)

--- a/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberQueryRepositoryTest.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.member.repository;
 
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.repository.ApplicationFormRepository;
 import org.ject.support.domain.apply.repository.ApplyRepository;
 import org.ject.support.domain.member.JobFamily;
@@ -28,9 +29,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.ject.support.domain.apply.domain.Apply.Status.JOINED;
-import static org.ject.support.domain.apply.domain.Apply.Status.SUBMITTED;
-import static org.ject.support.domain.apply.domain.Apply.Status.TEMP_SAVED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.JOINED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
+import static org.ject.support.domain.apply.domain.ApplyStatus.TEMP_SAVED;
 import static org.ject.support.domain.member.JobFamily.BE;
 import static org.ject.support.domain.member.JobFamily.FE;
 import static org.ject.support.domain.member.JobFamily.PD;
@@ -415,7 +416,7 @@ class MemberQueryRepositoryTest {
                 .build();
     }
 
-    private Apply createApply(Recruit recruit, Member member, Apply.Status status) {
+    private Apply createApply(Recruit recruit, Member member, ApplyStatus status) {
         return applyRepository.save(Apply.builder()
                 .member(member)
                 .recruit(recruit)

--- a/src/test/java/org/ject/support/domain/recruit/repository/ApplicationFormRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/repository/ApplicationFormRepositoryTest.java
@@ -3,6 +3,7 @@ package org.ject.support.domain.recruit.repository;
 import org.assertj.core.api.Assertions;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.apply.repository.ApplicationFormRepository;
 import org.ject.support.domain.apply.repository.ApplyRepository;
 import org.ject.support.domain.member.JobFamily;
@@ -71,7 +72,7 @@ class ApplicationFormRepositoryTest {
         Apply apply = applyRepository.save(Apply.builder()
                 .member(member)
                 .recruit(recruit)
-                .status(Apply.Status.JOINED)
+                .status(ApplyStatus.JOINED)
                 .build());
 
         applicationFormRepository.save(ApplicationForm.builder().


### PR DESCRIPTION
## #️⃣연관된 이슈

close #461

## 📝 작업 내용

### `Apply.Status` 내부 enum → `ApplyStatus` 독립 enum으로 추출
- `Apply.Status` (JOINED, TEMP_SAVED, SUBMITTED, REJECTED)를 `ApplyStatus` 클래스로 분리하여 도메인 전반에서 일관되게 사용
- `Apply`, `ApplyService`, `RemindApplyService`, `ApplyRepository` 등 관련 참조를 모두 `ApplyStatus`로 변경

### 관리자 지원서 목록 조회 API 통합
- **Controller 통합**: `SubmittedApplyController` → `AdminApplyController`로 리네이밍, 엔드포인트를 `/admin/applies`로 통일
- **Service 통합**: `SubmittedApplyService` → `AdminApplyService`로 리네이밍
- **`AdminTempApplyController.getTempApplies` 제거**: 임시 저장 지원서 목록 조회를 `AdminApplyController.findApplies`로 통합
- **`AdminTempApplyService.getTempApplies` 제거**: 임시 저장 지원서 목록 조회를 `AdminApplyService.findApplies`로 통합
- `findApplies` 메서드에 `ApplyStatus` 파라미터를 추가하여 `SUBMITTED` / `TEMP_SAVED` 등 상태별 조회를 하나의 엔드포인트로 처리

### DTO 통합
- `SubmittedApplyResponse` → `AdminApplyResponse`로 리네이밍하여 상태에 관계없이 범용적으로 사용
- `SubmittedApplyCountResponse` 및 `countSubmittedApply()` 메서드 삭제

### QueryRepository 시그니처 변경
- `AdminApplyQueryRepository.findAppliesByStatus`의 파라미터 순서를 `(ApplyStatus, semesterId, jobFamily, recruitType, pageable)`로 통일
- `Apply.Status` → `ApplyStatus` 타입으로 변경

### 5. 테스트 이관 및 정리
- `AdminTempApplyServiceTest`에서 `getTempApplies` 관련 테스트 3건 제거
- `SubmittedApplyServiceTest`에 동일 시나리오를 `AdminApplyService.findApplies(TEMP_SAVED, ...)` 호출로 이관
  - `임시_저장된_지원서_목록_조회시_결과가_없으면_빈_페이지_반환`
  - `임시_저장된_지원서_목록_조회_성공`
  - `임시_저장된_지원서_목록을_semesterId로_필터링하여_조회`
- `countSubmittedApply` 관련 테스트 2건 (`제출된_지원서_수_조회_성공`, `제출된_지원서가_없을_때_0_반환`) 삭제
- 전체 테스트에서 `Apply.Status` → `ApplyStatus` 참조 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩터링**
  * 관리자용 신청 관리 경로를 통합 및 명칭 정비(/admin/applies).
  * 내부 상태 표현을 별도 열거형으로 이관하여 상태 처리 일관성 개선.

* **신규 기능**
  * 신청 목록 조회 시 상태 필터(예: 제출/임시저장)로 검색 가능.

* **제거**
  * 신청 전체 카운트 및 임시 저장 목록 조회용 공개 엔드포인트 삭제.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->