### PR TITLE
refactor(apply): 지원서 제출 동시성 제어를 비관적 락에서 낙관적 락으로 전환

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/domain/Apply.java
+++ b/src/main/java/org/ject/support/domain/apply/domain/Apply.java
@@ -29,7 +29,7 @@ import org.ject.support.domain.recruit.domain.Recruit;
 @Entity
 @Getter
 @Builder
-@SQLDelete(sql = "UPDATE apply SET is_deleted = true WHERE id = ? AND version = ?")
+@SQLDelete(sql = "UPDATE apply SET is_deleted = true, version = version + 1 WHERE id = ? AND version = ?")
 @SQLRestriction("is_deleted = false")
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/ject/support/domain/apply/domain/Apply.java
+++ b/src/main/java/org/ject/support/domain/apply/domain/Apply.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,7 +29,7 @@ import org.ject.support.domain.recruit.domain.Recruit;
 @Entity
 @Getter
 @Builder
-@SQLDelete(sql = "UPDATE apply SET is_deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE apply SET is_deleted = true WHERE id = ? AND version = ?")
 @SQLRestriction("is_deleted = false")
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -60,6 +61,9 @@ public class Apply extends BaseTimeEntity {
     @Column(name = "is_deleted", nullable = false)
     @Builder.Default
     private Boolean isDeleted = false;
+
+    @Version
+    private Long version;
 
     public static Apply createApply(Member member, Recruit recruit) {
         return Apply.builder()

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -6,11 +6,9 @@ import org.ject.support.domain.recruit.domain.Recruit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.repository.query.Param;
 
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
@@ -22,10 +20,6 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
     @Query("select a from Apply a join a.recruit r where a.member.id = :memberId and r.startDate <= :now and r.endDate >= :now")
     Optional<Apply> findByMemberIdInActiveRecruit(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select a from Apply a join a.recruit r where a.member.id = :memberId and r.startDate <= :now and r.endDate >= :now")
-    Optional<Apply> findByMemberIdInActiveRecruitForUpdate(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
 
     @Query("select a from Apply a join a.recruit r where a.member.id = :memberId and r.id = :recruitId and r.startDate <= :now and r.endDate >= :now")
     Optional<Apply> findByMemberIdAndRecruitIdInActiveRecruit(@Param("memberId") Long memberId,

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -29,6 +29,7 @@ import org.ject.support.domain.recruit.exception.RecruitErrorCode;
 import org.ject.support.domain.recruit.exception.RecruitException;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -142,31 +143,36 @@ public class ApplyService implements ApplyUsecase {
                                   JobFamily jobFamily,
                                   Map<String, String> answers,
                                   List<ApplyPortfolioDto> portfolios) {
-        // 1. jobFamily를 통해 현재 기수 지원양식 id 조회
-        Recruit recruit = getPeriodRecruit(jobFamily);
+        try {
+            // 1. jobFamily를 통해 현재 기수 지원양식 id 조회
+            Recruit recruit = getPeriodRecruit(jobFamily);
 
-        // 2. 지원양식과 answers의 key를 비교해 올바른 질문 양식인지 점검
-        validateQuestions(answers, recruit);
+            // 2. 지원양식과 answers의 key를 비교해 올바른 질문 양식인지 점검
+            validateQuestions(answers, recruit);
 
-        // 3. 지원 정보 조회
-        Apply apply = applyRepository.findByMemberIdInActiveRecruitForUpdate(memberId, LocalDateTime.now())
-                .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
+            // 3. 지원 정보 조회 (낙관적 락 - @Version 기반 동시성 제어)
+            Apply apply = applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
+                    .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
 
-        String content = map2JsonSerializer.serializeAsString(answers);
-        List<Portfolio> newPortfolios = getNewPortfolios(portfolios);
+            String content = map2JsonSerializer.serializeAsString(answers);
+            List<Portfolio> newPortfolios = getNewPortfolios(portfolios);
 
-        // 4. ApplicationForm 준비
-        ApplicationForm applicationForm;
-        if (apply.isTempSaved()) {
-            applicationForm = apply.getApplicationForm();
-            applicationForm.updateContentAndPortfolios(content, newPortfolios);
-        } else {
-            applicationForm = createApplicationForm(apply, content, newPortfolios);
-            applicationFormRepository.save(applicationForm);
+            // 4. ApplicationForm 준비
+            ApplicationForm applicationForm;
+            if (apply.isTempSaved()) {
+                applicationForm = apply.getApplicationForm();
+                applicationForm.updateContentAndPortfolios(content, newPortfolios);
+            } else {
+                applicationForm = createApplicationForm(apply, content, newPortfolios);
+                applicationFormRepository.save(applicationForm);
+            }
+
+            // 5. Apply 엔티티에 제출 위임 (검증 및 상태 변경 포함)
+            apply.submit(applicationForm);
+        } catch (ObjectOptimisticLockingFailureException e) {
+            log.warn("지원서 제출 중 낙관적 락 충돌 발생. memberId: {}", memberId);
+            throw new ApplyException(ALREADY_SUBMITTED);
         }
-
-        // 5. Apply 엔티티에 제출 위임 (검증 및 상태 변경 포함)
-        apply.submit(applicationForm);
     }
 
     @Override

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -169,6 +169,9 @@ public class ApplyService implements ApplyUsecase {
 
             // 5. Apply 엔티티에 제출 위임 (검증 및 상태 변경 포함)
             apply.submit(applicationForm);
+
+            // 명시적 flush를 통해 낙관적 락 충돌을 메서드 내부에서 감지하고 catch 블록으로 전달합니다.
+            applyRepository.flush();
         } catch (ObjectOptimisticLockingFailureException e) {
             log.warn("지원서 제출 중 낙관적 락 충돌 발생. memberId: {}", memberId);
             throw new ApplyException(ALREADY_SUBMITTED);

--- a/src/main/resources/db/migration/V25__add_version_column_to_apply.sql
+++ b/src/main/resources/db/migration/V25__add_version_column_to_apply.sql
@@ -1,0 +1,2 @@
+-- Apply 엔티티에 낙관적 락(Optimistic Locking)을 위한 version 컬럼 추가
+ALTER TABLE apply ADD COLUMN version BIGINT NOT NULL DEFAULT 0;

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -103,7 +103,7 @@ class ApplyServiceTest extends UnitTestSupport {
         Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
 
         when(recruitRepository.findActiveRecruitByJobFamily(any(), any())).thenReturn(Optional.of(recruit));
-        when(applyRepository.findByMemberIdInActiveRecruitForUpdate(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
         // when
@@ -134,7 +134,7 @@ class ApplyServiceTest extends UnitTestSupport {
         Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
 
         when(recruitRepository.findActiveRecruitByJobFamily(any(), any())).thenReturn(Optional.of(recruit));
-        when(applyRepository.findByMemberIdInActiveRecruitForUpdate(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
         // expected
@@ -161,7 +161,7 @@ class ApplyServiceTest extends UnitTestSupport {
         );
 
         when(recruitRepository.findActiveRecruitByJobFamily(any(), any())).thenReturn(Optional.of(recruit));
-        when(applyRepository.findByMemberIdInActiveRecruitForUpdate(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
         // when


### PR DESCRIPTION
## 📝 작업 내용

### 배경
지원서 제출(`submitApplication`) 시 동시 중복 제출을 방지하기 위해 `PESSIMISTIC_WRITE` 락을 사용하고 있었습니다.
그러나 동일 사용자가 동시에 지원서를 제출하는 경우는 극히 드물어 비관적 락보다 낙관적 락이 더 적절한 조치였습니다.

| 파일 | 변경 내용 |
|---|---|
| `Apply.java` | `@Version` 필드 추가, `@SQLDelete`에 `AND version = ?` 조건 추가 |
| `ApplyRepository.java` | `findByMemberIdInActiveRecruitForUpdate()` 메서드 및 `@Lock` 관련 import 제거 |
| `ApplyService.java` | `submitApplication()`에서 일반 조회로 변경 + `ObjectOptimisticLockingFailureException` → `ALREADY_SUBMITTED` 예외 변환 |
| `ApplyServiceTest.java` | 3개 테스트의 mock 호출을 `findByMemberIdInActiveRecruit`로 변경 |
| `V25__add_version_column_to_apply.sql` | `apply` 테이블에 `version BIGINT NOT NULL DEFAULT 0` 컬럼 추가 |

- Hibernate가 UPDATE 시 자동으로 `WHERE version = ?`을 추가하고 version을 증가시킴
- 동시에 같은 row를 수정하면 한쪽이 `ObjectOptimisticLockingFailureException`을 받음
- 이를 catch하여 `ALREADY_SUBMITTED` (409 Conflict) 응답으로 변환

- **DB 부하 감소**: `SELECT ... FOR UPDATE` row-level lock 제거
- **데드락 위험 제거**: 비관적 락의 잠재적 데드락 가능성 해소
- **커넥션 점유 시간 단축**: 커밋 시점에만 검증하므로 커넥션 빠르게 해제

## 🙏 리뷰 요구사항 (선택)

1. `@SQLDelete`에 `AND version = ?`을 추가한 부분이 soft delete와 충돌하지 않는지 확인 부탁합니다.
2. `ObjectOptimisticLockingFailureException`을 `ALREADY_SUBMITTED`로 매핑하는 것이 사용자 경험상 적절한지 의견 주시면 감사하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 동시성 제어를 비관적에서 낙관적 잠금 방식으로 전환해 락 경합 완화
  * 비관적 잠금 관련 의존 제거
* **Bug Fixes**
  * 낙관적 잠금 충돌 발생 시 중복 제출로 처리하도록 예외를 잡아 명확히 응답
* **Chores**
  * 낙관적 잠금을 위한 DB 스키마 마이그레이션 적용
* **Tests**
  * 관련 테스트의 목 대상 및 흐름 수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->