### PR TITLE
feat: 지원서 제출 동시성 이슈 해결 (비관적 락 적용)

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -5,10 +5,14 @@ import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.repository.query.Param;
 
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
@@ -20,6 +24,11 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
     @Query("select a from Apply a join a.recruit r where a.member.id = :memberId and r.startDate <= :now and r.endDate >= :now")
     Optional<Apply> findByMemberIdInActiveRecruit(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
+    @Query("select a from Apply a join a.recruit r where a.member.id = :memberId and r.startDate <= :now and r.endDate >= :now")
+    Optional<Apply> findByMemberIdInActiveRecruitForUpdate(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
 
     @Query("select a from Apply a join a.recruit r where a.member.id = :memberId and r.id = :recruitId and r.startDate <= :now and r.endDate >= :now")
     Optional<Apply> findByMemberIdAndRecruitIdInActiveRecruit(@Param("memberId") Long memberId,

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -149,7 +149,7 @@ public class ApplyService implements ApplyUsecase {
         validateQuestions(answers, recruit);
 
         // 3. 지원 정보 조회
-        Apply apply = applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
+        Apply apply = applyRepository.findByMemberIdInActiveRecruitForUpdate(memberId, LocalDateTime.now())
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
 
         String content = map2JsonSerializer.serializeAsString(answers);

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -103,7 +103,7 @@ class ApplyServiceTest extends UnitTestSupport {
         Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
 
         when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruitForUpdate(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
         // when
@@ -134,7 +134,7 @@ class ApplyServiceTest extends UnitTestSupport {
         Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
 
         when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruitForUpdate(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
         // expected
@@ -161,7 +161,7 @@ class ApplyServiceTest extends UnitTestSupport {
         );
 
         when(recruitRepository.findActiveRecruits(any())).thenReturn(List.of(recruit));
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruitForUpdate(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
         // when

--- a/src/test/java/org/ject/support/domain/apply/service/ApplySubmitConcurrencyTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplySubmitConcurrencyTest.java
@@ -1,0 +1,172 @@
+package org.ject.support.domain.apply.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
+import org.ject.support.domain.apply.domain.ApplicationForm;
+import org.ject.support.domain.apply.repository.ApplicationFormRepository;
+import org.ject.support.domain.apply.repository.ApplyRepository;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.recruit.domain.Question;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.Semester;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.ject.support.domain.recruit.repository.SemesterRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ApplySubmitConcurrencyTest {
+
+    @Autowired
+    private ApplyService applyService;
+
+    @Autowired
+    private ApplyRepository applyRepository;
+
+    @Autowired
+    private ApplicationFormRepository applicationFormRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RecruitRepository recruitRepository;
+
+    @Autowired
+    private SemesterRepository semesterRepository;
+
+    private Long memberId;
+    private JobFamily jobFamily;
+    private Map<String, String> answers;
+
+    @BeforeEach
+    void setUp() {
+        // 기존 데이터 정리 (테스트 격리)
+        applicationFormRepository.deleteAll();
+        applyRepository.deleteAll();
+        recruitRepository.deleteAll();
+        memberRepository.deleteAll();
+        semesterRepository.deleteAll();
+
+        jobFamily = JobFamily.BE;
+
+        // 1. Semester 생성
+        Semester semester = semesterRepository.save(
+                Semester.builder()
+                        .name("test1")
+                        .build()
+        );
+
+        // 2. Member 생성
+        Member member = memberRepository.save(
+                Member.builder()
+                        .email("test@test.com")
+                        .name("테스터")
+                        .phoneNumber("01012345678")
+                        .role(Role.APPLY)
+                        .status(MemberStatus.ACTIVE)
+                        .semesterId(semester.getId())
+                        .jobFamily(jobFamily)
+                        .build()
+        );
+        memberId = member.getId();
+
+        // 3. Recruit 생성 (현재 활성 모집) + Question (CASCADE로 함께 저장)
+        Recruit recruit = Recruit.builder()
+                .semester(semester)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .jobFamily(jobFamily)
+                .build();
+
+        Question question = Question.builder()
+                .sequence(1)
+                .inputType(Question.InputType.TEXT)
+                .isRequired(true)
+                .title("Q1")
+                .label("label1")
+                .build();
+        recruit.addQuestion(question);
+        recruitRepository.save(recruit);
+
+        // 4. Apply 생성 (TEMP_SAVED) + ApplicationForm (제출 시 업데이트 대상)
+        Apply apply = Apply.createApply(member, recruit);
+        apply.updateStatus(ApplyStatus.TEMP_SAVED);
+        applyRepository.save(apply);
+
+        ApplicationForm applicationForm = ApplicationForm.builder()
+                .apply(apply)
+                .content("{\"" + question.getId() + "\":\"temp\"}")
+                .build();
+        applicationFormRepository.save(applicationForm);
+        apply.updateApplicationForm(applicationForm);
+        applyRepository.save(apply);
+
+        // 5. answers
+        answers = Map.of(String.valueOf(question.getId()), "answer1");
+    }
+
+    @Test
+    @DisplayName("동시 제출 시 Race Condition 발생 — 락 없이 두 요청 모두 성공하면 버그")
+    void 동시_제출_시_하나만_성공해야_한다() throws InterruptedException {
+        int threadCount = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    readyLatch.countDown();
+                    startLatch.await();
+
+                    applyService.submitApplication(memberId, jobFamily, answers, List.of());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    System.out.println("[" + Thread.currentThread().getName() + "] 예외: " + e.getClass().getSimpleName() + " - " + e.getMessage());
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+        doneLatch.await();
+        executorService.shutdown();
+
+        System.out.println("=== 동시성 테스트 결과 ===");
+        System.out.println("성공: " + successCount.get());
+        System.out.println("실패: " + failCount.get());
+
+        // ✅ 비관적 락 적용 후: 정확히 1건만 성공, 1건은 실패
+        // → 이 테스트가 PASS하면 Race Condition이 해결되었다는 증거
+        assertThat(successCount.get())
+                .as("비관적 락 적용 후: 정확히 1건만 성공해야 합니다.")
+                .isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #480

## 📝 작업 내용
### 지원서 제출 Race Condition 해결
- **문제점**: 모집 마감 직전 동시 제출 요청 시 isSubmitted() 체크가 1차 캐시 수준에서만 작동하여 이중 제출이 발생하는 문제 확인.
- **해결책**: SELECT FOR UPDATE를 통한 비관적 락을 적용하여 트랜잭션 간 직렬화 보장.
- **검증**: CountDownLatch를 이용한 동시성 테스트를 통해 Race Condition 해결을 정량적으로 증명.

## 🙏 리뷰 요구사항
- ApplyRepository의 락 타임아웃(3초) 설정이 적절한지 검토 부탁드립니다.
- 비관적 락 도입에 따른 성능 영향은 저빈도 연산임을 고려할 때 미비할 것으로 판단됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 동시 지원 제출 시 데이터 무결성을 보장하는 잠금 메커니즘 추가

* **Tests**
  * 동시 제출 환경에서의 안정성을 검증하는 새로운 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->