### PR TITLE
feat:관리자 로그아웃 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/admin/auth/controller/AdminAuthApiSpec.java
+++ b/src/main/java/org/ject/support/admin/auth/controller/AdminAuthApiSpec.java
@@ -28,4 +28,10 @@ public interface AdminAuthApiSpec {
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse
     );
+
+    @Operation(
+            summary = "관리자 로그아웃",
+            description = "관리자가 로그아웃합니다."
+    )
+    void logoutAdmin(HttpServletResponse httpResponse);
 }

--- a/src/main/java/org/ject/support/admin/auth/controller/AdminAuthController.java
+++ b/src/main/java/org/ject/support/admin/auth/controller/AdminAuthController.java
@@ -41,4 +41,9 @@ public class AdminAuthController implements AdminAuthApiSpec {
         customSuccessHandler.onAuthenticationSuccess(httpRequest, httpResponse, authentication);
         return true;
     }
+
+    @PostMapping("/logout")
+    public void logoutAdmin(HttpServletResponse httpResponse) {
+        customSuccessHandler.onLogoutSuccess(httpResponse);
+    }
 }

--- a/src/main/java/org/ject/support/common/security/CustomSuccessHandler.java
+++ b/src/main/java/org/ject/support/common/security/CustomSuccessHandler.java
@@ -54,6 +54,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     /**
      * 로그아웃 시 쿠키를 만료시키는 메소드
+     * @param response HttpServletResponse
      */
     public void onLogoutSuccess(HttpServletResponse response) {
         jwtCookieProvider.deleteAuthCookies(response);

--- a/src/main/java/org/ject/support/common/security/CustomSuccessHandler.java
+++ b/src/main/java/org/ject/support/common/security/CustomSuccessHandler.java
@@ -51,4 +51,11 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         response.addHeader(HttpHeaders.SET_COOKIE, jwtCookieProvider.createAccessCookie(newAccessToken).toString());
     }
+
+    /**
+     * 로그아웃 시 쿠키를 만료시키는 메소드
+     */
+    public void onLogoutSuccess(HttpServletResponse response) {
+        jwtCookieProvider.deleteAuthCookies(response);
+    }
 }

--- a/src/main/java/org/ject/support/common/security/jwt/JwtCookieProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtCookieProvider.java
@@ -1,9 +1,11 @@
 package org.ject.support.common.security.jwt;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
@@ -46,6 +48,33 @@ public class JwtCookieProvider {
         // 개발/QA 환경이면 cross-site 허용
         if (isDevOrLocal()) {
             builder.sameSite("None");
+        }
+
+        return builder.build();
+    }
+
+    public void deleteAuthCookies(HttpServletResponse response) {
+        String[] cookieNames = {"accessToken", "refreshToken", "verificationToken"};
+
+        for (String name : cookieNames) {
+            ResponseCookie cookie = deleteCookie(name);
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        }
+    }
+
+    private ResponseCookie deleteCookie(String cookieName) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(cookieName, "")
+                .domain(domain)
+                .path("/")
+                .maxAge(0) // 만료 시간을 0으로 설정하여 삭제
+                .httpOnly(true)
+                .secure(true);
+
+        // SameSite 설정은 생성 시와 동일하게 맞춰주는 것이 안전합니다
+        if (isDevOrLocal()) {
+            builder.sameSite("None");
+        } else {
+            builder.sameSite("Lax");
         }
 
         return builder.build();

--- a/src/main/java/org/ject/support/common/security/jwt/JwtCookieProvider.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtCookieProvider.java
@@ -70,11 +70,8 @@ public class JwtCookieProvider {
                 .httpOnly(true)
                 .secure(true);
 
-        // SameSite 설정은 생성 시와 동일하게 맞춰주는 것이 안전합니다
         if (isDevOrLocal()) {
             builder.sameSite("None");
-        } else {
-            builder.sameSite("Lax");
         }
 
         return builder.build();

--- a/src/test/java/org/ject/support/admin/auth/controller/AdminAuthControllerTest.java
+++ b/src/test/java/org/ject/support/admin/auth/controller/AdminAuthControllerTest.java
@@ -80,4 +80,13 @@ class AdminAuthControllerTest {
                 httpServletRequest, httpServletResponse, authentication
         );
     }
+
+    @Test
+    void 관리자_로그아웃에_성공할_경우_쿠키를_만료시킨다() {
+        // when
+        adminAuthController.logoutAdmin(httpServletResponse);
+
+        // then
+        verify(customSuccessHandler).onLogoutSuccess(httpServletResponse);
+    }
 }

--- a/src/test/java/org/ject/support/common/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/ject/support/common/security/jwt/JwtTokenProviderTest.java
@@ -2,6 +2,9 @@ package org.ject.support.common.security.jwt;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.ject.support.base.UnitTestSupport;
+import java.util.List;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.ject.support.common.exception.GlobalException;
 import org.ject.support.common.security.CustomUserDetails;
 import org.ject.support.domain.member.JobFamily;
@@ -174,6 +177,23 @@ class JwtTokenProviderTest extends UnitTestSupport {
         Authentication resultAuth = jwtTokenProvider.getAuthenticationByToken(token);
         assertThat(resultAuth.getAuthorities()).isNotEmpty();
         assertThat(resultAuth.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_SEMESTER");
+    }
+
+    @Test
+    void 로그아웃_시_쿠키를_만료시킨다() {
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        jwtCookieProvider.deleteAuthCookies(response);
+
+        // then
+        List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(3);
+        assertThat(cookies).allSatisfy(cookie -> assertThat(cookie).contains("Max-Age=0"));
+        assertThat(cookies).anySatisfy(cookie -> assertThat(cookie).contains("accessToken="));
+        assertThat(cookies).anySatisfy(cookie -> assertThat(cookie).contains("refreshToken="));
+        assertThat(cookies).anySatisfy(cookie -> assertThat(cookie).contains("verificationToken="));
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

close #468 

## 📝 작업 내용

### 관리자 로그아웃 기능 구현
 - accessToken, refreshToken 삭제
 - 테스트 코드 추가


## Description
 - 로그인 성공시 CustomSuccessHandler 를 통해 인증 관련 쿠키 로직을 다루고 있어 관리 포인트를 집중 시키기 위해 기존에 있는 클래스를 재사용했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 관리자 로그아웃 기능이 추가되었습니다.
  * 로그아웃 시 인증 관련 쿠키가 자동으로 삭제됩니다.

* **테스트**
  * 관리자 로그아웃 및 쿠키 삭제 동작을 검증하는 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->