### PR TITLE
feat:관리자 Role 업데이트 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
+++ b/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
@@ -5,11 +5,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
+import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
 import org.ject.support.admin.account.service.AdminAccountService;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,5 +30,15 @@ public class AdminAccountController {
             description = "관리자 계정 유형의 계정을 생성합니다.")
     public void createAccount(@RequestBody @Valid final AdminAccountCreateRequest request) {
         adminAccountService.createAccount(request);
+    }
+
+    @PatchMapping("/{memberId}/role")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    @Operation(
+            summary = "관리자 계정 권한 수정",
+            description = "관리자 계정의 권한을 수정합니다.")
+    public void updateRole(@PathVariable final Long memberId,
+                           @RequestBody @Valid final AdminAccountRoleUpdateRequest request) {
+        adminAccountService.updateRole(memberId, request);
     }
 }

--- a/src/main/java/org/ject/support/admin/account/dto/AdminAccountRoleUpdateRequest.java
+++ b/src/main/java/org/ject/support/admin/account/dto/AdminAccountRoleUpdateRequest.java
@@ -1,0 +1,16 @@
+package org.ject.support.admin.account.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.ject.support.domain.member.Role;
+
+@Schema(description = "관리자 계정 권한 수정 요청")
+public record AdminAccountRoleUpdateRequest(
+        @Schema(
+                description = "관리자 계정 유형",
+                example = "SUPPORTER",
+                allowableValues = {"ADMIN", "OPERATIONS", "SUPPORTER"})
+        @NotNull
+        Role role
+) {
+}

--- a/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
+++ b/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
@@ -8,6 +8,7 @@ import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.entity.MemberEditor;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -37,7 +38,11 @@ public class AdminAccountService {
 
         final Member member = adminMemberComponent.getRequiredBackofficeMemberById(memberId);
 
-        member.updateRole(request.role());
+        final MemberEditor editor = member.toEditor()
+                .role(request.role())
+                .build();
+
+        member.edit(editor);
     }
 
     private void validateBackofficeRole(final Role role) {

--- a/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
+++ b/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
@@ -2,8 +2,11 @@ package org.ject.support.admin.account.service;
 
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
+import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -19,16 +22,33 @@ public class AdminAccountService {
 
     @Transactional
     public void createAccount(final AdminAccountCreateRequest request) {
-        validateBackofficeRole(request);
+        validateBackofficeRole(request.role());
         validateEmailUniqueness(request);
 
         final String encodedPassword = passwordEncoder.encode(request.password());
         memberRepository.save(request.toEntity(encodedPassword));
     }
 
-    private void validateBackofficeRole(final AdminAccountCreateRequest request) {
-        if (!request.role().isBackoffice()) {
+    @Transactional
+    public void updateRole(final Long memberId, final AdminAccountRoleUpdateRequest request) {
+        validateBackofficeRole(request.role());
+
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
+        validateBackofficeAccount(member);
+
+        member.updateRole(request.role());
+    }
+
+    private void validateBackofficeRole(final Role role) {
+        if (!role.isBackoffice()) {
             throw new AdminException(AdminErrorCode.INVALID_ADMIN_ACCOUNT_ROLE);
+        }
+    }
+
+    private void validateBackofficeAccount(final Member member) {
+        if (!member.getRole().isBackoffice()) {
+            throw new AdminException(AdminErrorCode.NOT_FOUND_ADMIN);
         }
     }
 

--- a/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
+++ b/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
@@ -3,6 +3,7 @@ package org.ject.support.admin.account.service;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
+import org.ject.support.admin.component.AdminMemberComponent;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
 import org.ject.support.domain.member.Role;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminAccountService {
 
     private final MemberRepository memberRepository;
+    private final AdminMemberComponent adminMemberComponent;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -33,9 +35,7 @@ public class AdminAccountService {
     public void updateRole(final Long memberId, final AdminAccountRoleUpdateRequest request) {
         validateBackofficeRole(request.role());
 
-        final Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
-        validateBackofficeAccount(member);
+        final Member member = adminMemberComponent.getRequiredBackofficeMemberById(memberId);
 
         member.updateRole(request.role());
     }
@@ -43,12 +43,6 @@ public class AdminAccountService {
     private void validateBackofficeRole(final Role role) {
         if (!role.isBackoffice()) {
             throw new AdminException(AdminErrorCode.INVALID_ADMIN_ACCOUNT_ROLE);
-        }
-    }
-
-    private void validateBackofficeAccount(final Member member) {
-        if (!member.getRole().isBackoffice()) {
-            throw new AdminException(AdminErrorCode.NOT_FOUND_ADMIN);
         }
     }
 

--- a/src/main/java/org/ject/support/admin/auth/service/AdminAuthService.java
+++ b/src/main/java/org/ject/support/admin/auth/service/AdminAuthService.java
@@ -3,7 +3,7 @@ package org.ject.support.admin.auth.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
-import org.ject.support.admin.member.component.AdminMemberComponent;
+import org.ject.support.admin.component.AdminMemberComponent;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
 import org.ject.support.domain.member.MemberStatus;

--- a/src/main/java/org/ject/support/admin/component/AdminMemberComponent.java
+++ b/src/main/java/org/ject/support/admin/component/AdminMemberComponent.java
@@ -1,4 +1,4 @@
-package org.ject.support.admin.member.component;
+package org.ject.support.admin.component;
 
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.exception.AdminErrorCode;
@@ -22,6 +22,11 @@ public class AdminMemberComponent {
 
     public Member getRequiredBackofficeMemberByEmail(String email) {
         return memberRepository.findByEmailAndRoleIn(email, Role.backofficeRoles())
+                .orElseThrow(() -> new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
+    }
+
+    public Member getRequiredBackofficeMemberById(Long id) {
+        return memberRepository.findByIdAndRoleIn(id, Role.backofficeRoles())
                 .orElseThrow(() -> new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
     }
 

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -155,10 +155,6 @@ public class Member extends BaseTimeEntity {
         this.role = Role.SEMESTER;
     }
 
-    public void updateRole(final Role role) {
-        this.role = role;
-    }
-
     public boolean isProfileComplete() {
         return this.name != null && this.phoneNumber != null;
     }

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -155,6 +155,10 @@ public class Member extends BaseTimeEntity {
         this.role = Role.SEMESTER;
     }
 
+    public void updateRole(final Role role) {
+        this.role = role;
+    }
+
     public boolean isProfileComplete() {
         return this.name != null && this.phoneNumber != null;
     }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
@@ -15,5 +15,7 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberQue
 
     Optional<Member> findByEmailAndRoleIn(String email, Collection<Role> roles);
 
+    Optional<Member> findByIdAndRoleIn(Long id, Collection<Role> roles);
+
     boolean existsByEmail(String email);
 }

--- a/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
+++ b/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
@@ -2,6 +2,7 @@ package org.ject.support.admin.account.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
+import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
 import org.ject.support.admin.account.service.AdminAccountService;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.exception.GlobalErrorCode;
@@ -18,8 +19,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -71,6 +74,50 @@ class AdminAccountControllerTest extends UnitTestSupport {
         // when, then
         assertThat(preAuthorize).isNotNull();
         assertThat(preAuthorize.value()).isEqualTo("hasAuthority('ROLE_ADMIN')");
+    }
+
+    @Test
+    void 관리자_계정_권한_수정_성공() throws Exception {
+        // given
+        var memberId = 1L;
+        var request = new AdminAccountRoleUpdateRequest(Role.SUPPORTER);
+
+        doNothing().when(adminAccountService).updateRole(eq(memberId), any(AdminAccountRoleUpdateRequest.class));
+
+        // when, then
+        mockMvc.perform(patch("/admin/accounts/{memberId}/role", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        verify(adminAccountService).updateRole(eq(memberId), any(AdminAccountRoleUpdateRequest.class));
+    }
+
+    @Test
+    void 관리자_계정_권한_수정은_ADMIN_권한만_허용한다() throws Exception {
+        // when
+        PreAuthorize preAuthorize = AdminAccountController.class
+                .getMethod("updateRole", Long.class, AdminAccountRoleUpdateRequest.class)
+                .getAnnotation(PreAuthorize.class);
+
+        // when, then
+        assertThat(preAuthorize).isNotNull();
+        assertThat(preAuthorize.value()).isEqualTo("hasAuthority('ROLE_ADMIN')");
+    }
+
+    @Test
+    void 관리자_계정_권한_수정_실패_role_누락() throws Exception {
+        // given
+        var request = new AdminAccountRoleUpdateRequest(null);
+
+        // when, then
+        mockMvc.perform(patch("/admin/accounts/{memberId}/role", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(GlobalErrorCode.METHOD_VALIDATION_FAILED.getCode()))
+                .andDo(print());
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
+++ b/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
+import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
 import org.ject.support.base.UnitTestSupport;
@@ -19,6 +20,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
 
 class AdminAccountServiceTest extends UnitTestSupport {
 
@@ -128,5 +131,82 @@ class AdminAccountServiceTest extends UnitTestSupport {
         verify(memberRepository, never()).existsByEmail(anyString());
         verify(passwordEncoder, never()).encode(anyString());
         verify(memberRepository, never()).save(org.mockito.ArgumentMatchers.any(Member.class));
+    }
+
+    @Test
+    void 관리자_계정_권한_수정_성공() {
+        // given
+        var memberId = 1L;
+        var request = new AdminAccountRoleUpdateRequest(Role.SUPPORTER);
+        var member = Member.builder()
+                .id(memberId)
+                .email(TEST_EMAIL)
+                .role(Role.OPERATIONS)
+                .semesterId(1L)
+                .build();
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // when
+        adminAccountService.updateRole(memberId, request);
+
+        // then
+        verify(memberRepository).findById(memberId);
+        assertThat(member.getRole()).isEqualTo(Role.SUPPORTER);
+    }
+
+    @Test
+    void 관리자_계정_권한_수정_실패_관리자_계정_유형이_아닌_role() {
+        // given
+        var request = new AdminAccountRoleUpdateRequest(Role.SEMESTER);
+
+        // expected
+        assertThatThrownBy(() -> adminAccountService.updateRole(1L, request))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.INVALID_ADMIN_ACCOUNT_ROLE);
+
+        verify(memberRepository, never()).findById(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void 관리자_계정_권한_수정_실패_존재하지_않는_관리자() {
+        // given
+        var memberId = 999L;
+        var request = new AdminAccountRoleUpdateRequest(Role.SUPPORTER);
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // expected
+        assertThatThrownBy(() -> adminAccountService.updateRole(memberId, request))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.NOT_FOUND_ADMIN);
+
+        verify(memberRepository).findById(memberId);
+    }
+
+    @Test
+    void 관리자_계정_권한_수정_실패_대상이_관리자_계정이_아님() {
+        // given
+        var memberId = 1L;
+        var request = new AdminAccountRoleUpdateRequest(Role.SUPPORTER);
+        var member = Member.builder()
+                .id(memberId)
+                .email(TEST_EMAIL)
+                .role(Role.SEMESTER)
+                .semesterId(1L)
+                .build();
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // expected
+        assertThatThrownBy(() -> adminAccountService.updateRole(memberId, request))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.NOT_FOUND_ADMIN);
+
+        verify(memberRepository).findById(memberId);
+        assertThat(member.getRole()).isEqualTo(Role.SEMESTER);
     }
 }

--- a/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
+++ b/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
@@ -1,12 +1,5 @@
 package org.ject.support.admin.account.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
 import org.ject.support.admin.exception.AdminErrorCode;
@@ -22,6 +15,13 @@ import org.mockito.Mock;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 class AdminAccountServiceTest extends UnitTestSupport {
 
@@ -160,7 +160,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
         // given
         var request = new AdminAccountRoleUpdateRequest(Role.SEMESTER);
 
-        // expected
+        // when, then
         assertThatThrownBy(() -> adminAccountService.updateRole(1L, request))
                 .isInstanceOf(AdminException.class)
                 .extracting(e -> ((AdminException) e).getErrorCode())
@@ -177,7 +177,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
 
         given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
-        // expected
+        // when, then
         assertThatThrownBy(() -> adminAccountService.updateRole(memberId, request))
                 .isInstanceOf(AdminException.class)
                 .extracting(e -> ((AdminException) e).getErrorCode())
@@ -200,7 +200,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
 
-        // expected
+        // when, then
         assertThatThrownBy(() -> adminAccountService.updateRole(memberId, request))
                 .isInstanceOf(AdminException.class)
                 .extracting(e -> ((AdminException) e).getErrorCode())

--- a/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
+++ b/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
@@ -143,6 +143,8 @@ class AdminAccountServiceTest extends UnitTestSupport {
         var member = Member.builder()
                 .id(memberId)
                 .email(TEST_EMAIL)
+                .name("김젝트")
+                .phoneNumber("01012345678")
                 .role(Role.OPERATIONS)
                 .semesterId(1L)
                 .build();
@@ -155,6 +157,10 @@ class AdminAccountServiceTest extends UnitTestSupport {
         // then
         verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
         assertThat(member.getRole()).isEqualTo(Role.SUPPORTER);
+        assertThat(member.getEmail()).isEqualTo(TEST_EMAIL);
+        assertThat(member.getName()).isEqualTo("김젝트");
+        assertThat(member.getPhoneNumber()).isEqualTo("01012345678");
+        assertThat(member.getSemesterId()).isEqualTo(1L);
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
+++ b/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
@@ -2,6 +2,7 @@ package org.ject.support.admin.account.service;
 
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
+import org.ject.support.admin.component.AdminMemberComponent;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
 import org.ject.support.base.UnitTestSupport;
@@ -13,8 +14,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,6 +29,9 @@ class AdminAccountServiceTest extends UnitTestSupport {
 
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private AdminMemberComponent adminMemberComponent;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -145,13 +147,13 @@ class AdminAccountServiceTest extends UnitTestSupport {
                 .semesterId(1L)
                 .build();
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(adminMemberComponent.getRequiredBackofficeMemberById(memberId)).willReturn(member);
 
         // when
         adminAccountService.updateRole(memberId, request);
 
         // then
-        verify(memberRepository).findById(memberId);
+        verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
         assertThat(member.getRole()).isEqualTo(Role.SUPPORTER);
     }
 
@@ -166,7 +168,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
                 .extracting(e -> ((AdminException) e).getErrorCode())
                 .isEqualTo(AdminErrorCode.INVALID_ADMIN_ACCOUNT_ROLE);
 
-        verify(memberRepository, never()).findById(org.mockito.ArgumentMatchers.anyLong());
+        verify(adminMemberComponent, never()).getRequiredBackofficeMemberById(org.mockito.ArgumentMatchers.anyLong());
     }
 
     @Test
@@ -175,7 +177,8 @@ class AdminAccountServiceTest extends UnitTestSupport {
         var memberId = 999L;
         var request = new AdminAccountRoleUpdateRequest(Role.SUPPORTER);
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+        given(adminMemberComponent.getRequiredBackofficeMemberById(memberId))
+                .willThrow(new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
 
         // when, then
         assertThatThrownBy(() -> adminAccountService.updateRole(memberId, request))
@@ -183,7 +186,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
                 .extracting(e -> ((AdminException) e).getErrorCode())
                 .isEqualTo(AdminErrorCode.NOT_FOUND_ADMIN);
 
-        verify(memberRepository).findById(memberId);
+        verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
     }
 
     @Test
@@ -198,7 +201,8 @@ class AdminAccountServiceTest extends UnitTestSupport {
                 .semesterId(1L)
                 .build();
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(adminMemberComponent.getRequiredBackofficeMemberById(memberId))
+                .willThrow(new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
 
         // when, then
         assertThatThrownBy(() -> adminAccountService.updateRole(memberId, request))
@@ -206,7 +210,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
                 .extracting(e -> ((AdminException) e).getErrorCode())
                 .isEqualTo(AdminErrorCode.NOT_FOUND_ADMIN);
 
-        verify(memberRepository).findById(memberId);
+        verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
         assertThat(member.getRole()).isEqualTo(Role.SEMESTER);
     }
 }

--- a/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
+++ b/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
@@ -195,28 +195,4 @@ class AdminAccountServiceTest extends UnitTestSupport {
         verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
     }
 
-    @Test
-    void 관리자_계정_권한_수정_실패_대상이_관리자_계정이_아님() {
-        // given
-        var memberId = 1L;
-        var request = new AdminAccountRoleUpdateRequest(Role.SUPPORTER);
-        var member = Member.builder()
-                .id(memberId)
-                .email(TEST_EMAIL)
-                .role(Role.SEMESTER)
-                .semesterId(1L)
-                .build();
-
-        given(adminMemberComponent.getRequiredBackofficeMemberById(memberId))
-                .willThrow(new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
-
-        // when, then
-        assertThatThrownBy(() -> adminAccountService.updateRole(memberId, request))
-                .isInstanceOf(AdminException.class)
-                .extracting(e -> ((AdminException) e).getErrorCode())
-                .isEqualTo(AdminErrorCode.NOT_FOUND_ADMIN);
-
-        verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
-        assertThat(member.getRole()).isEqualTo(Role.SEMESTER);
-    }
 }

--- a/src/test/java/org/ject/support/admin/auth/service/AdminAuthServiceTest.java
+++ b/src/test/java/org/ject/support/admin/auth/service/AdminAuthServiceTest.java
@@ -3,7 +3,7 @@ package org.ject.support.admin.auth.service;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
-import org.ject.support.admin.member.component.AdminMemberComponent;
+import org.ject.support.admin.component.AdminMemberComponent;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
 import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Role;

--- a/src/test/java/org/ject/support/admin/component/AdminMemberComponentTest.java
+++ b/src/test/java/org/ject/support/admin/component/AdminMemberComponentTest.java
@@ -1,4 +1,4 @@
-package org.ject.support.admin.member.component;
+package org.ject.support.admin.component;
 
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
@@ -64,6 +64,43 @@ class AdminMemberComponentTest extends UnitTestSupport {
         assertEquals(email, result.getEmail());
         assertEquals(Role.ADMIN, result.getRole());
         assertEquals(MemberStatus.ACTIVE, result.getStatus());
+    }
+
+    @Test
+    void id로_관리자계정의_정보를_조회할_경우_Member_엔티티를_반환() {
+        // given
+        Long memberId = 1L;
+        Member foundMember = Member.builder()
+                .id(memberId)
+                .email("admin@test.com")
+                .status(MemberStatus.ACTIVE)
+                .role(Role.ADMIN)
+                .build();
+
+        given(memberRepository.findByIdAndRoleIn(memberId, BACKOFFICE_ROLES)).willReturn(Optional.of(foundMember));
+
+        // when
+        Member result = adminMemberComponent.getRequiredBackofficeMemberById(memberId);
+
+        // then
+        verify(memberRepository).findByIdAndRoleIn(memberId, BACKOFFICE_ROLES);
+        assertEquals(memberId, result.getId());
+        assertEquals(Role.ADMIN, result.getRole());
+        assertEquals(MemberStatus.ACTIVE, result.getStatus());
+    }
+
+    @Test
+    void 존재하지않는_id로_관리자계정의_정보를_조회할_경우_NOT_FOUND_ADMIN_예외가_발생() {
+        // given
+        Long memberId = 999L;
+
+        given(memberRepository.findByIdAndRoleIn(memberId, BACKOFFICE_ROLES)).willReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> adminMemberComponent.getRequiredBackofficeMemberById(memberId))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.NOT_FOUND_ADMIN);
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/component/AdminMemberComponentTest.java
+++ b/src/test/java/org/ject/support/admin/component/AdminMemberComponentTest.java
@@ -14,9 +14,11 @@ import org.mockito.Mock;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 class AdminMemberComponentTest extends UnitTestSupport {
@@ -64,6 +66,44 @@ class AdminMemberComponentTest extends UnitTestSupport {
         assertEquals(email, result.getEmail());
         assertEquals(Role.ADMIN, result.getRole());
         assertEquals(MemberStatus.ACTIVE, result.getStatus());
+    }
+
+    @Test
+    void 이메일로_관리자계정의_정보를_Optional로_조회할_경우_존재하면_Member를_반환() {
+        // given
+        String email = "admin@test.com";
+        Member foundMember = Member.builder()
+                .id(1L)
+                .email(email)
+                .status(MemberStatus.ACTIVE)
+                .role(Role.SUPPORTER)
+                .build();
+
+        given(memberRepository.findByEmailAndRoleIn(email, BACKOFFICE_ROLES)).willReturn(Optional.of(foundMember));
+
+        // when
+        Optional<Member> result = adminMemberComponent.findBackofficeMemberByEmail(email);
+
+        // then
+        verify(memberRepository).findByEmailAndRoleIn(email, BACKOFFICE_ROLES);
+        assertThat(result).isPresent();
+        assertThat(result.get().getEmail()).isEqualTo(email);
+        assertThat(result.get().getRole()).isEqualTo(Role.SUPPORTER);
+    }
+
+    @Test
+    void 이메일로_관리자계정의_정보를_Optional로_조회할_경우_없으면_빈_Optional을_반환() {
+        // given
+        String email = "not_found_admin@test.com";
+
+        given(memberRepository.findByEmailAndRoleIn(email, BACKOFFICE_ROLES)).willReturn(Optional.empty());
+
+        // when
+        Optional<Member> result = adminMemberComponent.findBackofficeMemberByEmail(email);
+
+        // then
+        verify(memberRepository).findByEmailAndRoleIn(email, BACKOFFICE_ROLES);
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -121,5 +161,23 @@ class AdminMemberComponentTest extends UnitTestSupport {
         // then
         verify(memberRepository).save(member);
         assertEquals(changeStatus, member.getStatus());
+    }
+
+    @Test
+    void 회원의_상태가_이미_같으면_저장하지_않는다() {
+        // given
+        Member member = Member.builder()
+                .id(1L)
+                .email("test@test.com")
+                .status(MemberStatus.ACTIVE)
+                .role(Role.ADMIN)
+                .build();
+
+        // when
+        adminMemberComponent.changeMemberStatus(member, MemberStatus.ACTIVE);
+
+        // then
+        verify(memberRepository, never()).save(member);
+        assertEquals(MemberStatus.ACTIVE, member.getStatus());
     }
 }

--- a/src/test/java/org/ject/support/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberRepositoryTest.java
@@ -88,6 +88,40 @@ class MemberRepositoryTest {
         assertThat(found).isEmpty();
     }
 
+    @Test
+    void id와_역할목록으로_회원을_조회시_목록에_포함된_역할이면_회원을_반환한다() {
+        // given
+        Member member = createMember("운영진", "01011112222", "operations@example.com", JobFamily.PM, Role.OPERATIONS);
+        Member savedMember = memberRepository.save(member);
+
+        // when
+        Optional<Member> found = memberRepository.findByIdAndRoleIn(
+                savedMember.getId(),
+                List.of(Role.ADMIN, Role.OPERATIONS, Role.SUPPORTER)
+        );
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(savedMember.getId());
+        assertThat(found.get().getRole()).isEqualTo(Role.OPERATIONS);
+    }
+
+    @Test
+    void id와_역할목록으로_회원을_조회시_목록에_없는_역할이면_빈_Optional을_반환한다() {
+        // given
+        Member member = createMember("학회원", "01033334444", "member@example.com", JobFamily.BE, Role.SEMESTER);
+        Member savedMember = memberRepository.save(member);
+
+        // when
+        Optional<Member> found = memberRepository.findByIdAndRoleIn(
+                savedMember.getId(),
+                List.of(Role.ADMIN, Role.OPERATIONS, Role.SUPPORTER)
+        );
+
+        // then
+        assertThat(found).isEmpty();
+    }
+
     private Member createMember(String name, String phoneNumber, String email, JobFamily jobFamily, Role role) {
         return Member.builder()
                 .name(name)


### PR DESCRIPTION
## #️⃣연관된 이슈

close #477 

## 📝 작업 내용

### 관리자 Role 업데이트 기능 구현
 - PATCH `/admin/accounts/{memberId}/role`
 - API 호출은 기존 관리자 계정 생성 API와 동일하게 ROLE_ADMIN 권한만 허용
 - 수정 가능한 Role은 백오피스 Role로 제한
   - ADMIN
   - OPERATIONS
   - SUPPORTER
 - 생성/수정 시 사용하는 백오피스 Role 검증 로직을 validateBackofficeRole(Role role)로 통합
 - Member 엔티티에 Role 변경 메서드 updateRole()을 추가
   


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자가 회원의 역할을 변경할 수 있는 새로운 관리 기능 추가 (ADMIN, OPERATIONS, SUPPORTER 역할 지원)
  * 역할 변경 시 검증 로직 및 오류 처리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->