### PR TITLE
feat: Redis SPOF 방어를 위한 Circuitbreaker 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Cache resilience
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+
     // Util
     implementation 'com.google.guava:guava:33.3.0-jre'
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     // Cache resilience
     implementation 'org.springframework.boot:spring-boot-starter-aop'
-    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 
     // Util
     implementation 'com.google.guava:guava:33.3.0-jre'

--- a/src/main/java/org/ject/support/common/data/redis/RedisCacheConfig.java
+++ b/src/main/java/org/ject/support/common/data/redis/RedisCacheConfig.java
@@ -2,8 +2,15 @@ package org.ject.support.common.data.redis;
 
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.common.data.redis.resilience.ResilientCacheErrorHandler;
+import org.ject.support.common.data.redis.resilience.ResilientCacheResolver;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.cache.interceptor.CacheResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -13,19 +20,31 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import java.time.Duration;
-
 @Configuration
 @EnableCaching
-public class RedisCacheConfig {
+@RequiredArgsConstructor
+public class RedisCacheConfig implements CachingConfigurer {
+
+    private final ResilientCacheErrorHandler resilientCacheErrorHandler;
+    private final RedisConnectionFactory connectionFactory;
 
     @Bean
-    public CacheManager redisCacheManager(
-            RedisConnectionFactory connectionFactory
-    ) {
+    public CacheManager redisCacheManager() {
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(redisCacheConfiguration())
                 .build();
+    }
+
+    @Override
+    public CacheResolver cacheResolver() {
+        // 서킷 오픈 시 NoOpCache로 전환해 Redis 접근을 우회, 추후 로컬 캐시로 도입 논의 필요.
+        return new ResilientCacheResolver(redisCacheManager());
+    }
+
+    @Override
+    public CacheErrorHandler errorHandler() {
+        // Redis 관련 캐시 예외는 삼키고 비즈니스 로직이 DB 폴백을 수행하도록 한다.
+        return resilientCacheErrorHandler;
     }
 
     private RedisCacheConfiguration redisCacheConfiguration() {

--- a/src/main/java/org/ject/support/common/data/redis/RedisCacheConfig.java
+++ b/src/main/java/org/ject/support/common/data/redis/RedisCacheConfig.java
@@ -43,7 +43,7 @@ public class RedisCacheConfig implements CachingConfigurer {
 
     @Override
     public CacheErrorHandler errorHandler() {
-        // Redis 관련 캐시 예외는 삼키고 비즈니스 로직이 DB 폴백을 수행하도록 한다.
+        // Redis 관련 캐시 예외는 삼키고 비즈니스 로직이 DB 폴백 수행
         return resilientCacheErrorHandler;
     }
 

--- a/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
@@ -4,20 +4,24 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -31,29 +35,36 @@ public class CacheCircuitBreakerAspect {
     // 캐시 이름별로 서킷 브레이커 인스턴스를 관리하고 반환하는 프로바이더
     private final RedisCacheCircuitBreakerProvider circuitBreakerProvider;
 
-    // @Cacheable, @CachePut, @CacheEvict, @Caching 어노테이션이 사용된 모든 메서드를 가로챕니다.
+    /**
+     * @Cacheable, @CachePut, @CacheEvict, @Caching 어노테이션이 사용된 메서드나 클래스를 가로챕니다.
+     */
     @Around("@annotation(org.springframework.cache.annotation.Cacheable) || " +
             "@annotation(org.springframework.cache.annotation.CachePut) || " +
             "@annotation(org.springframework.cache.annotation.CacheEvict) || " +
-            "@annotation(org.springframework.cache.annotation.Caching)")
+            "@annotation(org.springframework.cache.annotation.Caching) || " +
+            "@within(org.springframework.cache.annotation.Cacheable) || " +
+            "@within(org.springframework.cache.annotation.CachePut) || " +
+            "@within(org.springframework.cache.annotation.CacheEvict) || " +
+            "@within(org.springframework.cache.annotation.Caching)")
     public Object aroundCacheCall(final ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        Method method = signature.getMethod();
+        // 실제 대상 객체의 메서드를 찾아 인터페이스나 상속 관계에서의 어노테이션까지 감지할 수 있게 합니다.
+        Method method = AopUtils.getMostSpecificMethod(signature.getMethod(), joinPoint.getTarget().getClass());
 
-        // 하나의 메서드는 여러 어노테이션을 통해 다수의 캐시 이름을 참조할 수 있습니다.
+        // 메서드 및 클래스 레벨에서 참조하는 모든 캐시 이름을 추출
         List<String> cacheNames = extractCacheNames(method);
-        // 이번 요청에서 실행 권한을 획득한 서킷 브레이커들을 추적합니다.
+        // 이번 요청에서 실행 권한을 획득한 서킷 브레이커들을 추적
         List<CircuitBreakerExecution> grantedBreakers = new ArrayList<>(cacheNames.size());
-        // 참조하는 캐시 중 하나라도 OPEN 상태면 이번 호출은 캐시를 우회합니다.
+        // 참조하는 캐시 중 하나라도 OPEN 상태면 이번 호출은 캐시를 우회
         boolean bypassEnabled = false;
 
-        // 캐시별 서킷 브레이커로부터 실행 권한을 획득 시도합니다.
+        // 캐시별 서킷 브레이커로부터 실행 권한을 획득 시도
         for (String cacheName : cacheNames) {
             CircuitBreaker circuitBreaker = circuitBreakerProvider.get(cacheName);
-            // 레디스 호출 방지를 위해 OPEN 상태는 즉시 권한을 거부합니다.(Fail-fast)
+            // 레디스 호출 방지를 위해 OPEN 상태는 즉시 권한을 거부(Fail-fast)
             if (!circuitBreaker.tryAcquirePermission()) {
                 bypassEnabled = true;
-                log.debug("Cache circuit is open. cache={}, method={}", cacheName, joinPoint.getSignature());
+                log.debug("Cache circuit is open. cache={}, method={}", cacheName, method.getName());
                 continue;
             }
 
@@ -61,74 +72,71 @@ public class CacheCircuitBreakerAspect {
             grantedBreakers.add(new CircuitBreakerExecution(cacheName, circuitBreaker));
         }
 
-        // ThreadLocal 우회 설정을 스택에 쌓아 중첩된 호출에서도 상태를 유지합니다.
+        // ThreadLocal 우회 설정을 스택에 쌓아 중첩된 호출에서도 상태를 유지
         RedisCacheExecutionContext.pushContext(bypassEnabled);
 
         try {
-            // 메서드 실행을 계속합니다. 우회가 활성화된 경우 캐시 레이어는 건너뜁니다.
+            // 메서드 실행을 계속,  우회가 활성화된 경우 캐시 레이어는 패스
             Object result = joinPoint.proceed();
-            // 실제 레디스 캐시를 사용한 경우(우회되지 않은 경우)에만 성공을 기록합니다.
+            // 실제 레디스 캐시를 사용한 경우(우회되지 않은 경우)에만 성공을 기록
             if (!bypassEnabled) {
                 recordSuccess(grantedBreakers);
             }
             return result;
         } finally {
-            // 이번 호출의 컨텍스트를 제거하여 이전 호출 상태로 복구합니다.
+            // 이번 호출의 컨텍스트를 제거하여 이전 호출 상태로 복구
             RedisCacheExecutionContext.popContext();
-            // 최상위 호출이 종료될 때 전체 상태를 정리하여 메모리 누수를 방지합니다.
+            // 최상위 호출이 종료될 때 전체 상태를 정리하여 메모리 누수를 방지
             if (!RedisCacheExecutionContext.hasContext()) {
                 RedisCacheExecutionContext.clear();
             }
         }
     }
 
-    // 이번 호출에서 레디스 장애가 발생하지 않은 캐시들에 대해서만 성공을 기록합니다.
+    // 이번 호출에서 레디스 장애가 발생하지 않은 캐시들에 대해서만 성공을 기록
     private void recordSuccess(final List<CircuitBreakerExecution> grantedBreakers) {
         for (CircuitBreakerExecution execution : grantedBreakers) {
-            // 캐시 조회/저장 중 장애가 발생했다면, ErrorHandler에서 이미 실패로 처리했습니다.
+            // 캐시 조회/저장 중 장애가 발생했다면, ErrorHandler에서 이미 실패로 처리
             if (RedisCacheExecutionContext.hasFailure(execution.cacheName())) {
                 continue;
             }
-            // 단순 성공 여부만 필요하므로 지연 시간(duration)은 0으로 기록합니다.
+            // 단순 성공 여부만 필요하므로 지연 시간(duration)은 0으로 기록
             execution.circuitBreaker().onSuccess(0, TimeUnit.NANOSECONDS);
         }
     }
 
-    // @Caching을 포함하여 메서드에 선언된 모든 캐시 관련 어노테이션에서 캐시 이름을 추출합니다.
+    // @Caching을 포함하여 메서드 및 클래스 레벨에 선언된 모든 캐시 관련 어노테이션에서 캐시 이름을 추출
     private List<String> extractCacheNames(final Method method) {
-        List<String> names = new ArrayList<>();
+        Set<String> names = new HashSet<>();
+        Class<?> targetClass = method.getDeclaringClass();
 
-        // @Cacheable 처리
-        Cacheable cacheable = method.getAnnotation(Cacheable.class);
-        if (cacheable != null) {
-            names.addAll(getNames(cacheable.cacheNames(), cacheable.value()));
-        }
+        // 클래스 레벨의 @CacheConfig를 통해 기본 캐시 이름을 확보합니다.
+        CacheConfig cacheConfig = AnnotatedElementUtils.findMergedAnnotation(targetClass, CacheConfig.class);
+        String[] defaultNames = (cacheConfig != null) ? cacheConfig.cacheNames() : new String[0];
 
-        // @CachePut 처리
-        CachePut cachePut = method.getAnnotation(CachePut.class);
-        if (cachePut != null) {
-            names.addAll(getNames(cachePut.cacheNames(), cachePut.value()));
-        }
+        // @Cacheable 추출
+        Cacheable mCacheable = AnnotatedElementUtils.findMergedAnnotation(method, Cacheable.class);
+        Cacheable cCacheable = (mCacheable == null) ? AnnotatedElementUtils.findMergedAnnotation(targetClass, Cacheable.class) : null;
+        if (mCacheable != null) names.addAll(resolveNames(mCacheable.cacheNames(), mCacheable.value(), defaultNames));
+        if (cCacheable != null) names.addAll(resolveNames(cCacheable.cacheNames(), cCacheable.value(), defaultNames));
 
-        // @CacheEvict 처리
-        CacheEvict cacheEvict = method.getAnnotation(CacheEvict.class);
-        if (cacheEvict != null) {
-            names.addAll(getNames(cacheEvict.cacheNames(), cacheEvict.value()));
-        }
+        // @CachePut 추출
+        CachePut mCachePut = AnnotatedElementUtils.findMergedAnnotation(method, CachePut.class);
+        CachePut cCachePut = (mCachePut == null) ? AnnotatedElementUtils.findMergedAnnotation(targetClass, CachePut.class) : null;
+        if (mCachePut != null) names.addAll(resolveNames(mCachePut.cacheNames(), mCachePut.value(), defaultNames));
+        if (cCachePut != null) names.addAll(resolveNames(cCachePut.cacheNames(), cCachePut.value(), defaultNames));
 
-        // @Caching 처리 (복합 어노테이션)
-        Caching caching = method.getAnnotation(Caching.class);
-        if (caching != null) {
-            Stream.of(caching.cacheable())
-                    .forEach(c -> names.addAll(getNames(c.cacheNames(), c.value())));
-            Stream.of(caching.put())
-                    .forEach(c -> names.addAll(getNames(c.cacheNames(), c.value())));
-            Stream.of(caching.evict())
-                    .forEach(c -> names.addAll(getNames(c.cacheNames(), c.value())));
-        }
+        // @CacheEvict 추출
+        CacheEvict mCacheEvict = AnnotatedElementUtils.findMergedAnnotation(method, CacheEvict.class);
+        CacheEvict cCacheEvict = (mCacheEvict == null) ? AnnotatedElementUtils.findMergedAnnotation(targetClass, CacheEvict.class) : null;
+        if (mCacheEvict != null) names.addAll(resolveNames(mCacheEvict.cacheNames(), mCacheEvict.value(), defaultNames));
+        if (cCacheEvict != null) names.addAll(resolveNames(cCacheEvict.cacheNames(), cCacheEvict.value(), defaultNames));
 
-        // 클래스 레벨의 @CacheConfig가 있을 경우 기본 캐시 이름을 추가로 고려할 수 있으나,
-        // 현재는 메서드 레벨의 명시적 선언을 우선순위로 하여 추출합니다.
+        // @Caching 추출 (복합 어노테이션)
+        Caching mCaching = AnnotatedElementUtils.findMergedAnnotation(method, Caching.class);
+        Caching cCaching = (mCaching == null) ? AnnotatedElementUtils.findMergedAnnotation(targetClass, Caching.class) : null;
+        processCaching(mCaching, names, defaultNames);
+        processCaching(cCaching, names, defaultNames);
 
         return names.stream()
                 .filter(name -> name != null && !name.isEmpty())
@@ -136,14 +144,20 @@ public class CacheCircuitBreakerAspect {
                 .toList();
     }
 
-    private List<String> getNames(final String[] cacheNames, final String[] value) {
-        if (cacheNames.length > 0) {
-            return Arrays.asList(cacheNames);
-        }
-        return Arrays.asList(value);
+    private void processCaching(final Caching caching, final Set<String> names, final String[] defaultNames) {
+        if (caching == null) return;
+        for (Cacheable c : caching.cacheable()) names.addAll(resolveNames(c.cacheNames(), c.value(), defaultNames));
+        for (CachePut p : caching.put()) names.addAll(resolveNames(p.cacheNames(), p.value(), defaultNames));
+        for (CacheEvict e : caching.evict()) names.addAll(resolveNames(e.cacheNames(), e.value(), defaultNames));
     }
 
-    // 각 캐시별 서킷 브레이커 실행 상태를 담는 불변 객체입니다.
+    private List<String> resolveNames(final String[] cacheNames, final String[] value, final String[] defaultNames) {
+        if (cacheNames.length > 0) return Arrays.asList(cacheNames);
+        if (value.length > 0) return Arrays.asList(value);
+        return Arrays.asList(defaultNames);
+    }
+
+    // 각 캐시별 서킷 브레이커 실행 상태를 담는 불변 객체
     private record CircuitBreakerExecution(String cacheName, CircuitBreaker circuitBreaker) {
     }
 }

--- a/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
@@ -46,35 +46,30 @@ public class CacheCircuitBreakerAspect {
     @Around("cacheOperation()")
     public Object aroundCacheCall(final ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        // 실제 호출 대상 클래스를 확보합니다. (Spring의 어노테이션 탐색 규칙에 필요)
         Class<?> targetClass = joinPoint.getTarget().getClass();
-        // 실제 대상 객체의 메서드를 찾아 인터페이스나 상속 관계에서의 어노테이션까지 감지할 수 있게 합니다.
         Method method = AopUtils.getMostSpecificMethod(signature.getMethod(), targetClass);
 
         // 메서드 및 클래스 레벨에서 참조하는 모든 캐시 이름을 추출
         Collection<CacheOperation> operations = cacheOperationSource.getCacheOperations(method, targetClass);
         List<String> cacheNames = extractCacheNames(operations);
         
-        // 쓰기 작업(put, evict)이 포함되어 있다면 엄격한 모드로 실행 (실패 시 예외 throw)
-        // @Cacheable만 있는 경우(read-only)에는 가용성을 위해 put 실패를 허용(swallow)
+        // 읽기 작업인 경우 swallow exception, 쓰기 작업인 경우 실패 시 throw exception
         boolean strictWrite = isStrictWriteRequired(operations);
 
-        // 이번 요청에서 실행 권한을 획득한 서킷 브레이커들을 추적
-        List<CircuitBreakerExecution> grantedBreakers = new ArrayList<>(cacheNames.size());
-        // 참조하는 캐시 중 하나라도 OPEN 상태면 이번 호출은 캐시를 우회
-        boolean bypassEnabled = false;
 
         // 캐시별 서킷 브레이커로부터 실행 권한을 획득 시도
+        List<CircuitBreakerExecution> grantedBreakers = new ArrayList<>(cacheNames.size());
+        boolean bypassEnabled = false;
         for (String cacheName : cacheNames) {
             CircuitBreaker circuitBreaker = circuitBreakerProvider.get(cacheName);
-            // 레디스 호출 방지를 위해 OPEN 상태는 즉시 권한을 거부(Fail-fast)
+            // 레디스 호출 방지를 위해 OPEN 상태는 즉시 권한을 거부
             if (!circuitBreaker.tryAcquirePermission()) {
                 bypassEnabled = true;
                 log.debug("Cache circuit is open. cache={}, method={}", cacheName, method.getName());
                 continue;
             }
 
-            // 메서드 실행 후 성공 여부를 기록하기 위해 획득한 서킷 브레이커를 보관합니다.
+            // 메서드 실행 후 성공 여부를 기록하기 위해 획득한 서킷 브레이커를 보관
             grantedBreakers.add(new CircuitBreakerExecution(cacheName, circuitBreaker));
         }
 
@@ -82,7 +77,7 @@ public class CacheCircuitBreakerAspect {
         RedisCacheExecutionContext.pushContext(bypassEnabled, strictWrite);
 
         try {
-            // 메서드 실행을 계속,  우회가 활성화된 경우 캐시 레이어는 패스
+            // 메서드 실행을 계속, 우회가 활성화된 경우 캐시 레이어는 패스
             Object result = joinPoint.proceed();
             // 실제 레디스 캐시를 사용한 경우(우회되지 않은 경우)에만 성공을 기록
             if (!bypassEnabled) {

--- a/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.cache.annotation.AnnotationCacheOperationSource;
@@ -28,16 +29,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CacheCircuitBreakerAspect {
 
-    // 캐시 이름별로 서킷 브레이커 인스턴스를 관리하고 반환하는 프로바이더
     private final RedisCacheCircuitBreakerProvider circuitBreakerProvider;
 
-    // 스프링의 캐시 추상화 인프라를 활용하여 메서드/클래스의 캐시 설정을 분석
     private final CacheOperationSource cacheOperationSource = new AnnotationCacheOperationSource();
 
-    /**
-     * 스프링 캐시 어노테이션이 사용된 메서드나 클래스를 가로챕니다.
-     */
-    @Around("@annotation(org.springframework.cache.annotation.Cacheable) || " +
+    @Pointcut("@annotation(org.springframework.cache.annotation.Cacheable) || " +
             "@annotation(org.springframework.cache.annotation.CachePut) || " +
             "@annotation(org.springframework.cache.annotation.CacheEvict) || " +
             "@annotation(org.springframework.cache.annotation.Caching) || " +
@@ -45,6 +41,9 @@ public class CacheCircuitBreakerAspect {
             "@within(org.springframework.cache.annotation.CachePut) || " +
             "@within(org.springframework.cache.annotation.CacheEvict) || " +
             "@within(org.springframework.cache.annotation.Caching)")
+    public void cacheOperation() {}
+
+    @Around("cacheOperation()")
     public Object aroundCacheCall(final ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         // 실제 호출 대상 클래스를 확보합니다. (Spring의 어노테이션 탐색 규칙에 필요)

--- a/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
@@ -4,9 +4,9 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -16,6 +16,7 @@ import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -23,92 +24,116 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Aspect
 @Component
-// Execute before Spring Cache interceptor so we can decide whether to bypass cache access.
-@Order(Ordered.HIGHEST_PRECEDENCE)
+@Order(Ordered.HIGHEST_PRECEDENCE) // 스프링 캐시 인터셉터보다 먼저 실행되어 캐시 접근을 우회할지 결정
 @RequiredArgsConstructor
 public class CacheCircuitBreakerAspect {
 
-    // Provider that returns one circuit breaker instance per cache name.
+    // 캐시 이름별로 서킷 브레이커 인스턴스를 관리하고 반환하는 프로바이더
     private final RedisCacheCircuitBreakerProvider circuitBreakerProvider;
 
-    // Intercepts every method that uses @Cacheable, @CachePut, or @CacheEvict.
+    // @Cacheable, @CachePut, @CacheEvict, @Caching 어노테이션이 사용된 모든 메서드를 가로챕니다.
     @Around("@annotation(org.springframework.cache.annotation.Cacheable) || " +
             "@annotation(org.springframework.cache.annotation.CachePut) || " +
-            "@annotation(org.springframework.cache.annotation.CacheEvict)")
+            "@annotation(org.springframework.cache.annotation.CacheEvict) || " +
+            "@annotation(org.springframework.cache.annotation.Caching)")
     public Object aroundCacheCall(final ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
 
-        // A single method can reference multiple cache names via different annotations.
+        // 하나의 메서드는 여러 어노테이션을 통해 다수의 캐시 이름을 참조할 수 있습니다.
         List<String> cacheNames = extractCacheNames(method);
-        // Track only circuit breakers that granted permission for this request.
+        // 이번 요청에서 실행 권한을 획득한 서킷 브레이커들을 추적합니다.
         List<CircuitBreakerExecution> grantedBreakers = new ArrayList<>(cacheNames.size());
-        // If at least one cache is OPEN, we force cache bypass for this invocation.
+        // 참조하는 캐시 중 하나라도 OPEN 상태면 이번 호출은 캐시를 우회합니다.
         boolean bypassEnabled = false;
 
-        // Try to acquire permission from each cache-specific circuit breaker.
+        // 캐시별 서킷 브레이커로부터 실행 권한을 획득 시도합니다.
         for (String cacheName : cacheNames) {
             CircuitBreaker circuitBreaker = circuitBreakerProvider.get(cacheName);
-            // OPEN state denies permission immediately (fail-fast, no redis round-trip).
+            // 레디스 호출 방지를 위해 OPEN 상태는 즉시 권한을 거부합니다.(Fail-fast)
             if (!circuitBreaker.tryAcquirePermission()) {
                 bypassEnabled = true;
                 log.debug("Cache circuit is open. cache={}, method={}", cacheName, joinPoint.getSignature());
                 continue;
             }
 
-            // Keep breaker so we can report success after method execution.
+            // 메서드 실행 후 성공 여부를 기록하기 위해 획득한 서킷 브레이커를 보관합니다.
             grantedBreakers.add(new CircuitBreakerExecution(cacheName, circuitBreaker));
         }
 
-        // Enable ThreadLocal bypass so CacheResolver returns NoOpCache.
-        if (bypassEnabled) {
-            RedisCacheExecutionContext.enableBypass();
-        }
+        // ThreadLocal 우회 설정을 스택에 쌓아 중첩된 호출에서도 상태를 유지합니다.
+        RedisCacheExecutionContext.pushContext(bypassEnabled);
 
         try {
-            // Continue to method execution; when bypass is enabled, cache layer is skipped.
+            // 메서드 실행을 계속합니다. 우회가 활성화된 경우 캐시 레이어는 건너뜁니다.
             Object result = joinPoint.proceed();
-            // Mark successful calls only when we actually used real cache (not bypassed).
+            // 실제 레디스 캐시를 사용한 경우(우회되지 않은 경우)에만 성공을 기록합니다.
             if (!bypassEnabled) {
                 recordSuccess(grantedBreakers);
             }
             return result;
         } finally {
-            // Always clear ThreadLocal to avoid leaking state across pooled threads.
-            RedisCacheExecutionContext.clear();
+            // 이번 호출의 컨텍스트를 제거하여 이전 호출 상태로 복구합니다.
+            RedisCacheExecutionContext.popContext();
+            // 최상위 호출이 종료될 때 전체 상태를 정리하여 메모리 누수를 방지합니다.
+            if (!RedisCacheExecutionContext.hasContext()) {
+                RedisCacheExecutionContext.clear();
+            }
         }
     }
 
-    // Records success only when no redis failure was marked for that cache in this call.
+    // 이번 호출에서 레디스 장애가 발생하지 않은 캐시들에 대해서만 성공을 기록합니다.
     private void recordSuccess(final List<CircuitBreakerExecution> grantedBreakers) {
         for (CircuitBreakerExecution execution : grantedBreakers) {
-            // If cache get/put failed, error handler already counted this call as failure.
+            // 캐시 조회/저장 중 장애가 발생했다면, ErrorHandler에서 이미 실패로 처리했습니다.
             if (RedisCacheExecutionContext.hasFailure(execution.cacheName())) {
                 continue;
             }
-            // Zero duration because we only need outcome, not latency metric.
+            // 단순 성공 여부만 필요하므로 지연 시간(duration)은 0으로 기록합니다.
             execution.circuitBreaker().onSuccess(0, TimeUnit.NANOSECONDS);
         }
     }
 
-    // Extract cache names from any cache-related annotation on the method.
+    // @Caching을 포함하여 메서드에 선언된 모든 캐시 관련 어노테이션에서 캐시 이름을 추출합니다.
     private List<String> extractCacheNames(final Method method) {
+        List<String> names = new ArrayList<>();
+
+        // @Cacheable 처리
         Cacheable cacheable = method.getAnnotation(Cacheable.class);
         if (cacheable != null) {
-            return getNames(cacheable.cacheNames(), cacheable.value());
+            names.addAll(getNames(cacheable.cacheNames(), cacheable.value()));
         }
 
+        // @CachePut 처리
         CachePut cachePut = method.getAnnotation(CachePut.class);
         if (cachePut != null) {
-            return getNames(cachePut.cacheNames(), cachePut.value());
+            names.addAll(getNames(cachePut.cacheNames(), cachePut.value()));
         }
 
+        // @CacheEvict 처리
         CacheEvict cacheEvict = method.getAnnotation(CacheEvict.class);
         if (cacheEvict != null) {
-            return getNames(cacheEvict.cacheNames(), cacheEvict.value());
+            names.addAll(getNames(cacheEvict.cacheNames(), cacheEvict.value()));
         }
 
-        return Collections.emptyList();
+        // @Caching 처리 (복합 어노테이션)
+        Caching caching = method.getAnnotation(Caching.class);
+        if (caching != null) {
+            Stream.of(caching.cacheable())
+                    .forEach(c -> names.addAll(getNames(c.cacheNames(), c.value())));
+            Stream.of(caching.put())
+                    .forEach(c -> names.addAll(getNames(c.cacheNames(), c.value())));
+            Stream.of(caching.evict())
+                    .forEach(c -> names.addAll(getNames(c.cacheNames(), c.value())));
+        }
+
+        // 클래스 레벨의 @CacheConfig가 있을 경우 기본 캐시 이름을 추가로 고려할 수 있으나,
+        // 현재는 메서드 레벨의 명시적 선언을 우선순위로 하여 추출합니다.
+
+        return names.stream()
+                .filter(name -> name != null && !name.isEmpty())
+                .distinct()
+                .toList();
     }
 
     private List<String> getNames(final String[] cacheNames, final String[] value) {
@@ -118,7 +143,7 @@ public class CacheCircuitBreakerAspect {
         return Arrays.asList(value);
     }
 
-    // Small immutable holder for per-cache breaker execution state.
+    // 각 캐시별 서킷 브레이커 실행 상태를 담는 불변 객체입니다.
     private record CircuitBreakerExecution(String cacheName, CircuitBreaker circuitBreaker) {
     }
 }

--- a/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
@@ -3,10 +3,8 @@ package org.ject.support.common.data.redis.resilience;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,13 +13,10 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.aop.support.AopUtils;
-import org.springframework.cache.annotation.CacheConfig;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.CachePut;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.cache.annotation.Caching;
+import org.springframework.cache.annotation.AnnotationCacheOperationSource;
+import org.springframework.cache.interceptor.CacheOperation;
+import org.springframework.cache.interceptor.CacheOperationSource;
 import org.springframework.core.Ordered;
-import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +29,9 @@ public class CacheCircuitBreakerAspect {
 
     // 캐시 이름별로 서킷 브레이커 인스턴스를 관리하고 반환하는 프로바이더
     private final RedisCacheCircuitBreakerProvider circuitBreakerProvider;
+
+    // 스프링의 캐시 추상화 인프라를 활용하여 메서드/클래스의 캐시 설정을 분석
+    private final CacheOperationSource cacheOperationSource = new AnnotationCacheOperationSource();
 
     /**
      * 스프링 캐시 어노테이션이 사용된 메서드나 클래스를 가로챕니다.
@@ -48,11 +46,13 @@ public class CacheCircuitBreakerAspect {
             "@within(org.springframework.cache.annotation.Caching)")
     public Object aroundCacheCall(final ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        // 실제 호출 대상 클래스를 확보합니다. (Spring의 어노테이션 탐색 규칙에 필요)
+        Class<?> targetClass = joinPoint.getTarget().getClass();
         // 실제 대상 객체의 메서드를 찾아 인터페이스나 상속 관계에서의 어노테이션까지 감지할 수 있게 합니다.
-        Method method = AopUtils.getMostSpecificMethod(signature.getMethod(), joinPoint.getTarget().getClass());
+        Method method = AopUtils.getMostSpecificMethod(signature.getMethod(), targetClass);
 
         // 메서드 및 클래스 레벨에서 참조하는 모든 캐시 이름을 추출
-        List<String> cacheNames = extractCacheNames(method);
+        List<String> cacheNames = extractCacheNames(method, targetClass);
         // 이번 요청에서 실행 권한을 획득한 서킷 브레이커들을 추적
         List<CircuitBreakerExecution> grantedBreakers = new ArrayList<>(cacheNames.size());
         // 참조하는 캐시 중 하나라도 OPEN 상태면 이번 호출은 캐시를 우회
@@ -105,52 +105,20 @@ public class CacheCircuitBreakerAspect {
         }
     }
 
-    // @Caching을 포함하여 메서드 및 클래스 레벨에 선언된 모든 캐시 관련 어노테이션에서 캐시 이름을 추출
-    private List<String> extractCacheNames(final Method method) {
-        Set<String> names = new HashSet<>();
-        Class<?> targetClass = method.getDeclaringClass();
+    // CacheOperationSource를 활용하여 메서드 및 클래스 레벨에 선언된 모든 캐시 이름을 추출
+    private List<String> extractCacheNames(final Method method, final Class<?> targetClass) {
+        // 스프링 인프라가 메서드, 클래스, 인터페이스에서 적용된 모든 캐시 작업을 탐색
+        Collection<CacheOperation> operations = cacheOperationSource.getCacheOperations(method, targetClass);
 
-        // 클래스 레벨의 @CacheConfig를 통해 기본 캐시 이름을 확보합니다.
-        CacheConfig cacheConfig = AnnotatedElementUtils.findMergedAnnotation(targetClass, CacheConfig.class);
-        String[] defaultNames = (cacheConfig != null) ? cacheConfig.cacheNames() : new String[0];
+        if (operations == null || operations.isEmpty()) {
+            return List.of();
+        }
 
-        Cacheable mCacheable = AnnotatedElementUtils.findMergedAnnotation(method, Cacheable.class);
-        Cacheable cCacheable = (mCacheable == null) ? AnnotatedElementUtils.findMergedAnnotation(targetClass, Cacheable.class) : null;
-        if (mCacheable != null) names.addAll(resolveNames(mCacheable.cacheNames(), mCacheable.value(), defaultNames));
-        if (cCacheable != null) names.addAll(resolveNames(cCacheable.cacheNames(), cCacheable.value(), defaultNames));
-
-        CachePut mCachePut = AnnotatedElementUtils.findMergedAnnotation(method, CachePut.class);
-        CachePut cCachePut = (mCachePut == null) ? AnnotatedElementUtils.findMergedAnnotation(targetClass, CachePut.class) : null;
-        if (mCachePut != null) names.addAll(resolveNames(mCachePut.cacheNames(), mCachePut.value(), defaultNames));
-        if (cCachePut != null) names.addAll(resolveNames(cCachePut.cacheNames(), cCachePut.value(), defaultNames));
-
-        CacheEvict mCacheEvict = AnnotatedElementUtils.findMergedAnnotation(method, CacheEvict.class);
-        CacheEvict cCacheEvict = (mCacheEvict == null) ? AnnotatedElementUtils.findMergedAnnotation(targetClass, CacheEvict.class) : null;
-        if (mCacheEvict != null) names.addAll(resolveNames(mCacheEvict.cacheNames(), mCacheEvict.value(), defaultNames));
-        if (cCacheEvict != null) names.addAll(resolveNames(cCacheEvict.cacheNames(), cCacheEvict.value(), defaultNames));
-
-        Caching mCaching = AnnotatedElementUtils.findMergedAnnotation(method, Caching.class);
-        Caching cCaching = (mCaching == null) ? AnnotatedElementUtils.findMergedAnnotation(targetClass, Caching.class) : null;
-        processCaching(mCaching, names, defaultNames);
-        processCaching(cCaching, names, defaultNames);
-
-        return names.stream()
+        return operations.stream()
+                .flatMap(operation -> operation.getCacheNames().stream())
                 .filter(name -> name != null && !name.isEmpty())
                 .distinct()
                 .toList();
-    }
-
-    private void processCaching(final Caching caching, final Set<String> names, final String[] defaultNames) {
-        if (caching == null) return;
-        for (Cacheable c : caching.cacheable()) names.addAll(resolveNames(c.cacheNames(), c.value(), defaultNames));
-        for (CachePut p : caching.put()) names.addAll(resolveNames(p.cacheNames(), p.value(), defaultNames));
-        for (CacheEvict e : caching.evict()) names.addAll(resolveNames(e.cacheNames(), e.value(), defaultNames));
-    }
-
-    private List<String> resolveNames(final String[] cacheNames, final String[] value, final String[] defaultNames) {
-        if (cacheNames.length > 0) return Arrays.asList(cacheNames);
-        if (value.length > 0) return Arrays.asList(value);
-        return Arrays.asList(defaultNames);
     }
 
     // 각 캐시별 서킷 브레이커 실행 상태를 담는 불변 객체

--- a/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
@@ -16,6 +16,7 @@ import org.springframework.aop.support.AopUtils;
 import org.springframework.cache.annotation.AnnotationCacheOperationSource;
 import org.springframework.cache.interceptor.CacheOperation;
 import org.springframework.cache.interceptor.CacheOperationSource;
+import org.springframework.cache.interceptor.CacheableOperation;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -52,7 +53,13 @@ public class CacheCircuitBreakerAspect {
         Method method = AopUtils.getMostSpecificMethod(signature.getMethod(), targetClass);
 
         // 메서드 및 클래스 레벨에서 참조하는 모든 캐시 이름을 추출
-        List<String> cacheNames = extractCacheNames(method, targetClass);
+        Collection<CacheOperation> operations = cacheOperationSource.getCacheOperations(method, targetClass);
+        List<String> cacheNames = extractCacheNames(operations);
+        
+        // 쓰기 작업(put, evict)이 포함되어 있다면 엄격한 모드로 실행 (실패 시 예외 throw)
+        // @Cacheable만 있는 경우(read-only)에는 가용성을 위해 put 실패를 허용(swallow)
+        boolean strictWrite = isStrictWriteRequired(operations);
+
         // 이번 요청에서 실행 권한을 획득한 서킷 브레이커들을 추적
         List<CircuitBreakerExecution> grantedBreakers = new ArrayList<>(cacheNames.size());
         // 참조하는 캐시 중 하나라도 OPEN 상태면 이번 호출은 캐시를 우회
@@ -73,7 +80,7 @@ public class CacheCircuitBreakerAspect {
         }
 
         // ThreadLocal 우회 설정을 스택에 쌓아 중첩된 호출에서도 상태를 유지
-        RedisCacheExecutionContext.pushContext(bypassEnabled);
+        RedisCacheExecutionContext.pushContext(bypassEnabled, strictWrite);
 
         try {
             // 메서드 실행을 계속,  우회가 활성화된 경우 캐시 레이어는 패스
@@ -106,10 +113,7 @@ public class CacheCircuitBreakerAspect {
     }
 
     // CacheOperationSource를 활용하여 메서드 및 클래스 레벨에 선언된 모든 캐시 이름을 추출
-    private List<String> extractCacheNames(final Method method, final Class<?> targetClass) {
-        // 스프링 인프라가 메서드, 클래스, 인터페이스에서 적용된 모든 캐시 작업을 탐색
-        Collection<CacheOperation> operations = cacheOperationSource.getCacheOperations(method, targetClass);
-
+    private List<String> extractCacheNames(final Collection<CacheOperation> operations) {
         if (operations == null || operations.isEmpty()) {
             return List.of();
         }
@@ -119,6 +123,16 @@ public class CacheCircuitBreakerAspect {
                 .filter(name -> name != null && !name.isEmpty())
                 .distinct()
                 .toList();
+    }
+
+    // 모든 작업이 @Cacheable인 경우(단순 조회 목적)가 아니라면 엄격한 예외 처리가 필요하다고 판단
+    private boolean isStrictWriteRequired(final Collection<CacheOperation> operations) {
+        if (operations == null || operations.isEmpty()) {
+            return true;
+        }
+
+        // 하나라도 @CachePut이나 @CacheEvict가 섞여 있다면 정합성을 위해 strict 모드 활성화
+        return operations.stream().anyMatch(op -> !(op instanceof CacheableOperation));
     }
 
     // 각 캐시별 서킷 브레이커 실행 상태를 담는 불변 객체

--- a/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
@@ -36,7 +36,7 @@ public class CacheCircuitBreakerAspect {
     private final RedisCacheCircuitBreakerProvider circuitBreakerProvider;
 
     /**
-     * @Cacheable, @CachePut, @CacheEvict, @Caching 어노테이션이 사용된 메서드나 클래스를 가로챕니다.
+     * 스프링 캐시 어노테이션이 사용된 메서드나 클래스를 가로챕니다.
      */
     @Around("@annotation(org.springframework.cache.annotation.Cacheable) || " +
             "@annotation(org.springframework.cache.annotation.CachePut) || " +
@@ -114,25 +114,21 @@ public class CacheCircuitBreakerAspect {
         CacheConfig cacheConfig = AnnotatedElementUtils.findMergedAnnotation(targetClass, CacheConfig.class);
         String[] defaultNames = (cacheConfig != null) ? cacheConfig.cacheNames() : new String[0];
 
-        // @Cacheable 추출
         Cacheable mCacheable = AnnotatedElementUtils.findMergedAnnotation(method, Cacheable.class);
         Cacheable cCacheable = (mCacheable == null) ? AnnotatedElementUtils.findMergedAnnotation(targetClass, Cacheable.class) : null;
         if (mCacheable != null) names.addAll(resolveNames(mCacheable.cacheNames(), mCacheable.value(), defaultNames));
         if (cCacheable != null) names.addAll(resolveNames(cCacheable.cacheNames(), cCacheable.value(), defaultNames));
 
-        // @CachePut 추출
         CachePut mCachePut = AnnotatedElementUtils.findMergedAnnotation(method, CachePut.class);
         CachePut cCachePut = (mCachePut == null) ? AnnotatedElementUtils.findMergedAnnotation(targetClass, CachePut.class) : null;
         if (mCachePut != null) names.addAll(resolveNames(mCachePut.cacheNames(), mCachePut.value(), defaultNames));
         if (cCachePut != null) names.addAll(resolveNames(cCachePut.cacheNames(), cCachePut.value(), defaultNames));
 
-        // @CacheEvict 추출
         CacheEvict mCacheEvict = AnnotatedElementUtils.findMergedAnnotation(method, CacheEvict.class);
         CacheEvict cCacheEvict = (mCacheEvict == null) ? AnnotatedElementUtils.findMergedAnnotation(targetClass, CacheEvict.class) : null;
         if (mCacheEvict != null) names.addAll(resolveNames(mCacheEvict.cacheNames(), mCacheEvict.value(), defaultNames));
         if (cCacheEvict != null) names.addAll(resolveNames(cCacheEvict.cacheNames(), cCacheEvict.value(), defaultNames));
 
-        // @Caching 추출 (복합 어노테이션)
         Caching mCaching = AnnotatedElementUtils.findMergedAnnotation(method, Caching.class);
         Caching cCaching = (mCaching == null) ? AnnotatedElementUtils.findMergedAnnotation(targetClass, Caching.class) : null;
         processCaching(mCaching, names, defaultNames);
@@ -158,6 +154,5 @@ public class CacheCircuitBreakerAspect {
     }
 
     // 각 캐시별 서킷 브레이커 실행 상태를 담는 불변 객체
-    private record CircuitBreakerExecution(String cacheName, CircuitBreaker circuitBreaker) {
-    }
+    private record CircuitBreakerExecution(String cacheName, CircuitBreaker circuitBreaker) {}
 }

--- a/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/CacheCircuitBreakerAspect.java
@@ -1,0 +1,124 @@
+package org.ject.support.common.data.redis.resilience;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+// Execute before Spring Cache interceptor so we can decide whether to bypass cache access.
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RequiredArgsConstructor
+public class CacheCircuitBreakerAspect {
+
+    // Provider that returns one circuit breaker instance per cache name.
+    private final RedisCacheCircuitBreakerProvider circuitBreakerProvider;
+
+    // Intercepts every method that uses @Cacheable, @CachePut, or @CacheEvict.
+    @Around("@annotation(org.springframework.cache.annotation.Cacheable) || " +
+            "@annotation(org.springframework.cache.annotation.CachePut) || " +
+            "@annotation(org.springframework.cache.annotation.CacheEvict)")
+    public Object aroundCacheCall(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        // A single method can reference multiple cache names via different annotations.
+        List<String> cacheNames = extractCacheNames(method);
+        // Track only circuit breakers that granted permission for this request.
+        List<CircuitBreakerExecution> grantedBreakers = new ArrayList<>(cacheNames.size());
+        // If at least one cache is OPEN, we force cache bypass for this invocation.
+        boolean bypassEnabled = false;
+
+        // Try to acquire permission from each cache-specific circuit breaker.
+        for (String cacheName : cacheNames) {
+            CircuitBreaker circuitBreaker = circuitBreakerProvider.get(cacheName);
+            // OPEN state denies permission immediately (fail-fast, no redis round-trip).
+            if (!circuitBreaker.tryAcquirePermission()) {
+                bypassEnabled = true;
+                log.debug("Cache circuit is open. cache={}, method={}", cacheName, joinPoint.getSignature());
+                continue;
+            }
+
+            // Keep breaker so we can report success after method execution.
+            grantedBreakers.add(new CircuitBreakerExecution(cacheName, circuitBreaker));
+        }
+
+        // Enable ThreadLocal bypass so CacheResolver returns NoOpCache.
+        if (bypassEnabled) {
+            RedisCacheExecutionContext.enableBypass();
+        }
+
+        try {
+            // Continue to method execution; when bypass is enabled, cache layer is skipped.
+            Object result = joinPoint.proceed();
+            // Mark successful calls only when we actually used real cache (not bypassed).
+            if (!bypassEnabled) {
+                recordSuccess(grantedBreakers);
+            }
+            return result;
+        } finally {
+            // Always clear ThreadLocal to avoid leaking state across pooled threads.
+            RedisCacheExecutionContext.clear();
+        }
+    }
+
+    // Records success only when no redis failure was marked for that cache in this call.
+    private void recordSuccess(final List<CircuitBreakerExecution> grantedBreakers) {
+        for (CircuitBreakerExecution execution : grantedBreakers) {
+            // If cache get/put failed, error handler already counted this call as failure.
+            if (RedisCacheExecutionContext.hasFailure(execution.cacheName())) {
+                continue;
+            }
+            // Zero duration because we only need outcome, not latency metric.
+            execution.circuitBreaker().onSuccess(0, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    // Extract cache names from any cache-related annotation on the method.
+    private List<String> extractCacheNames(final Method method) {
+        Cacheable cacheable = method.getAnnotation(Cacheable.class);
+        if (cacheable != null) {
+            return getNames(cacheable.cacheNames(), cacheable.value());
+        }
+
+        CachePut cachePut = method.getAnnotation(CachePut.class);
+        if (cachePut != null) {
+            return getNames(cachePut.cacheNames(), cachePut.value());
+        }
+
+        CacheEvict cacheEvict = method.getAnnotation(CacheEvict.class);
+        if (cacheEvict != null) {
+            return getNames(cacheEvict.cacheNames(), cacheEvict.value());
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<String> getNames(final String[] cacheNames, final String[] value) {
+        if (cacheNames.length > 0) {
+            return Arrays.asList(cacheNames);
+        }
+        return Arrays.asList(value);
+    }
+
+    // Small immutable holder for per-cache breaker execution state.
+    private record CircuitBreakerExecution(String cacheName, CircuitBreaker circuitBreaker) {
+    }
+}

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerConfig.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerConfig.java
@@ -1,0 +1,39 @@
+package org.ject.support.common.data.redis.resilience;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.time.Duration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisCacheCircuitBreakerConfig {
+
+    // Shared named config template applied to each cache-specific breaker instance.
+    public static final String REDIS_CACHE_CONFIG_NAME = "redis-cache";
+
+    @Bean
+    public CircuitBreakerRegistry circuitBreakerRegistry() {
+        // Circuit breaker policy tuned for quick detection and short recovery probing.
+        CircuitBreakerConfig config = CircuitBreakerConfig.custom()
+                // OPEN when failure rate >= 50% in current sliding window.
+                .failureRateThreshold(50)
+                // Avoid opening on tiny sample size.
+                .minimumNumberOfCalls(5)
+                // Count last 10 calls per cache breaker.
+                .slidingWindowSize(10)
+                // Stay OPEN for 10s before moving to HALF_OPEN.
+                .waitDurationInOpenState(Duration.ofSeconds(10))
+                // Allow limited trial calls while HALF_OPEN.
+                .permittedNumberOfCallsInHalfOpenState(3)
+                // Only redis-related failures contribute to breaker metrics.
+                .recordException(RedisCacheExceptionClassifier::isRedisRelated)
+                .build();
+
+        // Start with default registry, then add our named redis profile.
+        CircuitBreakerRegistry registry = CircuitBreakerRegistry.ofDefaults();
+        registry.addConfiguration(REDIS_CACHE_CONFIG_NAME, config);
+        return registry;
+    }
+}
+

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerConfig.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerConfig.java
@@ -9,28 +9,27 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RedisCacheCircuitBreakerConfig {
 
-    // Shared named config template applied to each cache-specific breaker instance.
+    // 각 캐시별 서킷 브레이커 인스턴스에 적용될 공통 설정 템플릿 이름
     public static final String REDIS_CACHE_CONFIG_NAME = "redis-cache";
 
     @Bean
     public CircuitBreakerRegistry circuitBreakerRegistry() {
-        // Circuit breaker policy tuned for quick detection and short recovery probing.
         CircuitBreakerConfig config = CircuitBreakerConfig.custom()
-                // OPEN when failure rate >= 50% in current sliding window.
+                // 실패율이 50% 이상일 때 서킷을 OPEN
                 .failureRateThreshold(50)
-                // Avoid opening on tiny sample size.
+                // 너무 적은 수로 서킷 OPEN 방지하기 위해 최소 호출 횟수를 5회로 제한
                 .minimumNumberOfCalls(5)
-                // Count last 10 calls per cache breaker.
+                // 캐시별 서킷 브레이커에서 최근 10개의 호출 계산
                 .slidingWindowSize(10)
-                // Stay OPEN for 10s before moving to HALF_OPEN.
+                // OPEN 상태에서 10초 동안 대기한 후 HALF_OPEN 상태로 전환합니다.
                 .waitDurationInOpenState(Duration.ofSeconds(10))
-                // Allow limited trial calls while HALF_OPEN.
+                // HALF_OPEN 상태에서 재시도할 호출 횟수를 3회로 제한
                 .permittedNumberOfCallsInHalfOpenState(3)
-                // Only redis-related failures contribute to breaker metrics.
+                // 레디스 관련 장애만 서킷 브레이커 지표에 기록
                 .recordException(RedisCacheExceptionClassifier::isRedisRelated)
                 .build();
 
-        // Start with default registry, then add our named redis profile.
+        // 기본 레지스트리에 레디스 전용 프로필 설정을 추가
         CircuitBreakerRegistry registry = CircuitBreakerRegistry.ofDefaults();
         registry.addConfiguration(REDIS_CACHE_CONFIG_NAME, config);
         return registry;

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerConfig.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerConfig.java
@@ -29,7 +29,6 @@ public class RedisCacheCircuitBreakerConfig {
                 .recordException(RedisCacheExceptionClassifier::isRedisRelated)
                 .build();
 
-        // 기본 레지스트리에 레디스 전용 프로필 설정을 추가
         CircuitBreakerRegistry registry = CircuitBreakerRegistry.ofDefaults();
         registry.addConfiguration(REDIS_CACHE_CONFIG_NAME, config);
         return registry;

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerProvider.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerProvider.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RedisCacheCircuitBreakerProvider {
 
-    // 이름 기반의 서킷 브레이커 인스턴스를 관리하고 재사용하는 전역 레지스트리
     private final CircuitBreakerRegistry circuitBreakerRegistry;
 
     public CircuitBreaker get(final String cacheName) {

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerProvider.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerProvider.java
@@ -1,0 +1,24 @@
+package org.ject.support.common.data.redis.resilience;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisCacheCircuitBreakerProvider {
+
+    // 이름 기반 서킷 브레이커를 저장하고 재사용하는 전역 레지스트리.
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
+
+    public CircuitBreaker get(final String cacheName) {
+        // 캐시별로 브레이커를 분리해 도메인 캐시 간 장애 전파를 막는다.
+        return circuitBreakerRegistry.circuitBreaker(
+                "redis-cache-" + cacheName,
+                // Redis 전용 공통 브레이커 설정을 적용한다.
+                RedisCacheCircuitBreakerConfig.REDIS_CACHE_CONFIG_NAME
+        );
+    }
+}
+

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerProvider.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerProvider.java
@@ -20,5 +20,11 @@ public class RedisCacheCircuitBreakerProvider {
                 RedisCacheCircuitBreakerConfig.REDIS_CACHE_CONFIG_NAME
         );
     }
+
+    public void resetAll() {
+        // 모든 서킷 브레이커의 상태와 메트릭을 초기화하여 테스트 간 격리 등을 지원
+        circuitBreakerRegistry.getAllCircuitBreakers()
+                .forEach(CircuitBreaker::reset);
+    }
 }
 

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerProvider.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheCircuitBreakerProvider.java
@@ -9,14 +9,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RedisCacheCircuitBreakerProvider {
 
-    // 이름 기반 서킷 브레이커를 저장하고 재사용하는 전역 레지스트리.
+    // 이름 기반의 서킷 브레이커 인스턴스를 관리하고 재사용하는 전역 레지스트리
     private final CircuitBreakerRegistry circuitBreakerRegistry;
 
     public CircuitBreaker get(final String cacheName) {
-        // 캐시별로 브레이커를 분리해 도메인 캐시 간 장애 전파를 막는다.
+        // 캐시별로 서킷 브레이커를 분리하여 도메인 캐시 간 장애 전파 방지
         return circuitBreakerRegistry.circuitBreaker(
                 "redis-cache-" + cacheName,
-                // Redis 전용 공통 브레이커 설정을 적용한다.
+                // 레디스 전용 공통 서킷 브레이커 설정을 적용
                 RedisCacheCircuitBreakerConfig.REDIS_CACHE_CONFIG_NAME
         );
     }

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExceptionClassifier.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExceptionClassifier.java
@@ -1,25 +1,20 @@
 package org.ject.support.common.data.redis.resilience;
 
-import java.util.Locale;
 import java.util.concurrent.TimeoutException;
+import lombok.experimental.UtilityClass;
 import org.springframework.dao.QueryTimeoutException;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.RedisSystemException;
 
+@UtilityClass
 public final class RedisCacheExceptionClassifier {
 
-    // Utility class: prevent instantiation.
-    private RedisCacheExceptionClassifier() {
-    }
-
-    // Walks throwable cause chain and decides whether failure is redis/network related.
+    // 예외의 원인 체인(Cause Chain)을 탐색하여 레디스 인프라 장애(연결, 타임아웃 등)인지 판단합니다.
     public static boolean isRedisRelated(final Throwable throwable) {
-        // Start from top-level exception thrown by cache infrastructure.
         Throwable cursor = throwable;
 
-        // Inspect whole cause chain because wrappers differ by driver/spring version.
         while (cursor != null) {
-            // Known redis/timeout exception types handled explicitly.
+            // 명시적으로 처리되는 레디스/네트워크 타임아웃 예외 타입
             if (cursor instanceof RedisConnectionFailureException
                     || cursor instanceof RedisSystemException
                     || cursor instanceof QueryTimeoutException
@@ -27,17 +22,16 @@ public final class RedisCacheExceptionClassifier {
                 return true;
             }
 
-            // Defensive fallback for wrapped vendor-specific exception names.
-            String className = cursor.getClass().getName().toLowerCase(Locale.ROOT);
-            if (className.contains("redis") || className.contains("lettuce")) {
+            // 라이브러리(Lettuce 등) 전용 하위 예외나 네트워크 관련 키워드를 포함하는 경우만 인프라 장애로 간주
+            // SerializationException과 같이 비인프라(데이터/코드)성 예외는 포함되지 않도록 범위 설정
+            String className = cursor.getClass().getName();
+            if (className.contains("io.lettuce.core") || className.contains("RedisCommand") || className.contains("RedisConnection")) {
                 return true;
             }
 
-            // Move down to nested cause.
             cursor = cursor.getCause();
         }
 
-        // Not a redis-related failure.
         return false;
     }
 }

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExceptionClassifier.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExceptionClassifier.java
@@ -1,0 +1,44 @@
+package org.ject.support.common.data.redis.resilience;
+
+import java.util.Locale;
+import java.util.concurrent.TimeoutException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
+
+public final class RedisCacheExceptionClassifier {
+
+    // Utility class: prevent instantiation.
+    private RedisCacheExceptionClassifier() {
+    }
+
+    // Walks throwable cause chain and decides whether failure is redis/network related.
+    public static boolean isRedisRelated(final Throwable throwable) {
+        // Start from top-level exception thrown by cache infrastructure.
+        Throwable cursor = throwable;
+
+        // Inspect whole cause chain because wrappers differ by driver/spring version.
+        while (cursor != null) {
+            // Known redis/timeout exception types handled explicitly.
+            if (cursor instanceof RedisConnectionFailureException
+                    || cursor instanceof RedisSystemException
+                    || cursor instanceof QueryTimeoutException
+                    || cursor instanceof TimeoutException) {
+                return true;
+            }
+
+            // Defensive fallback for wrapped vendor-specific exception names.
+            String className = cursor.getClass().getName().toLowerCase(Locale.ROOT);
+            if (className.contains("redis") || className.contains("lettuce")) {
+                return true;
+            }
+
+            // Move down to nested cause.
+            cursor = cursor.getCause();
+        }
+
+        // Not a redis-related failure.
+        return false;
+    }
+}
+

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExceptionClassifier.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExceptionClassifier.java
@@ -9,12 +9,11 @@ import org.springframework.data.redis.RedisSystemException;
 @UtilityClass
 public final class RedisCacheExceptionClassifier {
 
-    // 예외의 원인 체인(Cause Chain)을 탐색하여 레디스 인프라 장애(연결, 타임아웃 등)인지 판단합니다.
+    // 예외의 cause chain을 탐색하여 레디스 인프라 장애인지 판단
     public static boolean isRedisRelated(final Throwable throwable) {
         Throwable cursor = throwable;
 
         while (cursor != null) {
-            // 명시적으로 처리되는 레디스/네트워크 타임아웃 예외 타입
             if (cursor instanceof RedisConnectionFailureException
                     || cursor instanceof RedisSystemException
                     || cursor instanceof QueryTimeoutException
@@ -22,10 +21,11 @@ public final class RedisCacheExceptionClassifier {
                 return true;
             }
 
-            // 라이브러리(Lettuce 등) 전용 하위 예외나 네트워크 관련 키워드를 포함하는 경우만 인프라 장애로 간주
-            // SerializationException과 같이 비인프라(데이터/코드)성 예외는 포함되지 않도록 범위 설정
+            // 라이브러리 전용 예외나 관련 키워드를 포함하는 경우만 장애로 간주
             String className = cursor.getClass().getName();
-            if (className.contains("io.lettuce.core") || className.contains("RedisCommand") || className.contains("RedisConnection")) {
+            if (className.contains("io.lettuce.core")
+                    || className.contains("RedisCommand")
+                    || className.contains("RedisConnection")) {
                 return true;
             }
 

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExceptionClassifier.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExceptionClassifier.java
@@ -7,7 +7,7 @@ import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.RedisSystemException;
 
 @UtilityClass
-public final class RedisCacheExceptionClassifier {
+public class RedisCacheExceptionClassifier {
 
     // 예외의 cause chain을 탐색하여 레디스 인프라 장애인지 판단
     public static boolean isRedisRelated(final Throwable throwable) {

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExecutionContext.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExecutionContext.java
@@ -13,10 +13,18 @@ public class RedisCacheExecutionContext {
     private static final ThreadLocal<Deque<Boolean>> BYPASS_STACK = ThreadLocal.withInitial(ArrayDeque::new);
     // 요청별 레디스 장애가 발생한 캐시 이름들의 집합 (레벨별 독립 Set 관리)
     private static final ThreadLocal<Deque<Set<String>>> FAILED_CACHES_STACK = ThreadLocal.withInitial(ArrayDeque::new);
+    // 쓰기 작업(put, evict, clear) 시 엄격한 예외 처리를 적용할지 여부 (기본값: true)
+    private static final ThreadLocal<Deque<Boolean>> STRICT_WRITE_STACK = ThreadLocal.withInitial(ArrayDeque::new);
 
-    // 캐시 호출 시작 시 현재 상태(우회 여부)와 새로운 실패 집합을 스택에 추가
-    public static void pushContext(final boolean bypassEnabled) {
+    /**
+     * 캐시 호출 시작 시 현재 상태를 스택에 추가합니다.
+     *
+     * @param bypassEnabled 서킷 브레이커에 의해 레디스 호출을 건너뛸지 여부
+     * @param strictWrite   쓰기 작업 실패 시 예외를 던질지 여부 (false면 swallow)
+     */
+    public static void pushContext(final boolean bypassEnabled, final boolean strictWrite) {
         BYPASS_STACK.get().push(bypassEnabled);
+        STRICT_WRITE_STACK.get().push(strictWrite);
         FAILED_CACHES_STACK.get().push(new HashSet<>());
     }
 
@@ -25,6 +33,10 @@ public class RedisCacheExecutionContext {
         Deque<Boolean> stack = BYPASS_STACK.get();
         if (!stack.isEmpty()) {
             stack.pop();
+        }
+        Deque<Boolean> strictStack = STRICT_WRITE_STACK.get();
+        if (!strictStack.isEmpty()) {
+            strictStack.pop();
         }
         Deque<Set<String>> failedStack = FAILED_CACHES_STACK.get();
         if (!failedStack.isEmpty()) {
@@ -52,6 +64,12 @@ public class RedisCacheExecutionContext {
         return !stack.isEmpty() && stack.peek().contains(cacheName);
     }
 
+    // 쓰기 작업 실패 시 엄격한 처리(re-throw)가 필요한지 확인 (기본값은 true)
+    public static boolean isStrictWriteEnabled() {
+        Boolean strict = STRICT_WRITE_STACK.get().peek();
+        return strict == null || strict;
+    }
+
     // 현재 활성화된 실행 컨텍스트(스택에 쌓인 호출)가 있는지 확인
     public static boolean hasContext() {
         return !BYPASS_STACK.get().isEmpty();
@@ -61,6 +79,7 @@ public class RedisCacheExecutionContext {
     public static void clear() {
         BYPASS_STACK.remove();
         FAILED_CACHES_STACK.remove();
+        STRICT_WRITE_STACK.remove();
     }
 }
 

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExecutionContext.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExecutionContext.java
@@ -1,0 +1,42 @@
+package org.ject.support.common.data.redis.resilience;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public final class RedisCacheExecutionContext {
+
+    // Per-request flag: true means cache access should be bypassed for current thread.
+    private static final ThreadLocal<Boolean> CACHE_BYPASS = ThreadLocal.withInitial(() -> false);
+    // Per-request set of cache names that failed due to redis issues.
+    private static final ThreadLocal<Set<String>> FAILED_CACHES = ThreadLocal.withInitial(HashSet::new);
+
+    private RedisCacheExecutionContext() {
+    }
+
+    // Called by aspect when any related circuit breaker is OPEN.
+    public static void enableBypass() {
+        CACHE_BYPASS.set(true);
+    }
+
+    // Read by CacheResolver to decide between real cache and NoOpCache.
+    public static boolean isBypassEnabled() {
+        return CACHE_BYPASS.get();
+    }
+
+    // Called by CacheErrorHandler when redis call fails for this cache.
+    public static void markFailure(final String cacheName) {
+        FAILED_CACHES.get().add(cacheName);
+    }
+
+    // Read by aspect to avoid marking breaker success on failed cache calls.
+    public static boolean hasFailure(final String cacheName) {
+        return FAILED_CACHES.get().contains(cacheName);
+    }
+
+    // Must be called in finally block to prevent ThreadLocal memory/state leak.
+    public static void clear() {
+        CACHE_BYPASS.remove();
+        FAILED_CACHES.remove();
+    }
+}
+

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExecutionContext.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExecutionContext.java
@@ -7,16 +7,17 @@ import java.util.Set;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
-public final class RedisCacheExecutionContext {
+public class RedisCacheExecutionContext {
 
     // 중첩된 캐시 호출 시 상태를 보존하기 위해 스택(Deque) 구조를 사용
     private static final ThreadLocal<Deque<Boolean>> BYPASS_STACK = ThreadLocal.withInitial(ArrayDeque::new);
-    // 요청별 레디스 장애가 발생한 캐시 이름들의 집합 (동일 스레드 내 모든 호출 공유)
-    private static final ThreadLocal<Set<String>> FAILED_CACHES = ThreadLocal.withInitial(HashSet::new);
+    // 요청별 레디스 장애가 발생한 캐시 이름들의 집합 (레벨별 독립 Set 관리)
+    private static final ThreadLocal<Deque<Set<String>>> FAILED_CACHES_STACK = ThreadLocal.withInitial(ArrayDeque::new);
 
-    // 캐시 호출 시작 시 현재 상태(우회 여부)를 스택에 추가
+    // 캐시 호출 시작 시 현재 상태(우회 여부)와 새로운 실패 집합을 스택에 추가
     public static void pushContext(final boolean bypassEnabled) {
         BYPASS_STACK.get().push(bypassEnabled);
+        FAILED_CACHES_STACK.get().push(new HashSet<>());
     }
 
     // 캐시 호출 종료 시 이전 상태로 복구
@@ -24,6 +25,10 @@ public final class RedisCacheExecutionContext {
         Deque<Boolean> stack = BYPASS_STACK.get();
         if (!stack.isEmpty()) {
             stack.pop();
+        }
+        Deque<Set<String>> failedStack = FAILED_CACHES_STACK.get();
+        if (!failedStack.isEmpty()) {
+            failedStack.pop();
         }
     }
 
@@ -33,14 +38,18 @@ public final class RedisCacheExecutionContext {
         return bypass != null && bypass;
     }
 
-    // 특정 캐시에 대한 레디스 호출이 실패했을 때 CacheErrorHandler에 의해 호출
+    // 특정 캐시에 대한 레디스 호출이 실패했을 때 CacheErrorHandler에 의해 호출 (현재 레벨에만 기록)
     public static void markFailure(final String cacheName) {
-        FAILED_CACHES.get().add(cacheName);
+        Deque<Set<String>> stack = FAILED_CACHES_STACK.get();
+        if (!stack.isEmpty()) {
+            stack.peek().add(cacheName);
+        }
     }
 
-    // 실패한 캐시 호출에 대해 서킷 브레이커가 성공을 기록하지 않도록 Aspect에서 참조
+    // 실패한 캐시 호출에 대해 서킷 브레이커가 성공을 기록하지 않도록 Aspect에서 참조 (현재 레벨만 확인)
     public static boolean hasFailure(final String cacheName) {
-        return FAILED_CACHES.get().contains(cacheName);
+        Deque<Set<String>> stack = FAILED_CACHES_STACK.get();
+        return !stack.isEmpty() && stack.peek().contains(cacheName);
     }
 
     // 현재 활성화된 실행 컨텍스트(스택에 쌓인 호출)가 있는지 확인
@@ -51,7 +60,7 @@ public final class RedisCacheExecutionContext {
     // ThreadLocal 메모리 누수 및 상태 오염을 방지하기 위해 최상위 호출이 끝날 때 호출
     public static void clear() {
         BYPASS_STACK.remove();
-        FAILED_CACHES.remove();
+        FAILED_CACHES_STACK.remove();
     }
 }
 

--- a/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExecutionContext.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/RedisCacheExecutionContext.java
@@ -1,41 +1,56 @@
 package org.ject.support.common.data.redis.resilience;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.Set;
+import lombok.experimental.UtilityClass;
 
+@UtilityClass
 public final class RedisCacheExecutionContext {
 
-    // Per-request flag: true means cache access should be bypassed for current thread.
-    private static final ThreadLocal<Boolean> CACHE_BYPASS = ThreadLocal.withInitial(() -> false);
-    // Per-request set of cache names that failed due to redis issues.
+    // 중첩된 캐시 호출 시 상태를 보존하기 위해 스택(Deque) 구조를 사용
+    private static final ThreadLocal<Deque<Boolean>> BYPASS_STACK = ThreadLocal.withInitial(ArrayDeque::new);
+    // 요청별 레디스 장애가 발생한 캐시 이름들의 집합 (동일 스레드 내 모든 호출 공유)
     private static final ThreadLocal<Set<String>> FAILED_CACHES = ThreadLocal.withInitial(HashSet::new);
 
-    private RedisCacheExecutionContext() {
+    // 캐시 호출 시작 시 현재 상태(우회 여부)를 스택에 추가
+    public static void pushContext(final boolean bypassEnabled) {
+        BYPASS_STACK.get().push(bypassEnabled);
     }
 
-    // Called by aspect when any related circuit breaker is OPEN.
-    public static void enableBypass() {
-        CACHE_BYPASS.set(true);
+    // 캐시 호출 종료 시 이전 상태로 복구
+    public static void popContext() {
+        Deque<Boolean> stack = BYPASS_STACK.get();
+        if (!stack.isEmpty()) {
+            stack.pop();
+        }
     }
 
-    // Read by CacheResolver to decide between real cache and NoOpCache.
+    // 현재 실행 컨텍스트에서 캐시 우회가 활성화되어 있는지 확인
     public static boolean isBypassEnabled() {
-        return CACHE_BYPASS.get();
+        Boolean bypass = BYPASS_STACK.get().peek();
+        return bypass != null && bypass;
     }
 
-    // Called by CacheErrorHandler when redis call fails for this cache.
+    // 특정 캐시에 대한 레디스 호출이 실패했을 때 CacheErrorHandler에 의해 호출
     public static void markFailure(final String cacheName) {
         FAILED_CACHES.get().add(cacheName);
     }
 
-    // Read by aspect to avoid marking breaker success on failed cache calls.
+    // 실패한 캐시 호출에 대해 서킷 브레이커가 성공을 기록하지 않도록 Aspect에서 참조
     public static boolean hasFailure(final String cacheName) {
         return FAILED_CACHES.get().contains(cacheName);
     }
 
-    // Must be called in finally block to prevent ThreadLocal memory/state leak.
+    // 현재 활성화된 실행 컨텍스트(스택에 쌓인 호출)가 있는지 확인
+    public static boolean hasContext() {
+        return !BYPASS_STACK.get().isEmpty();
+    }
+
+    // ThreadLocal 메모리 누수 및 상태 오염을 방지하기 위해 최상위 호출이 끝날 때 호출
     public static void clear() {
-        CACHE_BYPASS.remove();
+        BYPASS_STACK.remove();
         FAILED_CACHES.remove();
     }
 }

--- a/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheErrorHandler.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheErrorHandler.java
@@ -58,8 +58,9 @@ public class ResilientCacheErrorHandler implements CacheErrorHandler {
         }
 
         // 쓰기 작업(put, evict, clear) 중 레디스 장애 발생 시,
-        // 데이터 정합성을 위해 예외를 던져, 상위 비즈니스 로직(트랜잭션 등)이 롤백되거나 에러를 인지
-        if ("put".equals(operation) || "evict".equals(operation) || "clear".equals(operation)) {
+        // 데이터 정합성을 위해 엄격한 모드가 활성화되어 있다면 예외를 다시 던짐
+        if (RedisCacheExecutionContext.isStrictWriteEnabled() &&
+                ("put".equals(operation) || "evict".equals(operation) || "clear".equals(operation))) {
             log.error("Redis cache write operation failed. Operation: {}, Cache: {}, Key: {}, Message: {}",
                     operation, cache.getName(), key, exception.getMessage());
             throw exception;

--- a/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheErrorHandler.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheErrorHandler.java
@@ -14,14 +14,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ResilientCacheErrorHandler implements CacheErrorHandler {
 
-    // Provides cache-name scoped circuit breakers used to track redis health.
+    // 레디스의 상태를 추적하기 위해 캐시 이름별 서킷 브레이커를 제공
     private final RedisCacheCircuitBreakerProvider circuitBreakerProvider;
 
     @Override
     public void handleCacheGetError(@NonNull final RuntimeException exception,
                                     @NonNull final Cache cache,
                                     @NonNull final Object key) {
-        // get failures are most common with @Cacheable read path.
+        // @Cacheable의 조회(read) 경로에서 발생하는 get 실패를 처리
         handle("get", exception, cache, key);
     }
 
@@ -30,7 +30,7 @@ public class ResilientCacheErrorHandler implements CacheErrorHandler {
                                     @NonNull final Cache cache,
                                     @NonNull final Object key,
                                     final Object value) {
-        // put failures happen when @Cacheable tries to populate cache after DB fetch.
+        // @Cacheable이 DB 조회 후 캐시를 갱신하려고 할 때 발생하는 put 실패를 처리
         handle("put", exception, cache, key);
     }
 
@@ -38,35 +38,42 @@ public class ResilientCacheErrorHandler implements CacheErrorHandler {
     public void handleCacheEvictError(@NonNull final RuntimeException exception,
                                       @NonNull final Cache cache,
                                       @NonNull final Object key) {
-        // evict failures should not break business flow; mark breaker and continue.
+        // evict 실패가 비즈니스 흐름을 끊지 않도록 서킷 브레이커에 기록하고 계속 진행
         handle("evict", exception, cache, key);
     }
 
     @Override
     public void handleCacheClearError(@NonNull final RuntimeException exception,
                                       @NonNull final Cache cache) {
-        // clear has no single key; use wildcard for observability log.
         handle("clear", exception, cache, "*");
     }
 
-    // Centralized handling for all cache operations.
     private void handle(final String operation,
                         final RuntimeException exception,
                         final Cache cache,
                         final Object key) {
-        // Only swallow redis-related exceptions. Non-redis bugs must still fail fast.
+        // 레디스 관련 예외만 swallow, 그 외의 버그성 예외는 즉시 throw
         if (!RedisCacheExceptionClassifier.isRedisRelated(exception)) {
             throw exception;
         }
 
-        // Mark this cache as failed so aspect does not record false success.
+        // 쓰기 작업(put, evict, clear) 중 레디스 장애 발생 시,
+        // 데이터 정합성을 위해 예외를 던져, 상위 비즈니스 로직(트랜잭션 등)이 롤백되거나 에러를 인지
+        if ("put".equals(operation) || "evict".equals(operation) || "clear".equals(operation)) {
+            log.error("Redis cache write operation failed. Operation: {}, Cache: {}, Key: {}, Message: {}",
+                    operation, cache.getName(), key, exception.getMessage());
+            throw exception;
+        }
+
+        // 조회(get) 경로에서는 레디스 장애 시 DB 폴백을 위해 예외를 삼키고,
+        // Aspect에서 잘못된 성공을 기록하지 않도록 이 캐시를 실패 상태로 마킹
         RedisCacheExecutionContext.markFailure(cache.getName());
 
-        // Convert cache exception into circuit-breaker failure signal.
+        // 캐시 예외를 서킷 브레이커의 실패 신호로 변환하여 기록
         CircuitBreaker circuitBreaker = circuitBreakerProvider.get(cache.getName());
         circuitBreaker.onError(0, TimeUnit.NANOSECONDS, exception);
 
-        // Intentionally do not rethrow: application proceeds to DB fallback path.
+        // 의도적으로 예외를 다시 던지지 않고, 애플리케이션은 DB 폴백 경로로 진행
         log.warn("Redis cache {} failed. cache={}, key={}, fallback=DB, message={}",
                 operation,
                 cache.getName(),

--- a/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheErrorHandler.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheErrorHandler.java
@@ -57,8 +57,7 @@ public class ResilientCacheErrorHandler implements CacheErrorHandler {
             throw exception;
         }
 
-        // 쓰기 작업(put, evict, clear) 중 레디스 장애 발생 시,
-        // 데이터 정합성을 위해 엄격한 모드가 활성화되어 있다면 예외를 다시 던짐
+        // 쓰기 작업(put, evict, clear) 중 레디스 장애 발생 시, 예외를 다시 던짐
         if (RedisCacheExecutionContext.isStrictWriteEnabled() &&
                 ("put".equals(operation) || "evict".equals(operation) || "clear".equals(operation))) {
             log.error("Redis cache write operation failed. Operation: {}, Cache: {}, Key: {}, Message: {}",
@@ -66,7 +65,7 @@ public class ResilientCacheErrorHandler implements CacheErrorHandler {
             throw exception;
         }
 
-        // 조회(get) 경로에서는 레디스 장애 시 DB 폴백을 위해 예외를 삼키고,
+        // 조회 경로에서는 레디스 장애 시 DB 폴백을 위해 예외를 삼키고,
         // Aspect에서 잘못된 성공을 기록하지 않도록 이 캐시를 실패 상태로 마킹
         RedisCacheExecutionContext.markFailure(cache.getName());
 

--- a/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheErrorHandler.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheErrorHandler.java
@@ -1,0 +1,77 @@
+package org.ject.support.common.data.redis.resilience;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ResilientCacheErrorHandler implements CacheErrorHandler {
+
+    // Provides cache-name scoped circuit breakers used to track redis health.
+    private final RedisCacheCircuitBreakerProvider circuitBreakerProvider;
+
+    @Override
+    public void handleCacheGetError(@NonNull final RuntimeException exception,
+                                    @NonNull final Cache cache,
+                                    @NonNull final Object key) {
+        // get failures are most common with @Cacheable read path.
+        handle("get", exception, cache, key);
+    }
+
+    @Override
+    public void handleCachePutError(@NonNull final RuntimeException exception,
+                                    @NonNull final Cache cache,
+                                    @NonNull final Object key,
+                                    final Object value) {
+        // put failures happen when @Cacheable tries to populate cache after DB fetch.
+        handle("put", exception, cache, key);
+    }
+
+    @Override
+    public void handleCacheEvictError(@NonNull final RuntimeException exception,
+                                      @NonNull final Cache cache,
+                                      @NonNull final Object key) {
+        // evict failures should not break business flow; mark breaker and continue.
+        handle("evict", exception, cache, key);
+    }
+
+    @Override
+    public void handleCacheClearError(@NonNull final RuntimeException exception,
+                                      @NonNull final Cache cache) {
+        // clear has no single key; use wildcard for observability log.
+        handle("clear", exception, cache, "*");
+    }
+
+    // Centralized handling for all cache operations.
+    private void handle(final String operation,
+                        final RuntimeException exception,
+                        final Cache cache,
+                        final Object key) {
+        // Only swallow redis-related exceptions. Non-redis bugs must still fail fast.
+        if (!RedisCacheExceptionClassifier.isRedisRelated(exception)) {
+            throw exception;
+        }
+
+        // Mark this cache as failed so aspect does not record false success.
+        RedisCacheExecutionContext.markFailure(cache.getName());
+
+        // Convert cache exception into circuit-breaker failure signal.
+        CircuitBreaker circuitBreaker = circuitBreakerProvider.get(cache.getName());
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, exception);
+
+        // Intentionally do not rethrow: application proceeds to DB fallback path.
+        log.warn("Redis cache {} failed. cache={}, key={}, fallback=DB, message={}",
+                operation,
+                cache.getName(),
+                key,
+                exception.getMessage());
+    }
+}
+

--- a/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheErrorHandler.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheErrorHandler.java
@@ -14,14 +14,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ResilientCacheErrorHandler implements CacheErrorHandler {
 
-    // 레디스의 상태를 추적하기 위해 캐시 이름별 서킷 브레이커를 제공
     private final RedisCacheCircuitBreakerProvider circuitBreakerProvider;
 
     @Override
     public void handleCacheGetError(@NonNull final RuntimeException exception,
                                     @NonNull final Cache cache,
                                     @NonNull final Object key) {
-        // @Cacheable의 조회(read) 경로에서 발생하는 get 실패를 처리
         handle("get", exception, cache, key);
     }
 
@@ -30,7 +28,6 @@ public class ResilientCacheErrorHandler implements CacheErrorHandler {
                                     @NonNull final Cache cache,
                                     @NonNull final Object key,
                                     final Object value) {
-        // @Cacheable이 DB 조회 후 캐시를 갱신하려고 할 때 발생하는 put 실패를 처리
         handle("put", exception, cache, key);
     }
 
@@ -38,7 +35,6 @@ public class ResilientCacheErrorHandler implements CacheErrorHandler {
     public void handleCacheEvictError(@NonNull final RuntimeException exception,
                                       @NonNull final Cache cache,
                                       @NonNull final Object key) {
-        // evict 실패가 비즈니스 흐름을 끊지 않도록 서킷 브레이커에 기록하고 계속 진행
         handle("evict", exception, cache, key);
     }
 
@@ -57,7 +53,7 @@ public class ResilientCacheErrorHandler implements CacheErrorHandler {
             throw exception;
         }
 
-        // 쓰기 작업(put, evict, clear) 중 레디스 장애 발생 시, 예외를 다시 던짐
+        // 쓰기 작업 중 레디스 장애 발생 시, 예외를 다시 던짐
         if (RedisCacheExecutionContext.isStrictWriteEnabled() &&
                 ("put".equals(operation) || "evict".equals(operation) || "clear".equals(operation))) {
             log.error("Redis cache write operation failed. Operation: {}, Cache: {}, Key: {}, Message: {}",
@@ -65,8 +61,7 @@ public class ResilientCacheErrorHandler implements CacheErrorHandler {
             throw exception;
         }
 
-        // 조회 경로에서는 레디스 장애 시 DB 폴백을 위해 예외를 삼키고,
-        // Aspect에서 잘못된 성공을 기록하지 않도록 이 캐시를 실패 상태로 마킹
+        // 조회 경로에서는 레디스 장애 시 DB 폴백을 위해 예외를 삼키고, 실패 상태로 마킹
         RedisCacheExecutionContext.markFailure(cache.getName());
 
         // 캐시 예외를 서킷 브레이커의 실패 신호로 변환하여 기록

--- a/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheResolver.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheResolver.java
@@ -3,6 +3,7 @@ package org.ject.support.common.data.redis.resilience;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.interceptor.CacheOperationInvocationContext;
@@ -10,36 +11,33 @@ import org.springframework.cache.interceptor.CacheResolver;
 import org.springframework.cache.support.NoOpCache;
 import org.springframework.lang.NonNull;
 
+@RequiredArgsConstructor
 public class ResilientCacheResolver implements CacheResolver {
 
-    // Delegates actual cache lookup to Spring's configured CacheManager.
+    // 실제 캐시 조회 업무를 스프링에 설정된 CacheManager에 위임합니다.
     private final CacheManager cacheManager;
-
-    public ResilientCacheResolver(final CacheManager cacheManager) {
-        this.cacheManager = cacheManager;
-    }
 
     @Override
     @NonNull
     public Collection<? extends Cache> resolveCaches(@NonNull final CacheOperationInvocationContext<?> context) {
-        // Cache names declared on the current cache operation (@Cacheable/@CachePut/...)
+        // 현재 캐시 작업(@Cacheable, @CachePut 등)에 선언된 캐시 이름 추출
         Collection<String> cacheNames = context.getOperation().getCacheNames();
-        // Resolve in-order so behavior matches Spring default resolver semantics.
+        // 스프링의 기본 리졸버와 동일한 동작 방식을 위해 순서대로 리졸빙
         List<Cache> resolvedCaches = new ArrayList<>(cacheNames.size());
 
         for (String cacheName : cacheNames) {
-            // When bypass is enabled, return NoOpCache to skip all redis calls.
+            // 서킷 브레이커에 의해 우회(bypass)가 활성화된 경우, 모든 레디스 호출을 건너뛰기 위해 NoOpCache를 반환
             if (RedisCacheExecutionContext.isBypassEnabled()) {
                 resolvedCaches.add(new NoOpCache(cacheName));
                 continue;
             }
 
-            // Normal path: resolve real cache (RedisCache) from manager.
+            // 캐시 매니저로부터 실제 캐시(RedisCache)를 찾아 반환
             Cache cache = cacheManager.getCache(cacheName);
             if (cache != null) {
                 resolvedCaches.add(cache);
             }
-            // If cache is missing, ignore it to follow Spring's permissive behavior.
+            // 캐시를 찾을 수 없는 경우, 스프링의 기본 permissive 동작 방식을 따르기 위해 무시
         }
 
         return resolvedCaches;

--- a/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheResolver.java
+++ b/src/main/java/org/ject/support/common/data/redis/resilience/ResilientCacheResolver.java
@@ -1,0 +1,47 @@
+package org.ject.support.common.data.redis.resilience;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.interceptor.CacheOperationInvocationContext;
+import org.springframework.cache.interceptor.CacheResolver;
+import org.springframework.cache.support.NoOpCache;
+import org.springframework.lang.NonNull;
+
+public class ResilientCacheResolver implements CacheResolver {
+
+    // Delegates actual cache lookup to Spring's configured CacheManager.
+    private final CacheManager cacheManager;
+
+    public ResilientCacheResolver(final CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    @Override
+    @NonNull
+    public Collection<? extends Cache> resolveCaches(@NonNull final CacheOperationInvocationContext<?> context) {
+        // Cache names declared on the current cache operation (@Cacheable/@CachePut/...)
+        Collection<String> cacheNames = context.getOperation().getCacheNames();
+        // Resolve in-order so behavior matches Spring default resolver semantics.
+        List<Cache> resolvedCaches = new ArrayList<>(cacheNames.size());
+
+        for (String cacheName : cacheNames) {
+            // When bypass is enabled, return NoOpCache to skip all redis calls.
+            if (RedisCacheExecutionContext.isBypassEnabled()) {
+                resolvedCaches.add(new NoOpCache(cacheName));
+                continue;
+            }
+
+            // Normal path: resolve real cache (RedisCache) from manager.
+            Cache cache = cacheManager.getCache(cacheName);
+            if (cache != null) {
+                resolvedCaches.add(cache);
+            }
+            // If cache is missing, ignore it to follow Spring's permissive behavior.
+        }
+
+        return resolvedCaches;
+    }
+}

--- a/src/main/java/org/ject/support/domain/recruit/service/AccessPeriodVerifier.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/AccessPeriodVerifier.java
@@ -1,9 +1,16 @@
 package org.ject.support.domain.recruit.service;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.ject.support.common.data.redis.resilience.RedisCacheCircuitBreakerProvider;
+import org.ject.support.common.data.redis.resilience.RedisCacheExceptionClassifier;
+import org.ject.support.common.data.redis.resilience.RedisCacheExecutionContext;
 import org.ject.support.common.exception.GlobalErrorCode;
 import org.ject.support.common.exception.GlobalException;
 import org.ject.support.common.util.PeriodAccessible;
@@ -12,31 +19,61 @@ import org.ject.support.domain.recruit.dto.Constants;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
-
+@Slf4j
 @Aspect
 @Component
 @RequiredArgsConstructor
 public class AccessPeriodVerifier {
     private final RedisTemplate<String, String> redisTemplate;
+    private final RedisCacheCircuitBreakerProvider circuitBreakerProvider;
 
     @Around("@annotation(org.ject.support.common.util.PeriodAccessible) && @annotation(target)")
     public Object checkRecruitmentPeriod(ProceedingJoinPoint joinPoint, PeriodAccessible target) throws Throwable {
-        // 모든 직군에 대한 요청인 경우, 하나의 어떤 RECRUIT_FLAG만 있어도 허용
-        if (target.permitAllJob()) {
-            boolean isAnyRecruiting = Arrays.stream(JobFamily.values())
-                    .anyMatch(jobFamily -> Boolean.parseBoolean(redisTemplate.opsForValue()
-                            .get(getKeyName(jobFamily.name()))));
-            validateRecruiting(isAnyRecruiting);
+        // 이미 상위(Aspect 등)에서 레디스 장애를 감지하여 우회 모드라면 안전하게 통과 (가용성 우선)
+        if (RedisCacheExecutionContext.isBypassEnabled()) {
             return joinPoint.proceed();
         }
 
-        // 특정 직군을 파라미터로 받은 경우, 해당 직군에 대한 모집 여부로 판단
-        JobFamily jobFamily = extractJobFamily(joinPoint);
-        boolean isRecruiting = Boolean.parseBoolean(redisTemplate.opsForValue()
-                .get(getKeyName(jobFamily.name())));
-        validateRecruiting(isRecruiting);
-        return joinPoint.proceed();
+        CircuitBreaker circuitBreaker = circuitBreakerProvider.get("access-period");
+
+        // 서킷 브레이커 상태 체크 (OPEN 상태면 즉시 통과하여 장애 전파 방지)
+        if (!circuitBreaker.tryAcquirePermission()) {
+            log.warn("AccessPeriodVerifier circuit is open. Falling back to allow access.");
+            return joinPoint.proceed();
+        }
+
+        try {
+            // 모든 직군에 대한 요청인 경우, 하나의 어떤 RECRUIT_FLAG만 있어도 허용
+            if (target.permitAllJob()) {
+                boolean isAnyRecruiting = Arrays.stream(JobFamily.values())
+                        .anyMatch(jobFamily -> Boolean.parseBoolean(redisTemplate.opsForValue()
+                                .get(getKeyName(jobFamily.name()))));
+                validateRecruiting(isAnyRecruiting);
+            } else {
+                // 특정 직군을 파라미터로 받은 경우, 해당 직군에 대한 모집 여부로 판단
+                JobFamily jobFamily = extractJobFamily(joinPoint);
+                boolean isRecruiting = Boolean.parseBoolean(redisTemplate.opsForValue()
+                        .get(getKeyName(jobFamily.name())));
+                validateRecruiting(isRecruiting);
+            }
+
+            Object result = joinPoint.proceed();
+            // 성공 기록
+            circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+            return result;
+        } catch (Throwable throwable) {
+            // 레디스 관련 인프라 장애(연결, 타임아웃 등) 시 폴백 처리
+            if (RedisCacheExceptionClassifier.isRedisRelated(throwable)) {
+                log.warn("AccessPeriodVerifier failed due to Redis issue. Falling back to allow access. error={}", throwable.getMessage());
+                // 실패 기록 및 컨텍스트에 장애 발생 마킹
+                circuitBreaker.onError(0, TimeUnit.NANOSECONDS, throwable);
+                RedisCacheExecutionContext.markFailure("access-period");
+                return joinPoint.proceed();
+            }
+
+            // 비즈니스 로직 예외(모집 기간 종료 등)나 그 외 버그성 예외는 그대로 전파
+            throw throwable;
+        }
     }
 
     private String getKeyName(String jobFamilyName) {
@@ -44,14 +81,14 @@ public class AccessPeriodVerifier {
     }
 
     private void validateRecruiting(boolean isRecruiting) {
-        if (Boolean.FALSE.equals(isRecruiting)) {
+        if (!isRecruiting) {
             throw new GlobalException(GlobalErrorCode.OVER_PERIOD);
         }
     }
 
     private JobFamily extractJobFamily(ProceedingJoinPoint joinPoint) {
         return Arrays.stream(joinPoint.getArgs())
-                .filter(arg -> arg instanceof JobFamily)
+                .filter(JobFamily.class::isInstance)
                 .map(JobFamily.class::cast)
                 .findFirst()
                 .orElseThrow(() -> new GlobalException(GlobalErrorCode.MISS_REQUIRED_JOB_FAMILY_PARAMETER));

--- a/src/test/java/org/ject/support/common/data/redis/resilience/CacheFallbackIntegrationTest.java
+++ b/src/test/java/org/ject/support/common/data/redis/resilience/CacheFallbackIntegrationTest.java
@@ -1,0 +1,134 @@
+package org.ject.support.common.data.redis.resilience;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ject.support.domain.recruit.domain.Question.InputType.TEXT;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.recruit.domain.Question;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.Semester;
+import org.ject.support.domain.recruit.dto.QuestionResponses;
+import org.ject.support.domain.recruit.repository.QuestionRepository;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.ject.support.domain.recruit.repository.SemesterRepository;
+import org.ject.support.domain.recruit.service.QuestionService;
+import org.ject.support.testconfig.IntegrationTest;
+import org.ject.support.testconfig.RedisTestContainersConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.serializer.SerializationException;
+
+@IntegrationTest
+class CacheFallbackIntegrationTest {
+
+    @Autowired
+    private QuestionService questionService;
+
+    @Autowired
+    private RecruitRepository recruitRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private SemesterRepository semesterRepository;
+
+    @Autowired
+    private RedisCacheCircuitBreakerProvider circuitBreakerProvider;
+
+    @BeforeEach
+    void setUp() {
+        List<Question> questions = List.of(
+                Question.builder().sequence(1).inputType(TEXT).isRequired(true).title("title1").label("label").build()
+        );
+
+        Semester savedSemester = semesterRepository.save(Semester.builder()
+                .name("1기")
+                .isRecruiting(true)
+                .build());
+
+        Recruit recruit = Recruit.builder()
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .semester(savedSemester)
+                .jobFamily(JobFamily.BE)
+                .build();
+
+        for (Question question : questions) {
+            recruit.addQuestion(question);
+        }
+
+        recruitRepository.save(recruit);
+
+        Member member = Member.builder()
+                .email("test@gmail.com")
+                .semesterId(1L)
+                .jobFamily(JobFamily.BE)
+                .name("김젝트")
+                .role(Role.SEMESTER)
+                .phoneNumber("01012345678")
+                .pin("123456")
+                .status(MemberStatus.ACTIVE)
+                .build();
+        memberRepository.save(member);
+    }
+
+    @AfterEach
+    void restoreRedis() {
+        RedisTestContainersConfig.start();
+    }
+
+    @Test
+    @DisplayName("레디스가 다운되어도 DB에서 데이터를 정상적으로 조회하고 서킷 브레이커가 동작한다")
+    void shouldFallbackToDbWhenRedisIsDown() {
+        // given
+        RedisTestContainersConfig.stop(); // Redis 중단 시뮬레이션
+
+        // when: 캐시가 적용된 서비스 메서드 호출
+        // Redis가 죽어있으므로 CacheErrorHandler가 예외를 잡고, DB에서 데이터를 가져와야 함
+        QuestionResponses response = questionService.findQuestions(JobFamily.BE);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.questionResponses()).isNotEmpty();
+        assertThat(response.questionResponses().get(0).title()).isEqualTo("title1");
+
+        // 서킷 브레이커 상태 확인 최소 호출 횟수(5회)를 채워야 상태가 변하지만, 에러가 기록되었는지는 확인할 수 있음
+        CircuitBreaker breaker = circuitBreakerProvider.get("question");
+        assertThat(breaker.getMetrics().getNumberOfFailedCalls()).isPositive();
+    }
+
+    @Test
+    @DisplayName("직렬화 오류와 같은 비인프라 예외는 서킷 브레이커에 기록되지 않고 즉시 발생해야 한다")
+    void shouldNotSwallowNonInfrastructureExceptions() {
+        // given: 직렬화 예외 발생 시나리오
+        SerializationException serializationException = new SerializationException("Serialization failed");
+        
+        // expected
+        // ErrorHandler가 이 예외를 다시 던지는지 확인
+        ResilientCacheErrorHandler errorHandler = new ResilientCacheErrorHandler(circuitBreakerProvider);
+        assertThatThrownBy(() -> errorHandler.handleCacheGetError(serializationException, null, "key"))
+                .isSameAs(serializationException);
+        
+        // 서킷 브레이커에 실패가 기록되지 않았어야 함
+        CircuitBreaker breaker = circuitBreakerProvider.get("question");
+        long failedCallsBefore = breaker.getMetrics().getNumberOfFailedCalls();
+        
+        // handleCacheGetError 호출 후에도 실패 횟수가 그대로인지 확인 (이미 위에서 exception이 던져졌으므로 기록 안 됨)
+        assertThat(breaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(failedCallsBefore);
+    }
+}

--- a/src/test/java/org/ject/support/common/data/redis/resilience/CacheFallbackIntegrationTest.java
+++ b/src/test/java/org/ject/support/common/data/redis/resilience/CacheFallbackIntegrationTest.java
@@ -28,7 +28,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.serializer.SerializationException;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @IntegrationTest
 class CacheFallbackIntegrationTest {
 
@@ -52,12 +54,13 @@ class CacheFallbackIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        String uniqueSuffix = String.valueOf(System.currentTimeMillis());
         List<Question> questions = List.of(
                 Question.builder().sequence(1).inputType(TEXT).isRequired(true).title("title1").label("label").build()
         );
 
         Semester savedSemester = semesterRepository.save(Semester.builder()
-                .name("1기")
+                .name("1기" + uniqueSuffix)
                 .isRecruiting(true)
                 .build());
 
@@ -75,8 +78,8 @@ class CacheFallbackIntegrationTest {
         recruitRepository.save(recruit);
 
         Member member = Member.builder()
-                .email("test@gmail.com")
-                .semesterId(1L)
+                .email("test" + uniqueSuffix + "@gmail.com")
+                .semesterId(savedSemester.getId())
                 .jobFamily(JobFamily.BE)
                 .name("김젝트")
                 .role(Role.SEMESTER)

--- a/src/test/java/org/ject/support/common/data/redis/resilience/CacheFallbackIntegrationTest.java
+++ b/src/test/java/org/ject/support/common/data/redis/resilience/CacheFallbackIntegrationTest.java
@@ -90,6 +90,7 @@ class CacheFallbackIntegrationTest {
     @AfterEach
     void restoreRedis() {
         RedisTestContainersConfig.start();
+        circuitBreakerProvider.resetAll(); // 테스트 간 격리를 위해 서킷 브레이커 메트릭 초기화
     }
 
     @Test
@@ -127,6 +128,7 @@ class CacheFallbackIntegrationTest {
         // 서킷 브레이커에 실패가 기록되지 않았어야 함
         CircuitBreaker breaker = circuitBreakerProvider.get("question");
         long failedCallsBefore = breaker.getMetrics().getNumberOfFailedCalls();
+        assertThat(failedCallsBefore).isZero(); // 이전 테스트의 영향 없이 0이어야 함
         
         // handleCacheGetError 호출 후에도 실패 횟수가 그대로인지 확인 (이미 위에서 exception이 던져졌으므로 기록 안 됨)
         assertThat(breaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(failedCallsBefore);

--- a/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodVerifierTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodVerifierTest.java
@@ -6,8 +6,10 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.ject.support.base.UnitTestSupport;
+import org.ject.support.common.data.redis.resilience.RedisCacheCircuitBreakerProvider;
 import org.ject.support.common.exception.GlobalException;
 import org.ject.support.common.util.PeriodAccessible;
 import org.ject.support.domain.member.JobFamily;
@@ -35,9 +37,17 @@ class AccessPeriodVerifierTest extends UnitTestSupport {
     @Mock
     ValueOperations<String, String> valueOperations;
 
+    @Mock
+    RedisCacheCircuitBreakerProvider circuitBreakerProvider;
+
+    @Mock
+    CircuitBreaker circuitBreaker;
+
     @BeforeEach
     void setUp() {
         lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        lenient().when(circuitBreakerProvider.get(anyString())).thenReturn(circuitBreaker);
+        lenient().when(circuitBreaker.tryAcquirePermission()).thenReturn(true);
     }
 
     @Test

--- a/src/test/java/org/ject/support/testconfig/RedisTestContainersConfig.java
+++ b/src/test/java/org/ject/support/testconfig/RedisTestContainersConfig.java
@@ -1,7 +1,7 @@
 package org.ject.support.testconfig;
 
 import java.time.Duration;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -10,11 +10,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-
-import lombok.extern.slf4j.Slf4j;
 
 @Profile("test")
 @TestConfiguration
@@ -62,5 +58,25 @@ public class RedisTestContainersConfig implements DisposableBean {
         if(redisContainer.isRunning()) {
             redisContainer.stop();
         }
+    }
+
+    public static void stop() {
+        if (redisContainer.isRunning()) {
+            redisContainer.stop();
+        }
+    }
+
+    public static void start() {
+        if (!redisContainer.isRunning()) {
+            redisContainer.start();
+        }
+    }
+
+    public static String getHost() {
+        return redisContainer.getHost();
+    }
+
+    public static Integer getMappedPort() {
+        return redisContainer.getMappedPort(REDIS_PORT);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #506 

## 📝 작업 내용

Redis 장애가 전체 서비스의 가용성 저하로 이어지는 SPOF(Single Point of Failure)를 방지하기 위해, Resilience4j 기반의 서킷 브레이커를 구현했습니다.

- Circuitbreaker를 AOP 기반으로 적용하여 Redis 장애 시 타임아웃 대기 없이 즉시 요청을 차단하고 로직을 DB로 전환(Fallback)하도록 했습니다.
- `CachingConfigurer`를 구현하여 `ResilientCacheResolver`와 `ResilientCacheErrorHandler`가 모든 캐시 작업에 일관되게 적용되도록 구성했습니다.
- Redis 연결 오류 등 캐시 관련 예외가 비즈니스 로직(API 500)으로 전파되지 않도록 예외 처리 로직을 중앙 집중화했습니다.
- Redis 컨테이너를 강제 중단시킨 상황에서도 서비스가 중단 없이 DB 데이터를 반환하는지 검증하는 통합 테스트를 추가했습니다.
- 서킷 브레이커 도입 전후의 응답 지연 시간(Latency) 개선 효과를 k6 부하 테스트 및 통합 테스트를 통해 측정했습니다.
  - 가용성: Redis Down 상황에서도 5xx 에러 없이 2xx 정상 응답 반환 확인
  - Synthetic: `beforeAvgMs=98`, `afterAvgMs=29`
  - Domain Synthetic:
    - project: `97ms -> 28ms(≈71.1%)` 
    - ministudy: `90ms -> 29ms(≈67.8%)`
    - jectalk: `94ms -> 28ms(≈70.2%)`
    - question: `100ms -> 26ms(74.0%)`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Redis 캐시별 회로 차단기 도입으로 장애 시 해당 캐시만 자동 우회하고 애플리케이션 흐름은 계속 유지
  * 우회 상태를 기반으로 캐시 조회를 무시하는 동작(디폴트 대체 경로) 추가

* **버그 수정 / 안정성**
  * 캐시 오류 분류·처리 강화로 비-인프라 예외는 재던지고 Redis 관련 장애만 회로/메트릭에 기록
  * 스레드 로컬 컨텍스트로 요청 간 상태 누수 방지

* **잡업(Chores)**
  * 캐시 회복력 관련 런타임 라이브러리(Resilience4j, AOP 지원) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->