### PR TITLE
feat:백오피스 관련 역할 권한 추가

### DIFF
--- a/src/main/java/org/ject/support/admin/auth/service/AdminAuthService.java
+++ b/src/main/java/org/ject/support/admin/auth/service/AdminAuthService.java
@@ -36,7 +36,7 @@ public class AdminAuthService {
     public Authentication authenticateAdmin(String email, String password) {
         validateLoginAttemptLimit(email);
 
-        Member member = adminMemberComponent.findMemberAdminByEmail(email)
+        Member member = adminMemberComponent.findBackofficeMemberByEmail(email)
                 .orElseThrow(() -> handleInvalidAdminCredentials(email));
 
         if (!passwordEncoder.matches(password, member.getPin())) {

--- a/src/main/java/org/ject/support/admin/member/component/AdminMemberComponent.java
+++ b/src/main/java/org/ject/support/admin/member/component/AdminMemberComponent.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
-import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -20,15 +19,14 @@ import java.util.Set;
 public class AdminMemberComponent {
 
     private final MemberRepository memberRepository;
-    private static final Set<Role> BACKOFFICE_ROLES = Role.backofficeRoles();
 
     public Member getRequiredBackofficeMemberByEmail(String email) {
-        return memberRepository.findByEmailAndRoleIn(email, BACKOFFICE_ROLES)
+        return memberRepository.findByEmailAndRoleIn(email, Role.backofficeRoles())
                 .orElseThrow(() -> new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
     }
 
     public Optional<Member> findBackofficeMemberByEmail(String email) {
-        return memberRepository.findByEmailAndRoleIn(email, BACKOFFICE_ROLES);
+        return memberRepository.findByEmailAndRoleIn(email, Role.backofficeRoles());
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/org/ject/support/admin/member/component/AdminMemberComponent.java
+++ b/src/main/java/org/ject/support/admin/member/component/AdminMemberComponent.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -19,14 +20,15 @@ import java.util.Optional;
 public class AdminMemberComponent {
 
     private final MemberRepository memberRepository;
+    private static final Set<Role> BACKOFFICE_ROLES = Role.backofficeRoles();
 
     public Member getRequiredBackofficeMemberByEmail(String email) {
-        return memberRepository.findByEmailAndRoleIn(email, Role.BACKOFFICE_ROLES)
+        return memberRepository.findByEmailAndRoleIn(email, BACKOFFICE_ROLES)
                 .orElseThrow(() -> new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
     }
 
     public Optional<Member> findBackofficeMemberByEmail(String email) {
-        return memberRepository.findByEmailAndRoleIn(email, Role.BACKOFFICE_ROLES);
+        return memberRepository.findByEmailAndRoleIn(email, BACKOFFICE_ROLES);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/org/ject/support/admin/member/component/AdminMemberComponent.java
+++ b/src/main/java/org/ject/support/admin/member/component/AdminMemberComponent.java
@@ -21,12 +21,12 @@ public class AdminMemberComponent {
     private final MemberRepository memberRepository;
 
     public Member getMemberAdminByEmail(String email) {
-        return memberRepository.findByEmailAndRole(email, Role.ADMIN)
+        return memberRepository.findByEmailAndRoleIn(email, Role.BACKOFFICE_ROLES)
                 .orElseThrow(() -> new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
     }
 
     public Optional<Member> findMemberAdminByEmail(String email) {
-        return memberRepository.findByEmailAndRole(email, Role.ADMIN);
+        return memberRepository.findByEmailAndRoleIn(email, Role.BACKOFFICE_ROLES);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/org/ject/support/admin/member/component/AdminMemberComponent.java
+++ b/src/main/java/org/ject/support/admin/member/component/AdminMemberComponent.java
@@ -20,12 +20,12 @@ public class AdminMemberComponent {
 
     private final MemberRepository memberRepository;
 
-    public Member getMemberAdminByEmail(String email) {
+    public Member getRequiredBackofficeMemberByEmail(String email) {
         return memberRepository.findByEmailAndRoleIn(email, Role.BACKOFFICE_ROLES)
                 .orElseThrow(() -> new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
     }
 
-    public Optional<Member> findMemberAdminByEmail(String email) {
+    public Optional<Member> findBackofficeMemberByEmail(String email) {
         return memberRepository.findByEmailAndRoleIn(email, Role.BACKOFFICE_ROLES);
     }
 

--- a/src/main/java/org/ject/support/common/security/CustomUserDetails.java
+++ b/src/main/java/org/ject/support/common/security/CustomUserDetails.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import lombok.Getter;
 import org.ject.support.domain.member.Permission;
 import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.RolePermissions;
 import org.ject.support.domain.member.entity.Member;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -32,7 +33,7 @@ public class CustomUserDetails implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> collection = new ArrayList<>();
         collection.add((GrantedAuthority)() -> "ROLE_" + role);
-        role.getPermissions().stream()
+        RolePermissions.getPermissions(role).stream()
                 .map(Permission::name)
                 .map(permission -> (GrantedAuthority)() -> permission)
                 .forEach(collection::add);

--- a/src/main/java/org/ject/support/common/security/CustomUserDetails.java
+++ b/src/main/java/org/ject/support/common/security/CustomUserDetails.java
@@ -3,6 +3,7 @@ package org.ject.support.common.security;
 import java.util.ArrayList;
 import java.util.Collection;
 import lombok.Getter;
+import org.ject.support.domain.member.Permission;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.springframework.security.core.GrantedAuthority;
@@ -31,6 +32,10 @@ public class CustomUserDetails implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> collection = new ArrayList<>();
         collection.add((GrantedAuthority)() -> "ROLE_" + role);
+        role.getPermissions().stream()
+                .map(Permission::name)
+                .map(permission -> (GrantedAuthority)() -> permission)
+                .forEach(collection::add);
         return collection;
     }
 

--- a/src/main/java/org/ject/support/common/security/config/RoleHierarchySpec.java
+++ b/src/main/java/org/ject/support/common/security/config/RoleHierarchySpec.java
@@ -1,0 +1,39 @@
+package org.ject.support.common.security.config;
+
+import org.ject.support.domain.member.Role;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class RoleHierarchySpec {
+
+    private static final Map<Role, Set<Role>> HIERARCHY = Map.of(
+            Role.ADMIN, EnumSet.of(Role.SEMESTER),
+            Role.OPERATIONS, EnumSet.of(Role.SEMESTER),
+            Role.SUPPORTER, EnumSet.of(Role.SEMESTER),
+            Role.SEMESTER, EnumSet.of(Role.APPLY),
+            Role.APPLY, EnumSet.of(Role.VERIFICATION)
+    );
+
+    private RoleHierarchySpec() {
+    }
+
+    public static String hierarchyExpression() {
+        return HIERARCHY.entrySet().stream()
+                .flatMap(entry -> entry.getValue().stream()
+                        .map(child -> "ROLE_" + entry.getKey().name() + " > ROLE_" + child.name()))
+                .collect(Collectors.joining("\n"));
+    }
+
+    // 권한누락 방지용
+    public static Set<Role> getDefinedRoles() {
+        Set<Role> roles = EnumSet.noneOf(Role.class);
+        HIERARCHY.forEach((parent, children) -> {
+            roles.add(parent);
+            roles.addAll(children);
+        });
+        return roles;
+    }
+}

--- a/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.ject.support.common.security.jwt.JwtAccessDeniedHandler;
 import org.ject.support.common.security.jwt.JwtAuthenticationEntryPoint;
 import org.ject.support.common.security.jwt.JwtAuthenticationFilter;
 import org.ject.support.common.security.jwt.JwtExceptionHandlerFilter;
+import org.ject.support.domain.member.Role;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,6 +32,9 @@ import java.util.Arrays;
 public class SecurityConfig {
 
     private static final long MAX_AGE_SEC = 3600;
+    private static final String[] BACKOFFICE_ROLE_NAMES = Role.backofficeRoles().stream()
+            .map(Role::name)
+            .toArray(String[]::new);
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -67,7 +71,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(request -> request
                         .requestMatchers("/admin-auth/**").permitAll()
-                        .requestMatchers("/admin/**").hasAnyRole("ADMIN", "OPERATIONS", "SUPPORTER")
+                        .requestMatchers("/admin/**").hasAnyRole(BACKOFFICE_ROLE_NAMES)
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
@@ -47,13 +47,7 @@ public class SecurityConfig {
 
     @Bean
     public static RoleHierarchy roleHierarchy() {
-        return RoleHierarchyImpl.fromHierarchy("""
-                ROLE_ADMIN > ROLE_SEMESTER
-                ROLE_OPERATIONS > ROLE_SEMESTER
-                ROLE_SUPPORTER > ROLE_SEMESTER
-                ROLE_SEMESTER > ROLE_APPLY
-                ROLE_APPLY > ROLE_VERIFICATION
-                """);
+        return RoleHierarchyImpl.fromHierarchy(RoleHierarchySpec.hierarchyExpression());
     }
 
     @Bean

--- a/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ject/support/common/security/config/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.ject.support.common.security.jwt.JwtExceptionHandlerFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -50,6 +49,8 @@ public class SecurityConfig {
     public static RoleHierarchy roleHierarchy() {
         return RoleHierarchyImpl.fromHierarchy("""
                 ROLE_ADMIN > ROLE_SEMESTER
+                ROLE_OPERATIONS > ROLE_SEMESTER
+                ROLE_SUPPORTER > ROLE_SEMESTER
                 ROLE_SEMESTER > ROLE_APPLY
                 ROLE_APPLY > ROLE_VERIFICATION
                 """);
@@ -72,9 +73,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(request -> request
                         .requestMatchers("/admin-auth/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/admin/**")
-                            .hasAnyRole("ADMIN", "SUPPORTER")
-                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/admin/**").hasAnyRole("ADMIN", "OPERATIONS", "SUPPORTER")
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/org/ject/support/domain/member/Permission.java
+++ b/src/main/java/org/ject/support/domain/member/Permission.java
@@ -1,0 +1,33 @@
+package org.ject.support.domain.member;
+
+import lombok.Getter;
+
+@Getter
+public enum Permission {
+    APPLY_CREATE("지원서 생성"),
+    APPLY_READ("지원서 조회"),
+    APPLY_UPDATE("지원서 수정"),
+    APPLY_DELETE("지원서 삭제"),
+
+    APPLY_RESULT_FULL("지원 결과 처리 전체 관리"),
+
+    MEMBER_CREATE("구성원 생성"),
+    MEMBER_READ("구성원 조회"),
+    MEMBER_UPDATE("구성원 수정"),
+    MEMBER_DELETE("구성원 삭제"),
+
+    MAIL_TEMPLATE_CREATE("메일 템플릿 생성"),
+    MAIL_TEMPLATE_READ("메일 템플릿 조회"),
+    MAIL_TEMPLATE_UPDATE("메일 템플릿 수정"),
+    MAIL_TEMPLATE_DELETE("메일 템플릿 삭제"),
+
+    MAIL_SEND_FULL("메일 발송 전체 관리"),
+
+    ADMIN_ACCOUNT_FULL("관리자 계정 전체 관리");
+
+    private final String description;
+
+    Permission(final String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/org/ject/support/domain/member/Role.java
+++ b/src/main/java/org/ject/support/domain/member/Role.java
@@ -6,15 +6,21 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public enum Role {
-    ADMIN,        // 관리자
-    OPERATIONS,   // 운영팀
-    SUPPORTER,    // 서포터즈
-    SEMESTER,     // 동아리 원
-    APPLY,        // 지원자
-    VERIFICATION; // 임시
+    ADMIN(true),         // 관리자
+    OPERATIONS(true),    // 운영팀
+    SUPPORTER(true),     // 서포터즈
+    SEMESTER(false),     // 동아리 원
+    APPLY(false),        // 지원자
+    VERIFICATION(false); // 임시
+
+    private final boolean backoffice;
+
+    Role(boolean backoffice) {
+        this.backoffice = backoffice;
+    }
 
     public boolean isBackoffice() {
-        return this == ADMIN || this == OPERATIONS || this == SUPPORTER;
+        return backoffice;
     }
 
     public static Set<Role> backofficeRoles() {

--- a/src/main/java/org/ject/support/domain/member/Role.java
+++ b/src/main/java/org/ject/support/domain/member/Role.java
@@ -1,61 +1,25 @@
 package org.ject.support.domain.member;
 
-import lombok.Getter;
-
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-@Getter
 public enum Role {
-    ADMIN(adminPermissions()),           // 관리자
-    OPERATIONS(operationsPermissions()), // 운영팀
-    SUPPORTER(supporterPermissions()),   // 서포터즈
-    SEMESTER(noPermissions()),           // 동아리 원
-    APPLY(noPermissions()),              // 지원자
-    VERIFICATION(noPermissions());       // 임시
+    ADMIN,        // 관리자
+    OPERATIONS,   // 운영팀
+    SUPPORTER,    // 서포터즈
+    SEMESTER,     // 동아리 원
+    APPLY,        // 지원자
+    VERIFICATION; // 임시
 
-    private final Set<Permission> permissions;
-    public static final Set<Role> BACKOFFICE_ROLES = EnumSet.of(ADMIN, SUPPORTER, OPERATIONS);
-
-    Role(final Set<Permission> permissions) {
-        this.permissions = permissions;
+    public boolean isBackoffice() {
+        return this == ADMIN || this == OPERATIONS || this == SUPPORTER;
     }
 
-    private static Set<Permission> adminPermissions() {
-        return EnumSet.allOf(Permission.class);
-    }
-
-    private static Set<Permission> operationsPermissions() {
-        return EnumSet.of(
-                Permission.APPLY_CREATE,
-                Permission.APPLY_READ,
-                Permission.APPLY_UPDATE,
-                Permission.APPLY_DELETE,
-                Permission.APPLY_RESULT_FULL,
-                Permission.MEMBER_CREATE,
-                Permission.MEMBER_READ,
-                Permission.MEMBER_UPDATE,
-                Permission.MEMBER_DELETE,
-                Permission.MAIL_TEMPLATE_CREATE,
-                Permission.MAIL_TEMPLATE_READ,
-                Permission.MAIL_TEMPLATE_UPDATE,
-                Permission.MAIL_TEMPLATE_DELETE,
-                Permission.MAIL_SEND_FULL
-        );
-    }
-
-    private static Set<Permission> supporterPermissions() {
-        return EnumSet.of(
-                Permission.APPLY_READ,
-                Permission.MEMBER_READ,
-                Permission.MEMBER_UPDATE,
-                Permission.MAIL_TEMPLATE_CREATE,
-                Permission.MAIL_TEMPLATE_READ,
-                Permission.MAIL_TEMPLATE_UPDATE
-        );
-    }
-
-    private static Set<Permission> noPermissions() {
-        return EnumSet.noneOf(Permission.class);
+    public static Set<Role> backofficeRoles() {
+        return Arrays.stream(values())
+                .filter(Role::isBackoffice)
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(Role.class)));
     }
 }

--- a/src/main/java/org/ject/support/domain/member/Role.java
+++ b/src/main/java/org/ject/support/domain/member/Role.java
@@ -1,9 +1,61 @@
 package org.ject.support.domain.member;
 
+import lombok.Getter;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+@Getter
 public enum Role {
-    ADMIN,          // 관리자
-    SEMESTER,       // 동아리 원
-    APPLY,          // 지원자
-    VERIFICATION,   // 임시
-    SUPPORTER       // 서포터즈 토큰 발급용 (임시)
+    ADMIN(adminPermissions()),           // 관리자
+    OPERATIONS(operationsPermissions()), // 운영팀
+    SUPPORTER(supporterPermissions()),   // 서포터즈
+    SEMESTER(noPermissions()),           // 동아리 원
+    APPLY(noPermissions()),              // 지원자
+    VERIFICATION(noPermissions());       // 임시
+
+    private final Set<Permission> permissions;
+    public static final Set<Role> BACKOFFICE_ROLES = EnumSet.of(ADMIN, SUPPORTER, OPERATIONS);
+
+    Role(final Set<Permission> permissions) {
+        this.permissions = permissions;
+    }
+
+    private static Set<Permission> adminPermissions() {
+        return EnumSet.allOf(Permission.class);
+    }
+
+    private static Set<Permission> operationsPermissions() {
+        return EnumSet.of(
+                Permission.APPLY_CREATE,
+                Permission.APPLY_READ,
+                Permission.APPLY_UPDATE,
+                Permission.APPLY_DELETE,
+                Permission.APPLY_RESULT_FULL,
+                Permission.MEMBER_CREATE,
+                Permission.MEMBER_READ,
+                Permission.MEMBER_UPDATE,
+                Permission.MEMBER_DELETE,
+                Permission.MAIL_TEMPLATE_CREATE,
+                Permission.MAIL_TEMPLATE_READ,
+                Permission.MAIL_TEMPLATE_UPDATE,
+                Permission.MAIL_TEMPLATE_DELETE,
+                Permission.MAIL_SEND_FULL
+        );
+    }
+
+    private static Set<Permission> supporterPermissions() {
+        return EnumSet.of(
+                Permission.APPLY_READ,
+                Permission.MEMBER_READ,
+                Permission.MEMBER_UPDATE,
+                Permission.MAIL_TEMPLATE_CREATE,
+                Permission.MAIL_TEMPLATE_READ,
+                Permission.MAIL_TEMPLATE_UPDATE
+        );
+    }
+
+    private static Set<Permission> noPermissions() {
+        return EnumSet.noneOf(Permission.class);
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/RolePermissions.java
+++ b/src/main/java/org/ject/support/domain/member/RolePermissions.java
@@ -1,5 +1,6 @@
 package org.ject.support.domain.member;
 
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Map;
@@ -7,13 +8,15 @@ import java.util.Set;
 
 public final class RolePermissions {
 
+    private static final Set<Permission> NO_PERMISSIONS =
+            Collections.unmodifiableSet(EnumSet.noneOf(Permission.class));
     private static final Map<Role, Set<Permission>> ROLE_PERMISSIONS = createRolePermissions();
 
     private RolePermissions() {
     }
 
     public static Set<Permission> getPermissions(Role role) {
-        return ROLE_PERMISSIONS.getOrDefault(role, EnumSet.noneOf(Permission.class));
+        return ROLE_PERMISSIONS.getOrDefault(role, NO_PERMISSIONS);
     }
 
     public static Set<Role> getDefinedRoles() {
@@ -23,8 +26,9 @@ public final class RolePermissions {
     private static Map<Role, Set<Permission>> createRolePermissions() {
         Map<Role, Set<Permission>> rolePermissions = new EnumMap<>(Role.class);
 
-        rolePermissions.put(Role.ADMIN, EnumSet.allOf(Permission.class));
-        rolePermissions.put(Role.OPERATIONS, EnumSet.of(
+        rolePermissions.put(Role.ADMIN, unmodifiableEnumSet(EnumSet.allOf(Permission.class)));
+
+        rolePermissions.put(Role.OPERATIONS, unmodifiableEnumSet(EnumSet.of(
                 Permission.APPLY_CREATE,
                 Permission.APPLY_READ,
                 Permission.APPLY_UPDATE,
@@ -39,19 +43,25 @@ public final class RolePermissions {
                 Permission.MAIL_TEMPLATE_UPDATE,
                 Permission.MAIL_TEMPLATE_DELETE,
                 Permission.MAIL_SEND_FULL
-        ));
-        rolePermissions.put(Role.SUPPORTER, EnumSet.of(
+        )));
+
+        rolePermissions.put(Role.SUPPORTER, unmodifiableEnumSet(EnumSet.of(
                 Permission.APPLY_READ,
                 Permission.MEMBER_READ,
                 Permission.MEMBER_UPDATE,
                 Permission.MAIL_TEMPLATE_CREATE,
                 Permission.MAIL_TEMPLATE_READ,
                 Permission.MAIL_TEMPLATE_UPDATE
-        ));
-        rolePermissions.put(Role.SEMESTER, EnumSet.noneOf(Permission.class));
-        rolePermissions.put(Role.APPLY, EnumSet.noneOf(Permission.class));
-        rolePermissions.put(Role.VERIFICATION, EnumSet.noneOf(Permission.class));
+        )));
+
+        rolePermissions.put(Role.SEMESTER, NO_PERMISSIONS);
+        rolePermissions.put(Role.APPLY, NO_PERMISSIONS);
+        rolePermissions.put(Role.VERIFICATION, NO_PERMISSIONS);
 
         return rolePermissions;
+    }
+
+    private static Set<Permission> unmodifiableEnumSet(Set<Permission> permissions) {
+        return Collections.unmodifiableSet(permissions);
     }
 }

--- a/src/main/java/org/ject/support/domain/member/RolePermissions.java
+++ b/src/main/java/org/ject/support/domain/member/RolePermissions.java
@@ -1,0 +1,57 @@
+package org.ject.support.domain.member;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+public final class RolePermissions {
+
+    private static final Map<Role, Set<Permission>> ROLE_PERMISSIONS = createRolePermissions();
+
+    private RolePermissions() {
+    }
+
+    public static Set<Permission> getPermissions(Role role) {
+        return ROLE_PERMISSIONS.getOrDefault(role, EnumSet.noneOf(Permission.class));
+    }
+
+    public static Set<Role> getDefinedRoles() {
+        return EnumSet.copyOf(ROLE_PERMISSIONS.keySet());
+    }
+
+    private static Map<Role, Set<Permission>> createRolePermissions() {
+        Map<Role, Set<Permission>> rolePermissions = new EnumMap<>(Role.class);
+
+        rolePermissions.put(Role.ADMIN, EnumSet.allOf(Permission.class));
+        rolePermissions.put(Role.OPERATIONS, EnumSet.of(
+                Permission.APPLY_CREATE,
+                Permission.APPLY_READ,
+                Permission.APPLY_UPDATE,
+                Permission.APPLY_DELETE,
+                Permission.APPLY_RESULT_FULL,
+                Permission.MEMBER_CREATE,
+                Permission.MEMBER_READ,
+                Permission.MEMBER_UPDATE,
+                Permission.MEMBER_DELETE,
+                Permission.MAIL_TEMPLATE_CREATE,
+                Permission.MAIL_TEMPLATE_READ,
+                Permission.MAIL_TEMPLATE_UPDATE,
+                Permission.MAIL_TEMPLATE_DELETE,
+                Permission.MAIL_SEND_FULL
+        ));
+        rolePermissions.put(Role.SUPPORTER, EnumSet.of(
+                Permission.APPLY_READ,
+                Permission.MEMBER_READ,
+                Permission.MEMBER_UPDATE,
+                Permission.MAIL_TEMPLATE_CREATE,
+                Permission.MAIL_TEMPLATE_READ,
+                Permission.MAIL_TEMPLATE_UPDATE
+        ));
+        rolePermissions.put(Role.SEMESTER, EnumSet.noneOf(Permission.class));
+        rolePermissions.put(Role.APPLY, EnumSet.noneOf(Permission.class));
+        rolePermissions.put(Role.VERIFICATION, EnumSet.noneOf(Permission.class));
+
+        return rolePermissions;
+    }
+}

--- a/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
@@ -4,6 +4,7 @@ import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberQueryRepository {
@@ -11,6 +12,8 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberQue
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByEmailAndRole(String email, Role role);
+
+    Optional<Member> findByEmailAndRoleIn(String email, Collection<Role> roles);
 
     boolean existsByEmail(String email);
 }

--- a/src/test/java/org/ject/support/admin/auth/service/AdminAuthServiceTest.java
+++ b/src/test/java/org/ject/support/admin/auth/service/AdminAuthServiceTest.java
@@ -65,7 +65,7 @@ class AdminAuthServiceTest extends UnitTestSupport {
                 .build();
 
         given(redisTemplate.hasKey(blockKey)).willReturn(false);
-        given(adminMemberComponent.findMemberAdminByEmail(email)).willReturn(Optional.of(adminMember));
+        given(adminMemberComponent.findBackofficeMemberByEmail(email)).willReturn(Optional.of(adminMember));
         given(passwordEncoder.matches(password, adminMember.getPin())).willReturn(true);
         given(jwtTokenProvider.createAuthenticationByMember(adminMember)).willReturn(authentication);
 
@@ -94,7 +94,7 @@ class AdminAuthServiceTest extends UnitTestSupport {
                 .build();
 
         given(redisTemplate.hasKey(blockKey)).willReturn(false);
-        given(adminMemberComponent.findMemberAdminByEmail(email)).willReturn(Optional.of(operationsMember));
+        given(adminMemberComponent.findBackofficeMemberByEmail(email)).willReturn(Optional.of(operationsMember));
         given(passwordEncoder.matches(password, operationsMember.getPin())).willReturn(true);
         given(jwtTokenProvider.createAuthenticationByMember(operationsMember)).willReturn(authentication);
 
@@ -113,7 +113,7 @@ class AdminAuthServiceTest extends UnitTestSupport {
         String email = "not-found@test.com";
         String password = "Password123!";
         String failCountKey = "admin-login-password-fail-count:" + email;
-        given(adminMemberComponent.findMemberAdminByEmail(email)).willReturn(Optional.empty());
+        given(adminMemberComponent.findBackofficeMemberByEmail(email)).willReturn(Optional.empty());
         given(redisTemplate.hasKey("admin-login-password-block:" + email)).willReturn(false);
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.increment(failCountKey)).willReturn(1L);
@@ -139,7 +139,7 @@ class AdminAuthServiceTest extends UnitTestSupport {
                 .build();
         String failCountKey = "admin-login-password-fail-count:" + email;
 
-        given(adminMemberComponent.findMemberAdminByEmail(email)).willReturn(Optional.of(adminMember));
+        given(adminMemberComponent.findBackofficeMemberByEmail(email)).willReturn(Optional.of(adminMember));
         given(redisTemplate.hasKey("admin-login-password-block:" + email)).willReturn(false);
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.increment(failCountKey)).willReturn(1L);
@@ -165,7 +165,7 @@ class AdminAuthServiceTest extends UnitTestSupport {
                 .role(Role.ADMIN)
                 .build();
 
-        given(adminMemberComponent.findMemberAdminByEmail(email)).willReturn(Optional.of(adminMember));
+        given(adminMemberComponent.findBackofficeMemberByEmail(email)).willReturn(Optional.of(adminMember));
         given(redisTemplate.hasKey("admin-login-password-block:" + email)).willReturn(false);
         given(passwordEncoder.matches(password, adminMember.getPin())).willReturn(true);
 
@@ -197,7 +197,7 @@ class AdminAuthServiceTest extends UnitTestSupport {
         String password = "Password123!";
         String failCountKey = "admin-login-password-fail-count:" + email;
         String blockKey = "admin-login-password-block:" + email;
-        given(adminMemberComponent.findMemberAdminByEmail(email)).willReturn(Optional.empty());
+        given(adminMemberComponent.findBackofficeMemberByEmail(email)).willReturn(Optional.empty());
         given(redisTemplate.hasKey(blockKey)).willReturn(false);
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.increment(failCountKey)).willReturn(5L);

--- a/src/test/java/org/ject/support/admin/auth/service/AdminAuthServiceTest.java
+++ b/src/test/java/org/ject/support/admin/auth/service/AdminAuthServiceTest.java
@@ -79,6 +79,35 @@ class AdminAuthServiceTest extends UnitTestSupport {
     }
 
     @Test
+    void 운영팀_로그인_성공_시_Authentication_객체_반환() {
+        // given
+        String email = "operations@ject.org";
+        String password = "Password123";
+        String failCountKey = "admin-login-password-fail-count:" + email;
+        String blockKey = "admin-login-password-block:" + email;
+        Member operationsMember = Member.builder()
+                .id(2L)
+                .email(email)
+                .pin("$2a$10$encodedPin")
+                .status(MemberStatus.ACTIVE)
+                .role(Role.OPERATIONS)
+                .build();
+
+        given(redisTemplate.hasKey(blockKey)).willReturn(false);
+        given(adminMemberComponent.findMemberAdminByEmail(email)).willReturn(Optional.of(operationsMember));
+        given(passwordEncoder.matches(password, operationsMember.getPin())).willReturn(true);
+        given(jwtTokenProvider.createAuthenticationByMember(operationsMember)).willReturn(authentication);
+
+        // when
+        adminAuthService.authenticateAdmin(email, password);
+
+        // then
+        verify(redisTemplate).delete(failCountKey);
+        verify(redisTemplate).delete(blockKey);
+        verify(jwtTokenProvider).createAuthenticationByMember(operationsMember);
+    }
+
+    @Test
     void 관리자_로그인_시_이메일이_존재하지_않으면_INVALID_ADMIN_CREDENTIALS_예외_발생() {
         // given
         String email = "not-found@test.com";

--- a/src/test/java/org/ject/support/admin/member/component/AdminMemberComponentTest.java
+++ b/src/test/java/org/ject/support/admin/member/component/AdminMemberComponentTest.java
@@ -34,7 +34,7 @@ class AdminMemberComponentTest extends UnitTestSupport {
         given(memberRepository.findByEmailAndRoleIn(notFoundEmail, Role.BACKOFFICE_ROLES)).willReturn(Optional.empty());
 
         // when, then
-        assertThatThrownBy(() -> adminMemberComponent.getMemberAdminByEmail(notFoundEmail))
+        assertThatThrownBy(() -> adminMemberComponent.getRequiredBackofficeMemberByEmail(notFoundEmail))
                 .isInstanceOf(AdminException.class)
                 .extracting(e -> ((AdminException) e).getErrorCode())
                 .isEqualTo(AdminErrorCode.NOT_FOUND_ADMIN);
@@ -54,7 +54,7 @@ class AdminMemberComponentTest extends UnitTestSupport {
         given(memberRepository.findByEmailAndRoleIn(email, Role.BACKOFFICE_ROLES)).willReturn(Optional.of(foundMember));
 
         // when
-        Member result = adminMemberComponent.getMemberAdminByEmail(email);
+        Member result = adminMemberComponent.getRequiredBackofficeMemberByEmail(email);
 
         // then
         verify(memberRepository).findByEmailAndRoleIn(email, Role.BACKOFFICE_ROLES);

--- a/src/test/java/org/ject/support/admin/member/component/AdminMemberComponentTest.java
+++ b/src/test/java/org/ject/support/admin/member/component/AdminMemberComponentTest.java
@@ -30,9 +30,8 @@ class AdminMemberComponentTest extends UnitTestSupport {
     void 존재하지않는_이메일로_관리자계정의_정보를_조회할_경우_NOT_FOUND_ADMIN_예외가_발생() {
         // given
         String notFoundEmail = "not_found_admin@test.com";
-        Role adminRole = Role.ADMIN;
 
-        given(memberRepository.findByEmailAndRole(notFoundEmail, adminRole)).willReturn(Optional.empty());
+        given(memberRepository.findByEmailAndRoleIn(notFoundEmail, Role.BACKOFFICE_ROLES)).willReturn(Optional.empty());
 
         // when, then
         assertThatThrownBy(() -> adminMemberComponent.getMemberAdminByEmail(notFoundEmail))
@@ -45,23 +44,22 @@ class AdminMemberComponentTest extends UnitTestSupport {
     void 이메일로_관리자계정의_정보를_조회할_경우_Member_엔티티를_반환() {
         // given
         String email = "admin@test.com";
-        Role adminRole = Role.ADMIN;
         Member foundMember = Member.builder()
                 .id(1L)
                 .email(email)
                 .status(MemberStatus.ACTIVE)
-                .role(adminRole)
+                .role(Role.ADMIN)
                 .build();
 
-        given(memberRepository.findByEmailAndRole(email, adminRole)).willReturn(Optional.of(foundMember));
+        given(memberRepository.findByEmailAndRoleIn(email, Role.BACKOFFICE_ROLES)).willReturn(Optional.of(foundMember));
 
         // when
         Member result = adminMemberComponent.getMemberAdminByEmail(email);
 
         // then
-        verify(memberRepository).findByEmailAndRole(email, adminRole);
+        verify(memberRepository).findByEmailAndRoleIn(email, Role.BACKOFFICE_ROLES);
         assertEquals(email, result.getEmail());
-        assertEquals(adminRole, result.getRole());
+        assertEquals(Role.ADMIN, result.getRole());
         assertEquals(MemberStatus.ACTIVE, result.getStatus());
     }
 

--- a/src/test/java/org/ject/support/admin/member/component/AdminMemberComponentTest.java
+++ b/src/test/java/org/ject/support/admin/member/component/AdminMemberComponentTest.java
@@ -1,8 +1,8 @@
 package org.ject.support.admin.member.component;
 
-import org.ject.support.base.UnitTestSupport;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
+import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,6 +20,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 class AdminMemberComponentTest extends UnitTestSupport {
+
+    private static final Set<Role> BACKOFFICE_ROLES = Role.backofficeRoles();
 
     @InjectMocks
     AdminMemberComponent adminMemberComponent;
@@ -31,7 +34,7 @@ class AdminMemberComponentTest extends UnitTestSupport {
         // given
         String notFoundEmail = "not_found_admin@test.com";
 
-        given(memberRepository.findByEmailAndRoleIn(notFoundEmail, Role.BACKOFFICE_ROLES)).willReturn(Optional.empty());
+        given(memberRepository.findByEmailAndRoleIn(notFoundEmail, BACKOFFICE_ROLES)).willReturn(Optional.empty());
 
         // when, then
         assertThatThrownBy(() -> adminMemberComponent.getRequiredBackofficeMemberByEmail(notFoundEmail))
@@ -51,13 +54,13 @@ class AdminMemberComponentTest extends UnitTestSupport {
                 .role(Role.ADMIN)
                 .build();
 
-        given(memberRepository.findByEmailAndRoleIn(email, Role.BACKOFFICE_ROLES)).willReturn(Optional.of(foundMember));
+        given(memberRepository.findByEmailAndRoleIn(email, BACKOFFICE_ROLES)).willReturn(Optional.of(foundMember));
 
         // when
         Member result = adminMemberComponent.getRequiredBackofficeMemberByEmail(email);
 
         // then
-        verify(memberRepository).findByEmailAndRoleIn(email, Role.BACKOFFICE_ROLES);
+        verify(memberRepository).findByEmailAndRoleIn(email, BACKOFFICE_ROLES);
         assertEquals(email, result.getEmail());
         assertEquals(Role.ADMIN, result.getRole());
         assertEquals(MemberStatus.ACTIVE, result.getStatus());

--- a/src/test/java/org/ject/support/common/security/CustomUserDetailsTest.java
+++ b/src/test/java/org/ject/support/common/security/CustomUserDetailsTest.java
@@ -3,6 +3,7 @@ package org.ject.support.common.security;
 import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Permission;
 import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.RolePermissions;
 import org.ject.support.domain.member.entity.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,8 +20,7 @@ class CustomUserDetailsTest {
     private final Long TEST_MEMBER_ID = 1L;
 
     @Test
-    @DisplayName("Member 객체로 CustomUserDetails 생성 시 권한에 ROLE_ 접두사가 추가되는지 확인")
-    void getAuthorities_FromMember_ShouldAddRolePrefix() {
+    void Member_객체로_CustomUserDetails_생성_시_권한에_ROLE_접두사가_추가되는지_확인() {
         // given
         Member member = Member.builder()
                 .id(TEST_MEMBER_ID)
@@ -44,8 +44,7 @@ class CustomUserDetailsTest {
     }
 
     @Test
-    @DisplayName("파라미터로 CustomUserDetails 생성 시 권한에 ROLE_ 접두사가 추가되는지 확인")
-    void getAuthorities_FromParameters_ShouldAddRolePrefix() {
+    void 파라미터로_CustomUserDetails_생성_시_권한에_ROLE_접두사가_추가되는지_확인() {
         // given
         Role role = Role.SEMESTER;
 
@@ -62,8 +61,7 @@ class CustomUserDetailsTest {
     }
 
     @Test
-    @DisplayName("ADMIN 역할로 CustomUserDetails 생성 시 모든 Permission 이 authority 에 포함되는지 확인")
-    void getAuthorities_AdminRole_ShouldContainAllPermissions() {
+    void ADMIN_역할로_CustomUserDetails_생성_시_모든_Permission_이_authority_에_포함되는지_확인() {
         // given
         Role role = Role.ADMIN;
 
@@ -78,15 +76,14 @@ class CustomUserDetailsTest {
         assertThat(authorities).isNotEmpty();
         assertThat(authorityNames.get(0)).isEqualTo("ROLE_ADMIN");
         assertThat(authorityNames).containsAll(
-                Role.ADMIN.getPermissions().stream()
+                RolePermissions.getPermissions(Role.ADMIN).stream()
                         .map(Permission::name)
                         .toList()
         );
     }
 
     @Test
-    @DisplayName("SUPPORTER 역할로 CustomUserDetails 생성 시 role 과 permission authority 가 함께 반환되는지 확인")
-    void getAuthorities_SupporterRole_ShouldContainRoleAndPermissions() {
+    void SUPPORTER_역할로_CustomUserDetails_생성_시_role_과_permission_authority_가_함께_반환되는지_확인() {
         // given
         Role role = Role.SUPPORTER;
 

--- a/src/test/java/org/ject/support/common/security/CustomUserDetailsTest.java
+++ b/src/test/java/org/ject/support/common/security/CustomUserDetailsTest.java
@@ -1,6 +1,7 @@
 package org.ject.support.common.security;
 
 import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Permission;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.junit.jupiter.api.DisplayName;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.security.core.GrantedAuthority;
 
 import java.util.Collection;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,11 +34,13 @@ class CustomUserDetailsTest {
         // when
         CustomUserDetails userDetails = new CustomUserDetails(member);
         Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
+        List<String> authorityNames = authorities.stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
 
         // then
         assertThat(authorities).isNotEmpty();
-        assertThat(authorities).hasSize(1);
-        assertThat(authorities.iterator().next().getAuthority()).isEqualTo("ROLE_APPLY");
+        assertThat(authorityNames).containsExactly("ROLE_APPLY");
     }
 
     @Test
@@ -48,26 +52,59 @@ class CustomUserDetailsTest {
         // when
         CustomUserDetails userDetails = new CustomUserDetails(TEST_EMAIL, TEST_MEMBER_ID, role);
         Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
+        List<String> authorityNames = authorities.stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
 
         // then
         assertThat(authorities).isNotEmpty();
-        assertThat(authorities).hasSize(1);
-        assertThat(authorities.iterator().next().getAuthority()).isEqualTo("ROLE_SEMESTER");
+        assertThat(authorityNames).containsExactly("ROLE_SEMESTER");
     }
 
     @Test
-    @DisplayName("ADMIN 역할로 CustomUserDetails 생성 시 권한에 ROLE_ 접두사가 추가되는지 확인")
-    void getAuthorities_AdminRole_ShouldAddRolePrefix() {
+    @DisplayName("ADMIN 역할로 CustomUserDetails 생성 시 모든 Permission 이 authority 에 포함되는지 확인")
+    void getAuthorities_AdminRole_ShouldContainAllPermissions() {
         // given
         Role role = Role.ADMIN;
 
         // when
         CustomUserDetails userDetails = new CustomUserDetails(TEST_EMAIL, TEST_MEMBER_ID, role);
         Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
+        List<String> authorityNames = authorities.stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
 
         // then
         assertThat(authorities).isNotEmpty();
-        assertThat(authorities).hasSize(1);
-        assertThat(authorities.iterator().next().getAuthority()).isEqualTo("ROLE_ADMIN");
+        assertThat(authorityNames.get(0)).isEqualTo("ROLE_ADMIN");
+        assertThat(authorityNames).containsAll(
+                Role.ADMIN.getPermissions().stream()
+                        .map(Permission::name)
+                        .toList()
+        );
+    }
+
+    @Test
+    @DisplayName("SUPPORTER 역할로 CustomUserDetails 생성 시 role 과 permission authority 가 함께 반환되는지 확인")
+    void getAuthorities_SupporterRole_ShouldContainRoleAndPermissions() {
+        // given
+        Role role = Role.SUPPORTER;
+
+        // when
+        CustomUserDetails userDetails = new CustomUserDetails(TEST_EMAIL, TEST_MEMBER_ID, role);
+        List<String> authorityNames = userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+
+        // then
+        assertThat(authorityNames.get(0)).isEqualTo("ROLE_SUPPORTER");
+        assertThat(authorityNames).contains(
+                Permission.APPLY_READ.name(),
+                Permission.MEMBER_READ.name(),
+                Permission.MEMBER_UPDATE.name(),
+                Permission.MAIL_TEMPLATE_CREATE.name(),
+                Permission.MAIL_TEMPLATE_READ.name(),
+                Permission.MAIL_TEMPLATE_UPDATE.name()
+        );
     }
 }

--- a/src/test/java/org/ject/support/common/security/config/SecurityConfigTest.java
+++ b/src/test/java/org/ject/support/common/security/config/SecurityConfigTest.java
@@ -36,10 +36,12 @@ class SecurityConfigTest extends ApplicationPeriodTest {
         SimpleGrantedAuthority tempAuthority = new SimpleGrantedAuthority("ROLE_APPLY");
         SimpleGrantedAuthority userAuthority = new SimpleGrantedAuthority("ROLE_SEMESTER");
         SimpleGrantedAuthority adminAuthority = new SimpleGrantedAuthority("ROLE_ADMIN");
+        SimpleGrantedAuthority operationsAuthority = new SimpleGrantedAuthority("ROLE_OPERATIONS");
+        SimpleGrantedAuthority supporterAuthority = new SimpleGrantedAuthority("ROLE_SUPPORTER");
         SimpleGrantedAuthority verificationAuthority = new SimpleGrantedAuthority("ROLE_VERIFICATION");
 
         // when & then
-        // ADMIN > SEMESTER > APPLY 계층 구조 확인
+        // ADMIN > SEMESTER > APPLY > VERIFICATION 계층 구조 확인
         List<String> adminAuthorities = roleHierarchy.getReachableGrantedAuthorities(
                 java.util.Collections.singleton(adminAuthority))
                 .stream()
@@ -47,9 +49,38 @@ class SecurityConfigTest extends ApplicationPeriodTest {
                 .toList();
         
         assertThat(adminAuthorities).contains(
-                adminAuthority.getAuthority(), 
-                userAuthority.getAuthority(), 
-                tempAuthority.getAuthority());
+                adminAuthority.getAuthority(),
+                userAuthority.getAuthority(),
+                tempAuthority.getAuthority(),
+                verificationAuthority.getAuthority());
+
+        // OPERATIONS > SEMESTER > APPLY > VERIFICATION 계층 구조 확인
+        List<String> operationsAuthorities = roleHierarchy.getReachableGrantedAuthorities(
+                java.util.Collections.singleton(operationsAuthority))
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+
+        assertThat(operationsAuthorities).contains(
+                operationsAuthority.getAuthority(),
+                userAuthority.getAuthority(),
+                tempAuthority.getAuthority(),
+                verificationAuthority.getAuthority()
+        );
+
+        // SUPPORTER > SEMESTER > APPLY > VERIFICATION 계층 구조 확인
+        List<String> supporterAuthorities = roleHierarchy.getReachableGrantedAuthorities(
+                java.util.Collections.singleton(supporterAuthority))
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+
+        assertThat(supporterAuthorities).contains(
+                supporterAuthority.getAuthority(),
+                userAuthority.getAuthority(),
+                tempAuthority.getAuthority(),
+                verificationAuthority.getAuthority()
+        );
 
         // SEMESTER > APPLY 계층 구조 확인
         List<String> userAuthorities = roleHierarchy.getReachableGrantedAuthorities(
@@ -59,8 +90,8 @@ class SecurityConfigTest extends ApplicationPeriodTest {
                 .toList();
                 
         assertThat(userAuthorities)
-                .contains(userAuthority.getAuthority(), tempAuthority.getAuthority())
-                .doesNotContain(adminAuthority.getAuthority());
+                .contains(userAuthority.getAuthority(), tempAuthority.getAuthority(), verificationAuthority.getAuthority())
+                .doesNotContain(adminAuthority.getAuthority(), operationsAuthority.getAuthority(), supporterAuthority.getAuthority());
 
         // APPLY > VERIFICATION 계층 구조 확인
         List<String> tempAuthorities = roleHierarchy.getReachableGrantedAuthorities(
@@ -71,7 +102,12 @@ class SecurityConfigTest extends ApplicationPeriodTest {
                 
         assertThat(tempAuthorities)
                 .contains(tempAuthority.getAuthority(), verificationAuthority.getAuthority())
-                .doesNotContain(adminAuthority.getAuthority(), userAuthority.getAuthority());
+                .doesNotContain(
+                        adminAuthority.getAuthority(),
+                        operationsAuthority.getAuthority(),
+                        supporterAuthority.getAuthority(),
+                        userAuthority.getAuthority()
+                );
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/member/RolePolicyConsistencyTest.java
+++ b/src/test/java/org/ject/support/domain/member/RolePolicyConsistencyTest.java
@@ -9,6 +9,7 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RolePolicyConsistencyTest {
 
@@ -18,5 +19,11 @@ class RolePolicyConsistencyTest {
 
         assertThat(RolePermissions.getDefinedRoles()).isEqualTo(allRoles);
         assertThat(RoleHierarchySpec.getDefinedRoles()).isEqualTo(allRoles);
+    }
+
+    @Test
+    void RolePermissions_에서_반환한_권한_목록은_외부에서_수정할_수_없다() {
+        assertThatThrownBy(() -> RolePermissions.getPermissions(Role.ADMIN).clear())
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 }

--- a/src/test/java/org/ject/support/domain/member/RolePolicyConsistencyTest.java
+++ b/src/test/java/org/ject/support/domain/member/RolePolicyConsistencyTest.java
@@ -1,0 +1,22 @@
+package org.ject.support.domain.member;
+
+import org.ject.support.common.security.config.RoleHierarchySpec;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RolePolicyConsistencyTest {
+
+    @Test
+    void 모든_Role_은_권한_정책과_계층_정책에_누락_없이_반영되어야_한다() {
+        Set<Role> allRoles = EnumSet.copyOf(Arrays.asList(Role.values()));
+
+        assertThat(RolePermissions.getDefinedRoles()).isEqualTo(allRoles);
+        assertThat(RoleHierarchySpec.getDefinedRoles()).isEqualTo(allRoles);
+    }
+}

--- a/src/test/java/org/ject/support/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberRepositoryTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -46,6 +47,42 @@ class MemberRepositoryTest {
 
         // when
         Optional<Member> found = memberRepository.findByEmailAndRole(findEmail, findRole);
+
+        // then
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    void 이메일과_역할목록으로_회원을_조회시_목록에_포함된_역할이면_회원을_반환한다() {
+        // given
+        String email = "backoffice@example.com";
+        Member member = createMember("백오피스", "01087654321", email, JobFamily.FE, Role.OPERATIONS);
+        memberRepository.save(member);
+
+        // when
+        Optional<Member> found = memberRepository.findByEmailAndRoleIn(
+                email,
+                List.of(Role.ADMIN, Role.OPERATIONS)
+        );
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getEmail()).isEqualTo(email);
+        assertThat(found.get().getRole()).isEqualTo(Role.OPERATIONS);
+    }
+
+    @Test
+    void 이메일과_역할목록으로_회원을_조회시_목록에_없는_역할이면_빈_Optional을_반환한다() {
+        // given
+        String email = "semester@example.com";
+        Member member = createMember("학회원", "01099998888", email, JobFamily.BE, Role.SEMESTER);
+        memberRepository.save(member);
+
+        // when
+        Optional<Member> found = memberRepository.findByEmailAndRoleIn(
+                email,
+                List.of(Role.ADMIN, Role.OPERATIONS, Role.SUPPORTER)
+        );
 
         // then
         assertThat(found).isEmpty();


### PR DESCRIPTION
## #️⃣연관된 이슈

close #513 

## 📝 작업 내용
### 1. Role 추가
 - OPERATIONS, SUPPORTER
### 2. 권한 체계 추가
 - Permission enum 작성
 - Role별 권한 매핑 추가
 - CustomUserDetail 에서 role authority와 permission authority를 함께 주도록 변경
### 3. 백 오피스 로그인 수정
 - AS-IS : ADMIN Role만 로그인 할수 있었음
 - TO-BE : ADMIN, OPERATIONS, SUPPORTER 모두 로그인 시도 가능
### 4. 테스트 보강


## 🙏 리뷰 요구사항 (선택)
 - 권한 구조를 각 API에 필요한 permission을 PreAuthorize("hasAuthority(...)")로 명시하는 방향으로 가져가려 합니다.
  - 백 오피스 접근은 기본적으로 role로 1차 제한하고, 실제 API 권한은 authority(permission) 기준으로 세분화하는 구조를 생각하고 있습니다.
  - 이 방향이 현재 프로젝트 구조에서 적절한지, 더 나은 패턴이나 주의할 점이 있는지 중심으로 리뷰 부탁드립니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 운영팀(OPERATIONS) 역할 추가 및 백오피스 역할 그룹화
  * 권한(Permission) 열거체와 역할별 권한 매핑 도입으로 세분화된 권한 관리 제공

* **보안 개선**
  * 역할 계층 표현식 도입으로 권한 상속 명시화
  * 인증 시 역할 기반 권한(권한명들)을 권한 집합에 자동 포함

* **테스트**
  * 인증·권한·역할 계층 관련 단위 테스트 추가 및 기존 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->