### PR TITLE
feat: Redis SSL 연결 설정 추가

### DIFF
--- a/src/main/java/org/ject/support/common/data/redis/RedisConnectionConfig.java
+++ b/src/main/java/org/ject/support/common/data/redis/RedisConnectionConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
 @Configuration
@@ -24,6 +25,9 @@ public class RedisConnectionConfig {
     @Value("${spring.data.redis.local}")
     private boolean isLocal;
 
+    @Value("${spring.data.redis.ssl.enabled:false}")
+    private boolean useSsl;
+
     @Bean
     @ConditionalOnMissingBean
     public RedisConnectionFactory redisConnectionFactory() {
@@ -36,6 +40,14 @@ public class RedisConnectionConfig {
 
         if (isLocal) {
             return new LettuceConnectionFactory(redisConfig);
+        }
+
+        if (useSsl) {
+            LettuceClientConfiguration clientConfig =
+                    LettuceClientConfiguration.builder()
+                            .useSsl()
+                            .build();
+            return new LettuceConnectionFactory(redisConfig, clientConfig);
         }
 
         return new LettuceConnectionFactory(redisConfig);


### PR DESCRIPTION
## #️⃣연관된 이슈

close #504 

## 📝 작업 내용

Redis 연결 실패로 인해 애플리케이션이 비정상 종료되는 문제를 해결하기 위해 RedisConnectionConfig 설정을 개선했습니다.
Upstash Redis는 TLS(SSL) 연결이 필수임에도 기존 설정에서는 SSL이 적용되지 않아 연결 과정에서 실패가 발생하였고, 이를 해결하기 위해 SSL 설정을 명시적으로 추가했습니다.
또한 환경별로 Redis 연결 방식을 유연하게 제어할 수 있도록 프로퍼티 기반 분기 로직을 도입했습니다.
spring.data.redis.ssl 값을 통해 SSL 사용 여부를 제어할 수 있으며, 값이 정의되지 않은 경우 기본값(false)을 사용하도록 구성했습니다.

추후 이런 SPOF를 막기 위해 기존 이슈 #435 를 진행해야 할 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Redis 연결에 SSL 지원이 추가되었습니다. `spring.data.redis.ssl.enabled` 설정을 통해 필요에 따라 SSL을 활성화할 수 있습니다. (기본값: 비활성화)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->