### PR TITLE
feat:관리자 계정 활성화/비활성화 기능 추가

### DIFF
--- a/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
+++ b/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
@@ -8,6 +8,7 @@ import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
 import org.ject.support.admin.account.service.AdminAccountService;
+import org.ject.support.common.security.AuthPrincipal;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -48,8 +49,9 @@ public class AdminAccountController {
     @Operation(
             summary = "관리자 계정 활성화 상태 수정",
             description = "관리자 계정을 활성화하거나 비활성화합니다.")
-    public void updateActive(@PathVariable final Long memberId,
+    public void updateActive(@AuthPrincipal final Long requesterId,
+                             @PathVariable final Long memberId,
                              @RequestBody @Valid final AdminAccountActiveUpdateRequest request) {
-        adminAccountService.updateActive(memberId, request);
+        adminAccountService.updateActive(requesterId, memberId, request);
     }
 }

--- a/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
+++ b/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
@@ -1,6 +1,7 @@
 package org.ject.support.admin.account.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -49,7 +50,7 @@ public class AdminAccountController {
     @Operation(
             summary = "관리자 계정 활성화 상태 수정",
             description = "관리자 계정을 활성화하거나 비활성화합니다.")
-    public void updateActive(@AuthPrincipal final Long requesterId,
+    public void updateActive(@Parameter(hidden = true) @AuthPrincipal final Long requesterId,
                              @PathVariable final Long memberId,
                              @RequestBody @Valid final AdminAccountActiveUpdateRequest request) {
         adminAccountService.updateActive(requesterId, memberId, request);

--- a/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
+++ b/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
 import org.ject.support.admin.account.service.AdminAccountService;
@@ -40,5 +41,15 @@ public class AdminAccountController {
     public void updateRole(@PathVariable final Long memberId,
                            @RequestBody @Valid final AdminAccountRoleUpdateRequest request) {
         adminAccountService.updateRole(memberId, request);
+    }
+
+    @PatchMapping("/{memberId}/active")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    @Operation(
+            summary = "관리자 계정 활성화 상태 수정",
+            description = "관리자 계정을 활성화하거나 비활성화합니다.")
+    public void updateActive(@PathVariable final Long memberId,
+                             @RequestBody @Valid final AdminAccountActiveUpdateRequest request) {
+        adminAccountService.updateActive(memberId, request);
     }
 }

--- a/src/main/java/org/ject/support/admin/account/dto/AdminAccountActiveUpdateRequest.java
+++ b/src/main/java/org/ject/support/admin/account/dto/AdminAccountActiveUpdateRequest.java
@@ -1,0 +1,12 @@
+package org.ject.support.admin.account.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "관리자 계정 활성화 상태 수정 요청")
+public record AdminAccountActiveUpdateRequest(
+        @Schema(description = "관리자 계정 활성화 여부", example = "true")
+        @NotNull
+        Boolean active
+) {
+}

--- a/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
+++ b/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
@@ -48,11 +48,23 @@ public class AdminAccountService {
     }
 
     @Transactional
-    public void updateActive(final Long memberId, final AdminAccountActiveUpdateRequest request) {
+    public void updateActive(final Long requesterId,
+                             final Long memberId,
+                             final AdminAccountActiveUpdateRequest request) {
+        validateNotLockingSelf(requesterId, memberId, request.active());
+
         final Member member = adminMemberComponent.getRequiredBackofficeMemberById(memberId);
         final MemberStatus status = request.active() ? MemberStatus.ACTIVE : MemberStatus.LOCKED;
 
         adminMemberComponent.changeMemberStatus(member, status);
+    }
+
+    private void validateNotLockingSelf(final Long requesterId,
+                                        final Long memberId,
+                                        final boolean active) {
+        if (!active && requesterId.equals(memberId)) {
+            throw new AdminException(AdminErrorCode.CANNOT_LOCK_SELF);
+        }
     }
 
     private void validateBackofficeRole(final Role role) {

--- a/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
+++ b/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
@@ -1,11 +1,13 @@
 package org.ject.support.admin.account.service;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
 import org.ject.support.admin.component.AdminMemberComponent;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
+import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.entity.MemberEditor;
@@ -43,6 +45,14 @@ public class AdminAccountService {
                 .build();
 
         member.edit(editor);
+    }
+
+    @Transactional
+    public void updateActive(final Long memberId, final AdminAccountActiveUpdateRequest request) {
+        final Member member = adminMemberComponent.getRequiredBackofficeMemberById(memberId);
+        final MemberStatus status = request.active() ? MemberStatus.ACTIVE : MemberStatus.LOCKED;
+
+        adminMemberComponent.changeMemberStatus(member, status);
     }
 
     private void validateBackofficeRole(final Role role) {

--- a/src/main/java/org/ject/support/admin/component/AdminMemberComponent.java
+++ b/src/main/java/org/ject/support/admin/component/AdminMemberComponent.java
@@ -39,7 +39,9 @@ public class AdminMemberComponent {
         if (member.getStatus() == status)  {
             return;
         }
-        member.setStatus(status);
+        member.edit(member.toEditor()
+                .status(status)
+                .build());
         memberRepository.save(member);
     }
 }

--- a/src/main/java/org/ject/support/admin/exception/AdminErrorCode.java
+++ b/src/main/java/org/ject/support/admin/exception/AdminErrorCode.java
@@ -13,7 +13,8 @@ public enum AdminErrorCode implements ErrorCode {
     INVALID_ADMIN_CREDENTIALS(HttpStatus.UNAUTHORIZED, "ADMIN-6", "이메일 또는 비밀번호가 올바르지 않습니다."),
     LOGIN_ATTEMPT_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "ADMIN-7", "로그인 시도가 제한되었습니다. 잠시 후 다시 시도해주세요."),
     DUPLICATE_ADMIN_EMAIL(HttpStatus.CONFLICT, "ADMIN-8", "이미 사용중인 이메일 입니다."),
-    INVALID_ADMIN_ACCOUNT_ROLE(HttpStatus.BAD_REQUEST, "ADMIN-9", "관리자 계정 유형만 선택할 수 있습니다.");
+    INVALID_ADMIN_ACCOUNT_ROLE(HttpStatus.BAD_REQUEST, "ADMIN-9", "관리자 계정 유형만 선택할 수 있습니다."),
+    CANNOT_LOCK_SELF(HttpStatus.BAD_REQUEST, "ADMIN-10", "본인 계정은 비활성화할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtAuthenticationFilter.java
@@ -6,10 +6,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.ject.support.admin.exception.AdminErrorCode;
+import org.ject.support.admin.exception.AdminException;
+import org.ject.support.common.exception.BusinessException;
 import org.ject.support.common.exception.GlobalErrorCode;
 import org.ject.support.common.exception.GlobalException;
 import org.ject.support.common.security.CustomUserDetails;
+import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.repository.MemberRepository;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,6 +25,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * JWT 토큰 기반의 인증을 처리하는 필터
@@ -34,7 +41,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final Set<String> BACKOFFICE_AUTHORITIES = Role.backofficeRoles().stream()
+            .map(role -> "ROLE_" + role.name())
+            .collect(Collectors.toUnmodifiableSet());
+
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) {
@@ -48,6 +60,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (accessToken != null) {
                 if (jwtTokenProvider.validateToken(accessToken)) {
                     Authentication auth = jwtTokenProvider.getAuthenticationByToken(accessToken);
+                    validateBackofficeMemberStatus(auth);
                     SecurityContextHolder.getContext().setAuthentication(auth);
 
                     chain.doFilter(request, response);
@@ -78,11 +91,34 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             chain.doFilter(request, response);
 
+        } catch (BusinessException e) {
+            SecurityContextHolder.clearContext();
+            throw e;
         } catch (Exception e) {
             log.error("JWT 인증 처리 중 에러 발생", e);
             SecurityContextHolder.clearContext();
             throw new GlobalException(GlobalErrorCode.INVALID_ACCESS_TOKEN);
         }
+    }
+
+    private void validateBackofficeMemberStatus(Authentication authentication) {
+        if (!hasBackofficeRole(authentication)) {
+            return;
+        }
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        var member = memberRepository.findByIdAndRoleIn(userDetails.getMemberId(), Role.backofficeRoles())
+                .orElseThrow(() -> new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
+
+        if (member.getStatus() == MemberStatus.LOCKED) {
+            throw new AdminException(AdminErrorCode.LOCKED_ADMIN);
+        }
+    }
+
+    private boolean hasBackofficeRole(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(BACKOFFICE_AUTHORITIES::contains);
     }
     
     private Authentication createVerificationAuthentication(String email) {

--- a/src/main/java/org/ject/support/common/security/jwt/JwtExceptionHandlerFilter.java
+++ b/src/main/java/org/ject/support/common/security/jwt/JwtExceptionHandlerFilter.java
@@ -7,6 +7,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.ject.support.common.exception.BusinessException;
+import org.ject.support.common.exception.ErrorCode;
 import org.ject.support.common.exception.GlobalErrorCode;
 import org.ject.support.common.exception.GlobalException;
 import org.ject.support.common.response.ApiResponse;
@@ -43,6 +45,9 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
         } catch (GlobalException e) {
             setErrorResponse(response, e.getErrorCode());
             log.error("GlobalException: {}", e.getErrorCode().getMessage());
+        } catch (BusinessException e) {
+            setErrorResponse(response, e.getErrorCode());
+            log.error("BusinessException: {}", e.getErrorCode().getMessage());
         } catch (AuthenticationException e) {
             setErrorResponse(response, INVALID_ACCESS_TOKEN);
             log.error("AuthenticationException: {}", e.getMessage());
@@ -62,7 +67,7 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
 
     private void setErrorResponse(
             HttpServletResponse response,
-            GlobalErrorCode errorCode
+            ErrorCode errorCode
     ) throws IOException {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -17,7 +17,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.ject.support.common.util.StringListConverter;
@@ -91,7 +90,6 @@ public class Member extends BaseTimeEntity {
     @Builder.Default
     private Boolean isDeleted = false;
 
-    @Setter
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(45)", nullable = false)
     @Builder.Default
@@ -125,7 +123,8 @@ public class Member extends BaseTimeEntity {
                 .experiencePeriod(this.experiencePeriod)
                 .careerDetails(this.careerDetails)
                 .interestedDomains(this.interestedDomains)
-                .role(this.role);
+                .role(this.role)
+                .status(this.status);
     }
 
     public void edit(MemberEditor editor) {
@@ -139,6 +138,7 @@ public class Member extends BaseTimeEntity {
         this.careerDetails = editor.careerDetails();
         this.interestedDomains = editor.interestedDomains();
         this.role = editor.role();
+        this.status = editor.status();
     }
 
     public void deleteProfile() {

--- a/src/main/java/org/ject/support/domain/member/entity/MemberEditor.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberEditor.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 
@@ -20,6 +21,7 @@ public record MemberEditor(
     ExperiencePeriod experiencePeriod,
     CareerDetails careerDetails,
     List<String> interestedDomains,
-    Role role
+    Role role,
+    MemberStatus status
 ) {
 }

--- a/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
+++ b/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
@@ -1,6 +1,7 @@
 package org.ject.support.admin.account.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
 import org.ject.support.admin.account.service.AdminAccountService;
@@ -104,6 +105,50 @@ class AdminAccountControllerTest extends UnitTestSupport {
         // when, then
         assertThat(preAuthorize).isNotNull();
         assertThat(preAuthorize.value()).isEqualTo("hasAuthority('ROLE_ADMIN')");
+    }
+
+    @Test
+    void 관리자_계정_활성화_상태_수정_성공() throws Exception {
+        // given
+        var memberId = 1L;
+        var request = new AdminAccountActiveUpdateRequest(false);
+
+        doNothing().when(adminAccountService).updateActive(eq(memberId), any(AdminAccountActiveUpdateRequest.class));
+
+        // when, then
+        mockMvc.perform(patch("/admin/accounts/{memberId}/active", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        verify(adminAccountService).updateActive(eq(memberId), any(AdminAccountActiveUpdateRequest.class));
+    }
+
+    @Test
+    void 관리자_계정_활성화_상태_수정은_ADMIN_권한만_허용한다() throws Exception {
+        // when
+        PreAuthorize preAuthorize = AdminAccountController.class
+                .getMethod("updateActive", Long.class, AdminAccountActiveUpdateRequest.class)
+                .getAnnotation(PreAuthorize.class);
+
+        // when, then
+        assertThat(preAuthorize).isNotNull();
+        assertThat(preAuthorize.value()).isEqualTo("hasAuthority('ROLE_ADMIN')");
+    }
+
+    @Test
+    void 관리자_계정_활성화_상태_수정_실패_active_누락() throws Exception {
+        // given
+        var request = new AdminAccountActiveUpdateRequest(null);
+
+        // when, then
+        mockMvc.perform(patch("/admin/accounts/{memberId}/active", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(GlobalErrorCode.METHOD_VALIDATION_FAILED.getCode()))
+                .andDo(print());
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
+++ b/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
@@ -8,13 +8,18 @@ import org.ject.support.admin.account.service.AdminAccountService;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.exception.GlobalErrorCode;
 import org.ject.support.common.exception.GlobalExceptionHandler;
+import org.ject.support.common.security.AuthenticatedMemberIdResolver;
+import org.ject.support.common.security.CustomUserDetails;
 import org.ject.support.domain.member.Role;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -45,7 +50,13 @@ class AdminAccountControllerTest extends UnitTestSupport {
         objectMapper = new ObjectMapper();
         mockMvc = MockMvcBuilders.standaloneSetup(adminAccountController)
                 .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new AuthenticatedMemberIdResolver())
                 .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -110,10 +121,13 @@ class AdminAccountControllerTest extends UnitTestSupport {
     @Test
     void 관리자_계정_활성화_상태_수정_성공() throws Exception {
         // given
+        var requesterId = 2L;
         var memberId = 1L;
         var request = new AdminAccountActiveUpdateRequest(false);
+        setAuthentication(requesterId);
 
-        doNothing().when(adminAccountService).updateActive(eq(memberId), any(AdminAccountActiveUpdateRequest.class));
+        doNothing().when(adminAccountService)
+                .updateActive(eq(requesterId), eq(memberId), any(AdminAccountActiveUpdateRequest.class));
 
         // when, then
         mockMvc.perform(patch("/admin/accounts/{memberId}/active", memberId)
@@ -122,14 +136,14 @@ class AdminAccountControllerTest extends UnitTestSupport {
                 .andExpect(status().isOk())
                 .andDo(print());
 
-        verify(adminAccountService).updateActive(eq(memberId), any(AdminAccountActiveUpdateRequest.class));
+        verify(adminAccountService).updateActive(eq(requesterId), eq(memberId), any(AdminAccountActiveUpdateRequest.class));
     }
 
     @Test
     void 관리자_계정_활성화_상태_수정은_ADMIN_권한만_허용한다() throws Exception {
         // when
         PreAuthorize preAuthorize = AdminAccountController.class
-                .getMethod("updateActive", Long.class, AdminAccountActiveUpdateRequest.class)
+                .getMethod("updateActive", Long.class, Long.class, AdminAccountActiveUpdateRequest.class)
                 .getAnnotation(PreAuthorize.class);
 
         // when, then
@@ -141,6 +155,7 @@ class AdminAccountControllerTest extends UnitTestSupport {
     void 관리자_계정_활성화_상태_수정_실패_active_누락() throws Exception {
         // given
         var request = new AdminAccountActiveUpdateRequest(null);
+        setAuthentication(2L);
 
         // when, then
         mockMvc.perform(patch("/admin/accounts/{memberId}/active", 1L)
@@ -149,6 +164,12 @@ class AdminAccountControllerTest extends UnitTestSupport {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(GlobalErrorCode.METHOD_VALIDATION_FAILED.getCode()))
                 .andDo(print());
+    }
+
+    private void setAuthentication(final Long memberId) {
+        CustomUserDetails userDetails = new CustomUserDetails("admin@ject.kr", memberId, Role.ADMIN);
+        var authentication = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
+++ b/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
@@ -201,6 +201,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
     @Test
     void 관리자_계정_비활성화_성공() {
         // given
+        var requesterId = 2L;
         var memberId = 1L;
         var request = new AdminAccountActiveUpdateRequest(false);
         var member = Member.builder()
@@ -214,7 +215,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
         given(adminMemberComponent.getRequiredBackofficeMemberById(memberId)).willReturn(member);
 
         // when
-        adminAccountService.updateActive(memberId, request);
+        adminAccountService.updateActive(requesterId, memberId, request);
 
         // then
         verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
@@ -224,6 +225,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
     @Test
     void 관리자_계정_활성화_성공() {
         // given
+        var requesterId = 2L;
         var memberId = 1L;
         var request = new AdminAccountActiveUpdateRequest(true);
         var member = Member.builder()
@@ -237,7 +239,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
         given(adminMemberComponent.getRequiredBackofficeMemberById(memberId)).willReturn(member);
 
         // when
-        adminAccountService.updateActive(memberId, request);
+        adminAccountService.updateActive(requesterId, memberId, request);
 
         // then
         verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
@@ -247,6 +249,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
     @Test
     void 관리자_계정_활성화_상태_수정_실패_존재하지_않는_관리자() {
         // given
+        var requesterId = 1L;
         var memberId = 999L;
         var request = new AdminAccountActiveUpdateRequest(false);
 
@@ -254,11 +257,27 @@ class AdminAccountServiceTest extends UnitTestSupport {
                 .willThrow(new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
 
         // when, then
-        assertThatThrownBy(() -> adminAccountService.updateActive(memberId, request))
+        assertThatThrownBy(() -> adminAccountService.updateActive(requesterId, memberId, request))
                 .isInstanceOf(AdminException.class)
                 .extracting(e -> ((AdminException) e).getErrorCode())
                 .isEqualTo(AdminErrorCode.NOT_FOUND_ADMIN);
 
         verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
+    }
+
+    @Test
+    void 관리자_계정_활성화_상태_수정_실패_본인_계정_비활성화() {
+        // given
+        var requesterId = 1L;
+        var memberId = 1L;
+        var request = new AdminAccountActiveUpdateRequest(false);
+
+        // when, then
+        assertThatThrownBy(() -> adminAccountService.updateActive(requesterId, memberId, request))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.CANNOT_LOCK_SELF);
+
+        verify(adminMemberComponent, never()).getRequiredBackofficeMemberById(memberId);
     }
 }

--- a/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
+++ b/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
@@ -1,10 +1,12 @@
 package org.ject.support.admin.account.service;
 
+import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
 import org.ject.support.admin.component.AdminMemberComponent;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
+import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
@@ -18,6 +20,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -195,4 +198,67 @@ class AdminAccountServiceTest extends UnitTestSupport {
         verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
     }
 
+    @Test
+    void 관리자_계정_비활성화_성공() {
+        // given
+        var memberId = 1L;
+        var request = new AdminAccountActiveUpdateRequest(false);
+        var member = Member.builder()
+                .id(memberId)
+                .email(TEST_EMAIL)
+                .role(Role.OPERATIONS)
+                .status(MemberStatus.ACTIVE)
+                .semesterId(1L)
+                .build();
+
+        given(adminMemberComponent.getRequiredBackofficeMemberById(memberId)).willReturn(member);
+
+        // when
+        adminAccountService.updateActive(memberId, request);
+
+        // then
+        verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
+        verify(adminMemberComponent).changeMemberStatus(eq(member), eq(MemberStatus.LOCKED));
+    }
+
+    @Test
+    void 관리자_계정_활성화_성공() {
+        // given
+        var memberId = 1L;
+        var request = new AdminAccountActiveUpdateRequest(true);
+        var member = Member.builder()
+                .id(memberId)
+                .email(TEST_EMAIL)
+                .role(Role.OPERATIONS)
+                .status(MemberStatus.LOCKED)
+                .semesterId(1L)
+                .build();
+
+        given(adminMemberComponent.getRequiredBackofficeMemberById(memberId)).willReturn(member);
+
+        // when
+        adminAccountService.updateActive(memberId, request);
+
+        // then
+        verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
+        verify(adminMemberComponent).changeMemberStatus(eq(member), eq(MemberStatus.ACTIVE));
+    }
+
+    @Test
+    void 관리자_계정_활성화_상태_수정_실패_존재하지_않는_관리자() {
+        // given
+        var memberId = 999L;
+        var request = new AdminAccountActiveUpdateRequest(false);
+
+        given(adminMemberComponent.getRequiredBackofficeMemberById(memberId))
+                .willThrow(new AdminException(AdminErrorCode.NOT_FOUND_ADMIN));
+
+        // when, then
+        assertThatThrownBy(() -> adminAccountService.updateActive(memberId, request))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.NOT_FOUND_ADMIN);
+
+        verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
+    }
 }

--- a/src/test/java/org/ject/support/common/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/org/ject/support/common/security/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,133 @@
+package org.ject.support.common.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import org.ject.support.admin.exception.AdminErrorCode;
+import org.ject.support.admin.exception.AdminException;
+import org.ject.support.common.security.CustomUserDetails;
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @InjectMocks
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private static final String ACCESS_TOKEN = "access-token";
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 백오피스_계정이_ACTIVE이면_인증을_처리한다() throws Exception {
+        // given
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var authentication = createAuthentication(1L, Role.ADMIN);
+        var member = createMember(1L, Role.ADMIN, MemberStatus.ACTIVE);
+
+        given(jwtTokenProvider.resolveAccessToken(request)).willReturn(ACCESS_TOKEN);
+        given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
+        given(jwtTokenProvider.getAuthenticationByToken(ACCESS_TOKEN)).willReturn(authentication);
+        given(memberRepository.findByIdAndRoleIn(1L, Role.backofficeRoles())).willReturn(Optional.of(member));
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isEqualTo(authentication);
+    }
+
+    @Test
+    void 백오피스_계정이_LOCKED이면_인증을_차단한다() throws Exception {
+        // given
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var authentication = createAuthentication(1L, Role.ADMIN);
+        var member = createMember(1L, Role.ADMIN, MemberStatus.LOCKED);
+
+        given(jwtTokenProvider.resolveAccessToken(request)).willReturn(ACCESS_TOKEN);
+        given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
+        given(jwtTokenProvider.getAuthenticationByToken(ACCESS_TOKEN)).willReturn(authentication);
+        given(memberRepository.findByIdAndRoleIn(1L, Role.backofficeRoles())).willReturn(Optional.of(member));
+
+        // when, then
+        assertThatThrownBy(() -> jwtAuthenticationFilter.doFilterInternal(request, response, filterChain))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.LOCKED_ADMIN);
+
+        verify(filterChain, never()).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void 백오피스_계정이_아니면_상태를_조회하지_않는다() throws Exception {
+        // given
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var authentication = createAuthentication(1L, Role.APPLY);
+
+        given(jwtTokenProvider.resolveAccessToken(request)).willReturn(ACCESS_TOKEN);
+        given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
+        given(jwtTokenProvider.getAuthenticationByToken(ACCESS_TOKEN)).willReturn(authentication);
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(memberRepository, never()).findByIdAndRoleIn(1L, Role.backofficeRoles());
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isEqualTo(authentication);
+    }
+
+    private UsernamePasswordAuthenticationToken createAuthentication(final Long memberId,
+                                                                    final Role role) {
+        CustomUserDetails userDetails = new CustomUserDetails("test@ject.kr", memberId, role);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    private Member createMember(final Long memberId,
+                                final Role role,
+                                final MemberStatus status) {
+        return Member.builder()
+                .id(memberId)
+                .email("test@ject.kr")
+                .role(role)
+                .status(status)
+                .semesterId(1L)
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #476 

## 📝 작업 내용

### 관리자 계정 활성화/비활성화 API 추가
- `AdminAccountController`에 관리자 계정 활성화 상태 수정 API를 추가
- `PATCH /admin/accounts/{memberId}/active`
- 요청 값으로 `active`를 받아 관리자 계정을 활성화 또는 비활성화
- 접근 권한은 `@PreAuthorize("hasAuthority('ROLE_ADMIN')")`로 제한
- 관리자 계정 활성화/비활성화 API에서 요청자 본인의 계정을 직접 비활성화할 수 없도록 가드를 추가했습니다.
- 잠긴 백오피스 계정의 access token 인증 차단

### Member 상태 변경 방식 개선
- `Member.status` 필드의 `@Setter`를 제거했습니다.
- `MemberEditor`에 `status`를 추가해 `Member.edit()` 경유로 상태가 변경되도록 수정했습니다.
- `AdminMemberComponent.changeMemberStatus()`도 `setStatus()` 대신 `member.edit(member.toEditor().status(status).build())` 흐름을 사용하도록 변경

### Backlog
refresh token 무효화 및 토큰 revoke 정책
이번 PR에서는 LOCKED 처리된 백오피스 계정의 access token 인증 차단까지만 처리했습니다.
현재 구조는 JWT를 서버에서 별도로 저장하지 않는 stateless 방식이므로, 이미 발급된 refresh token 자체를 서버 측에서 즉시 폐기하는 처리는 포함하지 않았습니다.

추후 별도 작업으로 다음 항목에 대해 검토가 필요 합니다.
 - LOCKED 계정의 refresh token 재발급 차단
 - Redis 기반 tokenRevokedAt 관리
 - 사용자별 token version 전략 도입
 - 계정 비활성화 시 access token / refresh token 전체 revoke 정책 설계

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 계정의 활성화/비활성화 상태를 업데이트할 수 있는 새로운 API 엔드포인트 추가

* **테스트**
  * 새로운 엔드포인트의 성공 케이스, 인증, 유효성 검증 관련 테스트 추가
  * 활성화/비활성화 기능에 대한 서비스 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->