### PR TITLE
feat:백오피스의 관리자 계정 추가하기 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
+++ b/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
@@ -1,0 +1,31 @@
+package org.ject.support.admin.account.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
+import org.ject.support.admin.account.service.AdminAccountService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/accounts")
+@Tag(name = "Admin Account", description = "관리자 계정 관리 API")
+public class AdminAccountController {
+
+    private final AdminAccountService adminAccountService;
+
+    @PostMapping
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    @Operation(
+            summary = "관리자 계정 생성",
+            description = "관리자 계정 유형의 계정을 생성합니다.")
+    public void createAccount(@RequestBody @Valid final AdminAccountCreateRequest request) {
+        adminAccountService.createAccount(request);
+    }
+}

--- a/src/main/java/org/ject/support/admin/account/dto/AdminAccountCreateRequest.java
+++ b/src/main/java/org/ject/support/admin/account/dto/AdminAccountCreateRequest.java
@@ -1,0 +1,54 @@
+package org.ject.support.admin.account.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
+
+@Schema(description = "관리자 계정 생성 요청")
+public record AdminAccountCreateRequest(
+        @Schema(description = "관리자 계정 이메일", example = "admin@ject.kr", maxLength = 30)
+        @NotBlank
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Size(max = 30, message = "이메일 길이는 최대 30자리 까지 가능합니다.")
+        String email,
+
+        @Schema(description = "관리자 계정 비밀번호", example = "password123", minLength = 8, maxLength = 64)
+        @NotBlank
+        @Size(min = 8, max = 64)
+        String password,
+
+        @Schema(description = "관리자 이름", example = "김젝트", maxLength = 20, nullable = true)
+        @Size(max = 20, message = "이름 길이는 최대 20자리 까지 가능합니다.")
+        String name,
+
+        @Schema(
+                description = "관리자 계정 유형",
+                example = "OPERATIONS",
+                allowableValues = {"ADMIN", "OPERATIONS", "SUPPORTER"})
+        @NotNull
+        Role role
+) {
+
+    private static final long DEFAULT_ADMIN_ACCOUNT_SEMESTER_ID = 1L;
+
+    public Member toEntity(final String encodedPassword) {
+        return Member.builder()
+                .email(email)
+                .pin(encodedPassword)
+                .name(normalizeName())
+                .role(role)
+                .semesterId(DEFAULT_ADMIN_ACCOUNT_SEMESTER_ID)
+                .build();
+    }
+
+    private String normalizeName() {
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        return name;
+    }
+}

--- a/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
+++ b/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
@@ -1,0 +1,40 @@
+package org.ject.support.admin.account.service;
+
+import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
+import org.ject.support.admin.exception.AdminErrorCode;
+import org.ject.support.admin.exception.AdminException;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminAccountService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void createAccount(final AdminAccountCreateRequest request) {
+        validateBackofficeRole(request);
+        validateEmailUniqueness(request);
+
+        final String encodedPassword = passwordEncoder.encode(request.password());
+        memberRepository.save(request.toEntity(encodedPassword));
+    }
+
+    private void validateBackofficeRole(final AdminAccountCreateRequest request) {
+        if (!request.role().isBackoffice()) {
+            throw new AdminException(AdminErrorCode.INVALID_ADMIN_ACCOUNT_ROLE);
+        }
+    }
+
+    private void validateEmailUniqueness(final AdminAccountCreateRequest request) {
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new AdminException(AdminErrorCode.DUPLICATE_ADMIN_EMAIL);
+        }
+    }
+}

--- a/src/main/java/org/ject/support/admin/exception/AdminErrorCode.java
+++ b/src/main/java/org/ject/support/admin/exception/AdminErrorCode.java
@@ -11,7 +11,9 @@ public enum AdminErrorCode implements ErrorCode {
     NOT_FOUND_ADMIN(HttpStatus.NOT_FOUND, "ADMIN-1", "존재하지 않는 관리자 입니다."),
     LOCKED_ADMIN(HttpStatus.FORBIDDEN, "ADMIN-5", "계정이 비활성화되어 있습니다. 관리자에게 문의해주세요."),
     INVALID_ADMIN_CREDENTIALS(HttpStatus.UNAUTHORIZED, "ADMIN-6", "이메일 또는 비밀번호가 올바르지 않습니다."),
-    LOGIN_ATTEMPT_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "ADMIN-7", "로그인 시도가 제한되었습니다. 잠시 후 다시 시도해주세요.");
+    LOGIN_ATTEMPT_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "ADMIN-7", "로그인 시도가 제한되었습니다. 잠시 후 다시 시도해주세요."),
+    DUPLICATE_ADMIN_EMAIL(HttpStatus.CONFLICT, "ADMIN-8", "이미 사용중인 이메일 입니다."),
+    INVALID_ADMIN_ACCOUNT_ROLE(HttpStatus.BAD_REQUEST, "ADMIN-9", "관리자 계정 유형만 선택할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,7 +49,7 @@ public class Member extends BaseTimeEntity {
     private String email;
 
     @Column(length = 20)
-    @Pattern(regexp = "^[가-힣]{1,5}$", message = "한글 1~5글자만 입력 가능합니다.")
+    @Size(max = 20)
     private String name;
 
     @Column(length = 12)

--- a/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
+++ b/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
@@ -1,0 +1,130 @@
+package org.ject.support.admin.account.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
+import org.ject.support.admin.account.service.AdminAccountService;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.common.exception.GlobalErrorCode;
+import org.ject.support.common.exception.GlobalExceptionHandler;
+import org.ject.support.domain.member.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AdminAccountControllerTest extends UnitTestSupport {
+
+    @InjectMocks
+    private AdminAccountController adminAccountController;
+
+    @Mock
+    private AdminAccountService adminAccountService;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        mockMvc = MockMvcBuilders.standaloneSetup(adminAccountController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void 관리자_계정_생성_성공() throws Exception {
+        // given
+        var request = new AdminAccountCreateRequest("admin@ject.kr", "password123", "김젝트", Role.OPERATIONS);
+
+        doNothing().when(adminAccountService).createAccount(any(AdminAccountCreateRequest.class));
+
+        // when, then
+        mockMvc.perform(post("/admin/accounts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        verify(adminAccountService).createAccount(any(AdminAccountCreateRequest.class));
+    }
+
+    @Test
+    void 관리자_계정_생성은_ADMIN_권한만_허용한다() throws Exception {
+        // when
+        PreAuthorize preAuthorize = AdminAccountController.class
+                .getMethod("createAccount", AdminAccountCreateRequest.class)
+                .getAnnotation(PreAuthorize.class);
+
+        // when, then
+        assertThat(preAuthorize).isNotNull();
+        assertThat(preAuthorize.value()).isEqualTo("hasAuthority('ROLE_ADMIN')");
+    }
+
+    @Test
+    void 관리자_계정_생성_실패_올바르지_않은_이메일_형식() throws Exception {
+        // given
+        var request = new AdminAccountCreateRequest("invalid-email", "password123", "김젝트", Role.OPERATIONS);
+
+        // when, then
+        mockMvc.perform(post("/admin/accounts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(GlobalErrorCode.METHOD_VALIDATION_FAILED.getCode()))
+                .andExpect(jsonPath("$.messages[0]").value("올바른 이메일 형식이 아닙니다."))
+                .andDo(print());
+    }
+
+    @Test
+    void 관리자_계정_생성_실패_이메일_길이_초과() throws Exception {
+        // given
+        var request = new AdminAccountCreateRequest(
+                "very-long-admin-email-test@ject.kr",
+                "password123",
+                "김젝트",
+                Role.OPERATIONS
+        );
+
+        // when, then
+        mockMvc.perform(post("/admin/accounts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(GlobalErrorCode.METHOD_VALIDATION_FAILED.getCode()))
+                .andExpect(jsonPath("$.messages[0]").value("이메일 길이는 최대 30자리 까지 가능합니다."))
+                .andDo(print());
+    }
+
+    @Test
+    void 관리자_계정_생성_실패_이름_길이_초과() throws Exception {
+        // given
+        var request = new AdminAccountCreateRequest(
+                "admin@ject.kr",
+                "password123",
+                "김젝트김젝트김젝트김젝트김젝트김젝트김젝트",
+                Role.OPERATIONS
+        );
+
+        // when, then
+        mockMvc.perform(post("/admin/accounts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(GlobalErrorCode.METHOD_VALIDATION_FAILED.getCode()))
+                .andExpect(jsonPath("$.messages[0]").value("이름 길이는 최대 20자리 까지 가능합니다."))
+                .andDo(print());
+    }
+}

--- a/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
+++ b/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
@@ -1,0 +1,132 @@
+package org.ject.support.admin.account.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
+import org.ject.support.admin.exception.AdminErrorCode;
+import org.ject.support.admin.exception.AdminException;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class AdminAccountServiceTest extends UnitTestSupport {
+
+    @InjectMocks
+    private AdminAccountService adminAccountService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private static final String TEST_EMAIL = "admin@ject.kr";
+    private static final String TEST_PASSWORD = "password123";
+    private static final String ENCODED_PASSWORD = "encoded-password";
+
+    @Test
+    void 관리자_계정_생성_성공() {
+        // given
+        var request = new AdminAccountCreateRequest(TEST_EMAIL, TEST_PASSWORD, "김젝트", Role.OPERATIONS);
+
+        given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
+        given(passwordEncoder.encode(TEST_PASSWORD)).willReturn(ENCODED_PASSWORD);
+
+        // when
+        adminAccountService.createAccount(request);
+
+        // then
+        var memberCaptor = ArgumentCaptor.forClass(Member.class);
+        verify(memberRepository).existsByEmail(TEST_EMAIL);
+        verify(passwordEncoder).encode(TEST_PASSWORD);
+        verify(memberRepository).save(memberCaptor.capture());
+
+        Member savedMember = memberCaptor.getValue();
+        assertThat(savedMember.getEmail()).isEqualTo(TEST_EMAIL);
+        assertThat(savedMember.getPin()).isEqualTo(ENCODED_PASSWORD);
+        assertThat(savedMember.getName()).isEqualTo("김젝트");
+        assertThat(savedMember.getRole()).isEqualTo(Role.OPERATIONS);
+        assertThat(savedMember.getSemesterId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 관리자_계정_생성_시_빈_이름은_null로_저장한다() {
+        // given
+        var request = new AdminAccountCreateRequest(TEST_EMAIL, TEST_PASSWORD, "", Role.ADMIN);
+
+        given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
+        given(passwordEncoder.encode(TEST_PASSWORD)).willReturn(ENCODED_PASSWORD);
+
+        // when
+        adminAccountService.createAccount(request);
+
+        // then
+        var memberCaptor = ArgumentCaptor.forClass(Member.class);
+        verify(memberRepository).save(memberCaptor.capture());
+
+        assertThat(memberCaptor.getValue().getName()).isNull();
+    }
+
+    @Test
+    void 관리자_계정_생성_시_공백_이름은_null로_저장한다() {
+        // given
+        var request = new AdminAccountCreateRequest(TEST_EMAIL, TEST_PASSWORD, "   ", Role.ADMIN);
+
+        given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
+        given(passwordEncoder.encode(TEST_PASSWORD)).willReturn(ENCODED_PASSWORD);
+
+        // when
+        adminAccountService.createAccount(request);
+
+        // then
+        var memberCaptor = ArgumentCaptor.forClass(Member.class);
+        verify(memberRepository).save(memberCaptor.capture());
+
+        assertThat(memberCaptor.getValue().getName()).isNull();
+    }
+
+    @Test
+    void 관리자_계정_생성_실패_이미_사용중인_이메일() {
+        // given
+        var request = new AdminAccountCreateRequest(TEST_EMAIL, TEST_PASSWORD, "김젝트", Role.ADMIN);
+
+        given(memberRepository.existsByEmail(TEST_EMAIL)).willReturn(true);
+
+        // expected
+        assertThatThrownBy(() -> adminAccountService.createAccount(request))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.DUPLICATE_ADMIN_EMAIL);
+
+        verify(memberRepository).existsByEmail(TEST_EMAIL);
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(memberRepository, never()).save(org.mockito.ArgumentMatchers.any(Member.class));
+    }
+
+    @Test
+    void 관리자_계정_생성_실패_관리자_계정_유형이_아닌_role() {
+        // given
+        var request = new AdminAccountCreateRequest(TEST_EMAIL, TEST_PASSWORD, "김젝트", Role.SEMESTER);
+
+        // expected
+        assertThatThrownBy(() -> adminAccountService.createAccount(request))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.INVALID_ADMIN_ACCOUNT_ROLE);
+
+        verify(memberRepository, never()).existsByEmail(anyString());
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(memberRepository, never()).save(org.mockito.ArgumentMatchers.any(Member.class));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #475 

## 📝 작업 내용

### 백오피스 관리자 계정 생성하기 기능을 구현
 - POST /admin/accounts
 - Admin 권한만 사용 가능

## 🙏 리뷰 요구사항 (선택)
 - `Member.semesterId`가 nullable false라 관리자 계정 생성 시 임시로 `1L`을 사용했습니다.
 - 추후 관리자 계정 도메인 분리 또는 `semesterId` nullable 리팩토링이 필요합니다.
 - `Member.name` 엔티티 제약은 DB 제약에 맞춰 최대 20자로 완화했습니다.
