### PR TITLE
feat:관리자 계정 수정하기 구현

### DIFF
--- a/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
+++ b/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
+import org.ject.support.admin.account.dto.AdminAccountUpdateRequest;
 import org.ject.support.admin.account.service.AdminAccountService;
 import org.ject.support.common.security.AuthPrincipal;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -33,6 +34,17 @@ public class AdminAccountController {
             description = "관리자 계정 유형의 계정을 생성합니다.")
     public void createAccount(@RequestBody @Valid final AdminAccountCreateRequest request) {
         adminAccountService.createAccount(request);
+    }
+
+    @PatchMapping("/{memberId}")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    @Operation(
+            summary = "관리자 계정 정보 수정",
+            description = "관리자 계정의 이메일, 이름, 권한, 활성화 상태를 수정합니다.")
+    public void updateAccount(@Parameter(hidden = true) @AuthPrincipal final Long requesterId,
+                              @PathVariable final Long memberId,
+                              @RequestBody @Valid final AdminAccountUpdateRequest request) {
+        adminAccountService.updateAccount(requesterId, memberId, request);
     }
 
     @PatchMapping("/{memberId}/role")

--- a/src/main/java/org/ject/support/admin/account/dto/AdminAccountUpdateRequest.java
+++ b/src/main/java/org/ject/support/admin/account/dto/AdminAccountUpdateRequest.java
@@ -1,0 +1,40 @@
+package org.ject.support.admin.account.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.ject.support.domain.member.Role;
+
+@Schema(description = "관리자 계정 정보 수정 요청")
+public record AdminAccountUpdateRequest(
+        @Schema(description = "관리자 계정 이메일", example = "admin@ject.kr", maxLength = 30)
+        @NotBlank
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Size(max = 30, message = "이메일 길이는 최대 30자리 까지 가능합니다.")
+        String email,
+
+        @Schema(description = "관리자 이름", example = "김젝트", maxLength = 20, nullable = true)
+        @Size(max = 20, message = "이름 길이는 최대 20자리 까지 가능합니다.")
+        String name,
+
+        @Schema(
+                description = "관리자 계정 유형",
+                example = "OPERATIONS",
+                allowableValues = {"ADMIN", "OPERATIONS", "SUPPORTER"})
+        @NotNull
+        Role role,
+
+        @Schema(description = "관리자 계정 활성화 여부", example = "true")
+        @NotNull
+        Boolean active
+) {
+
+    public String normalizeName() {
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        return name;
+    }
+}

--- a/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
+++ b/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
+import org.ject.support.admin.account.dto.AdminAccountUpdateRequest;
 import org.ject.support.admin.component.AdminMemberComponent;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
@@ -32,6 +33,27 @@ public class AdminAccountService {
 
         final String encodedPassword = passwordEncoder.encode(request.password());
         memberRepository.save(request.toEntity(encodedPassword));
+    }
+
+    @Transactional
+    public void updateAccount(final Long requesterId,
+                              final Long memberId,
+                              final AdminAccountUpdateRequest request) {
+        validateBackofficeRole(request.role());
+        validateNotLockingSelf(requesterId, memberId, request.active());
+
+        final Member member = adminMemberComponent.getRequiredBackofficeMemberById(memberId);
+        validateEmailUniqueness(memberId, request.email());
+
+        final MemberStatus status = request.active() ? MemberStatus.ACTIVE : MemberStatus.LOCKED;
+        final MemberEditor editor = member.toEditor()
+                .email(request.email())
+                .name(request.normalizeName())
+                .role(request.role())
+                .status(status)
+                .build();
+
+        member.edit(editor);
     }
 
     @Transactional
@@ -77,5 +99,13 @@ public class AdminAccountService {
         if (memberRepository.existsByEmail(request.email())) {
             throw new AdminException(AdminErrorCode.DUPLICATE_ADMIN_EMAIL);
         }
+    }
+
+    private void validateEmailUniqueness(final Long memberId, final String email) {
+        memberRepository.findByEmail(email)
+                .filter(member -> !member.getId().equals(memberId))
+                .ifPresent(member -> {
+                    throw new AdminException(AdminErrorCode.DUPLICATE_ADMIN_EMAIL);
+                });
     }
 }

--- a/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
+++ b/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
@@ -41,6 +41,7 @@ public class AdminAccountService {
                               final AdminAccountUpdateRequest request) {
         validateBackofficeRole(request.role());
         validateNotLockingSelf(requesterId, memberId, request.active());
+        validateNotChangingOwnAdminRole(requesterId, memberId, request.role());
 
         final Member member = adminMemberComponent.getRequiredBackofficeMemberById(memberId);
         validateEmailUniqueness(memberId, request.email());
@@ -86,6 +87,14 @@ public class AdminAccountService {
                                         final boolean active) {
         if (!active && requesterId.equals(memberId)) {
             throw new AdminException(AdminErrorCode.CANNOT_LOCK_SELF);
+        }
+    }
+
+    private void validateNotChangingOwnAdminRole(final Long requesterId,
+                                                final Long memberId,
+                                                final Role role) {
+        if (requesterId.equals(memberId) && role != Role.ADMIN) {
+            throw new AdminException(AdminErrorCode.CANNOT_CHANGE_OWN_ADMIN_ROLE);
         }
     }
 

--- a/src/main/java/org/ject/support/admin/exception/AdminErrorCode.java
+++ b/src/main/java/org/ject/support/admin/exception/AdminErrorCode.java
@@ -14,7 +14,8 @@ public enum AdminErrorCode implements ErrorCode {
     LOGIN_ATTEMPT_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "ADMIN-7", "로그인 시도가 제한되었습니다. 잠시 후 다시 시도해주세요."),
     DUPLICATE_ADMIN_EMAIL(HttpStatus.CONFLICT, "ADMIN-8", "이미 사용중인 이메일 입니다."),
     INVALID_ADMIN_ACCOUNT_ROLE(HttpStatus.BAD_REQUEST, "ADMIN-9", "관리자 계정 유형만 선택할 수 있습니다."),
-    CANNOT_LOCK_SELF(HttpStatus.BAD_REQUEST, "ADMIN-10", "본인 계정은 비활성화할 수 없습니다.");
+    CANNOT_LOCK_SELF(HttpStatus.BAD_REQUEST, "ADMIN-10", "본인 계정은 비활성화할 수 없습니다."),
+    CANNOT_CHANGE_OWN_ADMIN_ROLE(HttpStatus.BAD_REQUEST, "ADMIN-11", "본인 계정의 관리자 권한은 변경할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
+++ b/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
+import org.ject.support.admin.account.dto.AdminAccountUpdateRequest;
 import org.ject.support.admin.account.service.AdminAccountService;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.exception.GlobalErrorCode;
@@ -86,6 +87,86 @@ class AdminAccountControllerTest extends UnitTestSupport {
         // when, then
         assertThat(preAuthorize).isNotNull();
         assertThat(preAuthorize.value()).isEqualTo("hasAuthority('ROLE_ADMIN')");
+    }
+
+    @Test
+    void 관리자_계정_정보_수정_성공() throws Exception {
+        // given
+        var requesterId = 2L;
+        var memberId = 1L;
+        var request = new AdminAccountUpdateRequest("updated@ject.kr", "이젝트", Role.SUPPORTER, false);
+        setAuthentication(requesterId);
+
+        doNothing().when(adminAccountService)
+                .updateAccount(eq(requesterId), eq(memberId), any(AdminAccountUpdateRequest.class));
+
+        // when, then
+        mockMvc.perform(patch("/admin/accounts/{memberId}", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        verify(adminAccountService)
+                .updateAccount(eq(requesterId), eq(memberId), any(AdminAccountUpdateRequest.class));
+    }
+
+    @Test
+    void 관리자_계정_정보_수정은_ADMIN_권한만_허용한다() throws Exception {
+        // when
+        PreAuthorize preAuthorize = AdminAccountController.class
+                .getMethod("updateAccount", Long.class, Long.class, AdminAccountUpdateRequest.class)
+                .getAnnotation(PreAuthorize.class);
+
+        // when, then
+        assertThat(preAuthorize).isNotNull();
+        assertThat(preAuthorize.value()).isEqualTo("hasAuthority('ROLE_ADMIN')");
+    }
+
+    @Test
+    void 관리자_계정_정보_수정_실패_올바르지_않은_이메일_형식() throws Exception {
+        // given
+        var request = new AdminAccountUpdateRequest("invalid-email", "김젝트", Role.OPERATIONS, true);
+        setAuthentication(2L);
+
+        // when, then
+        mockMvc.perform(patch("/admin/accounts/{memberId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(GlobalErrorCode.METHOD_VALIDATION_FAILED.getCode()))
+                .andExpect(jsonPath("$.messages[0]").value("올바른 이메일 형식이 아닙니다."))
+                .andDo(print());
+    }
+
+    @Test
+    void 관리자_계정_정보_수정_실패_role_누락() throws Exception {
+        // given
+        var request = new AdminAccountUpdateRequest("admin@ject.kr", "김젝트", null, true);
+        setAuthentication(2L);
+
+        // when, then
+        mockMvc.perform(patch("/admin/accounts/{memberId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(GlobalErrorCode.METHOD_VALIDATION_FAILED.getCode()))
+                .andDo(print());
+    }
+
+    @Test
+    void 관리자_계정_정보_수정_실패_active_누락() throws Exception {
+        // given
+        var request = new AdminAccountUpdateRequest("admin@ject.kr", "김젝트", Role.OPERATIONS, null);
+        setAuthentication(2L);
+
+        // when, then
+        mockMvc.perform(patch("/admin/accounts/{memberId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(GlobalErrorCode.METHOD_VALIDATION_FAILED.getCode()))
+                .andDo(print());
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
+++ b/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
@@ -3,6 +3,7 @@ package org.ject.support.admin.account.service;
 import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
+import org.ject.support.admin.account.dto.AdminAccountUpdateRequest;
 import org.ject.support.admin.component.AdminMemberComponent;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
@@ -16,6 +17,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -136,6 +139,132 @@ class AdminAccountServiceTest extends UnitTestSupport {
         verify(memberRepository, never()).existsByEmail(anyString());
         verify(passwordEncoder, never()).encode(anyString());
         verify(memberRepository, never()).save(org.mockito.ArgumentMatchers.any(Member.class));
+    }
+
+    @Test
+    void 관리자_계정_정보_수정_성공() {
+        // given
+        var requesterId = 2L;
+        var memberId = 1L;
+        var request = new AdminAccountUpdateRequest("updated@ject.kr", "이젝트", Role.SUPPORTER, false);
+        var member = Member.builder()
+                .id(memberId)
+                .email(TEST_EMAIL)
+                .name("김젝트")
+                .phoneNumber("01012345678")
+                .role(Role.OPERATIONS)
+                .status(MemberStatus.ACTIVE)
+                .semesterId(1L)
+                .build();
+
+        given(adminMemberComponent.getRequiredBackofficeMemberById(memberId)).willReturn(member);
+        given(memberRepository.findByEmail("updated@ject.kr")).willReturn(Optional.empty());
+
+        // when
+        adminAccountService.updateAccount(requesterId, memberId, request);
+
+        // then
+        verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
+        verify(memberRepository).findByEmail("updated@ject.kr");
+        assertThat(member.getEmail()).isEqualTo("updated@ject.kr");
+        assertThat(member.getName()).isEqualTo("이젝트");
+        assertThat(member.getRole()).isEqualTo(Role.SUPPORTER);
+        assertThat(member.getStatus()).isEqualTo(MemberStatus.LOCKED);
+        assertThat(member.getPhoneNumber()).isEqualTo("01012345678");
+        assertThat(member.getSemesterId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 관리자_계정_정보_수정_시_빈_이름은_null로_저장한다() {
+        // given
+        var requesterId = 2L;
+        var memberId = 1L;
+        var request = new AdminAccountUpdateRequest(TEST_EMAIL, "   ", Role.ADMIN, true);
+        var member = Member.builder()
+                .id(memberId)
+                .email(TEST_EMAIL)
+                .name("김젝트")
+                .role(Role.OPERATIONS)
+                .status(MemberStatus.ACTIVE)
+                .semesterId(1L)
+                .build();
+
+        given(adminMemberComponent.getRequiredBackofficeMemberById(memberId)).willReturn(member);
+        given(memberRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(member));
+
+        // when
+        adminAccountService.updateAccount(requesterId, memberId, request);
+
+        // then
+        assertThat(member.getName()).isNull();
+        assertThat(member.getEmail()).isEqualTo(TEST_EMAIL);
+        assertThat(member.getRole()).isEqualTo(Role.ADMIN);
+        assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+    }
+
+    @Test
+    void 관리자_계정_정보_수정_실패_이미_사용중인_이메일() {
+        // given
+        var requesterId = 2L;
+        var memberId = 1L;
+        var request = new AdminAccountUpdateRequest("duplicated@ject.kr", "김젝트", Role.ADMIN, true);
+        var member = Member.builder()
+                .id(memberId)
+                .email(TEST_EMAIL)
+                .role(Role.OPERATIONS)
+                .status(MemberStatus.ACTIVE)
+                .semesterId(1L)
+                .build();
+        var duplicatedMember = Member.builder()
+                .id(3L)
+                .email("duplicated@ject.kr")
+                .role(Role.SUPPORTER)
+                .status(MemberStatus.ACTIVE)
+                .semesterId(1L)
+                .build();
+
+        given(adminMemberComponent.getRequiredBackofficeMemberById(memberId)).willReturn(member);
+        given(memberRepository.findByEmail("duplicated@ject.kr")).willReturn(Optional.of(duplicatedMember));
+
+        // when, then
+        assertThatThrownBy(() -> adminAccountService.updateAccount(requesterId, memberId, request))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.DUPLICATE_ADMIN_EMAIL);
+
+        assertThat(member.getEmail()).isEqualTo(TEST_EMAIL);
+        assertThat(member.getRole()).isEqualTo(Role.OPERATIONS);
+        assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+    }
+
+    @Test
+    void 관리자_계정_정보_수정_실패_관리자_계정_유형이_아닌_role() {
+        // given
+        var request = new AdminAccountUpdateRequest(TEST_EMAIL, "김젝트", Role.SEMESTER, true);
+
+        // when, then
+        assertThatThrownBy(() -> adminAccountService.updateAccount(2L, 1L, request))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.INVALID_ADMIN_ACCOUNT_ROLE);
+
+        verify(adminMemberComponent, never()).getRequiredBackofficeMemberById(org.mockito.ArgumentMatchers.anyLong());
+        verify(memberRepository, never()).findByEmail(anyString());
+    }
+
+    @Test
+    void 관리자_계정_정보_수정_실패_본인_계정_비활성화() {
+        // given
+        var request = new AdminAccountUpdateRequest(TEST_EMAIL, "김젝트", Role.ADMIN, false);
+
+        // when, then
+        assertThatThrownBy(() -> adminAccountService.updateAccount(1L, 1L, request))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.CANNOT_LOCK_SELF);
+
+        verify(adminMemberComponent, never()).getRequiredBackofficeMemberById(org.mockito.ArgumentMatchers.anyLong());
+        verify(memberRepository, never()).findByEmail(anyString());
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
+++ b/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
@@ -268,6 +268,21 @@ class AdminAccountServiceTest extends UnitTestSupport {
     }
 
     @Test
+    void 관리자_계정_정보_수정_실패_본인_관리자_권한_제거() {
+        // given
+        var request = new AdminAccountUpdateRequest(TEST_EMAIL, "김젝트", Role.OPERATIONS, true);
+
+        // when, then
+        assertThatThrownBy(() -> adminAccountService.updateAccount(1L, 1L, request))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.CANNOT_CHANGE_OWN_ADMIN_ROLE);
+
+        verify(adminMemberComponent, never()).getRequiredBackofficeMemberById(org.mockito.ArgumentMatchers.anyLong());
+        verify(memberRepository, never()).findByEmail(anyString());
+    }
+
+    @Test
     void 관리자_계정_권한_수정_성공() {
         // given
         var memberId = 1L;


### PR DESCRIPTION
## #️⃣연관된 이슈

close #478 

## 📝 작업 내용

### 관리자 계정 정보 수정 API 추가
 - PATCH /admin/accounts/{memberId} 엔드포인트 추가
 - ROLE_ADMIN 권한을 가진 사용자만 호출 가능
 - 요청자 ID를 받아 본인 계정 비활성화 여부를 검증
 - 본인 계정을 OPERATIONS/SUPPORTER로 변경 차단

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자를 위한 계정 업데이트 기능 추가: 이메일, 이름, 역할, 활성 상태를 수정할 수 있습니다.
  * 관리자 권한 인증으로 보호된 계정 관리 엔드포인트 제공됩니다.
  * 이메일 중복 및 역할 검증을 포함한 데이터 무결성 보장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->