### PR TITLE
[FEAT] 모집 공고 타입 기본 모델 확장

### DIFF
--- a/src/main/java/org/ject/support/domain/recruit/domain/Recruit.java
+++ b/src/main/java/org/ject/support/domain/recruit/domain/Recruit.java
@@ -58,6 +58,11 @@ public class Recruit extends BaseTimeEntity {
     @Builder.Default
     private RecruitType recruitType = RecruitType.REGULAR;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recruit_type_detail", columnDefinition = "varchar(45)", nullable = false)
+    @Builder.Default
+    private RecruitTypeDetail recruitTypeDetail = RecruitTypeDetail.REGULAR;
+
     @OneToMany(mappedBy = "recruit", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<Question> questions = new ArrayList<>();

--- a/src/main/java/org/ject/support/domain/recruit/domain/RecruitType.java
+++ b/src/main/java/org/ject/support/domain/recruit/domain/RecruitType.java
@@ -5,6 +5,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum RecruitType {
+    SEMESTER("정규 기수 모집"),
+    MAKERS("메이커스 모집"),
+    SUPPORTERS("운영 서포터즈 모집"),
     REGULAR("정규 모집"),
     REGULAR_WAITLIST("정규 모집 - 추가합격"),
     BACKFILL("기존 기수 모집"),

--- a/src/main/java/org/ject/support/domain/recruit/domain/RecruitTypeDetail.java
+++ b/src/main/java/org/ject/support/domain/recruit/domain/RecruitTypeDetail.java
@@ -1,0 +1,15 @@
+package org.ject.support.domain.recruit.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RecruitTypeDetail {
+    REGULAR("정규 모집"),
+    NEW("신규 모집"),
+    REFILL("충원 모집"),
+    ;
+
+    private final String description;
+}

--- a/src/main/resources/db/migration/V26__add_recruit_type_detail_to_recruit.sql
+++ b/src/main/resources/db/migration/V26__add_recruit_type_detail_to_recruit.sql
@@ -1,0 +1,12 @@
+ALTER TABLE recruit
+    ADD COLUMN recruit_type_detail VARCHAR(45) NULL;
+
+UPDATE recruit
+SET recruit_type_detail = CASE
+    WHEN recruit_type = 'BACKFILL' THEN 'REFILL'
+    ELSE 'REGULAR'
+END
+WHERE recruit_type_detail IS NULL;
+
+ALTER TABLE recruit
+    MODIFY COLUMN recruit_type_detail VARCHAR(45) NOT NULL;

--- a/src/test/java/org/ject/support/domain/recruit/domain/RecruitTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/domain/RecruitTest.java
@@ -29,6 +29,21 @@ class RecruitTest {
     }
 
     @Test
+    @DisplayName("모집 사유는 기본값으로 정규 모집을 사용한다")
+    void default_recruit_type_detail_is_regular() {
+        // given
+        Recruit recruit = Recruit.builder()
+                .semester(Semester.builder().id(1L).name("1기").isRecruiting(true).build())
+                .jobFamily(JobFamily.BE)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        // then
+        assertThat(recruit.getRecruitTypeDetail()).isEqualTo(RecruitTypeDetail.REGULAR);
+    }
+
+    @Test
     @DisplayName("is invalid question semesterId")
     void is_invalid_question_id() {
         // given

--- a/src/test/java/org/ject/support/domain/recruit/domain/RecruitTypeTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/domain/RecruitTypeTest.java
@@ -1,0 +1,24 @@
+package org.ject.support.domain.recruit.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecruitTypeTest {
+
+    @Test
+    @DisplayName("신규 모집 유형과 기존 모집 유형을 함께 제공한다")
+    void provide_new_recruit_types_with_legacy_types() {
+        assertThat(RecruitType.values())
+                .contains(
+                        RecruitType.SEMESTER,
+                        RecruitType.MAKERS,
+                        RecruitType.SUPPORTERS,
+                        RecruitType.REGULAR,
+                        RecruitType.REGULAR_WAITLIST,
+                        RecruitType.BACKFILL,
+                        RecruitType.MANUAL
+                );
+    }
+}

--- a/src/test/java/org/ject/support/domain/recruit/domain/RecruitTypeTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/domain/RecruitTypeTest.java
@@ -21,4 +21,15 @@ class RecruitTypeTest {
                         RecruitType.MANUAL
                 );
     }
+
+    @Test
+    @DisplayName("모집 사유 값을 제공한다")
+    void provide_recruit_type_detail_values() {
+        assertThat(RecruitTypeDetail.values())
+                .contains(
+                        RecruitTypeDetail.REGULAR,
+                        RecruitTypeDetail.NEW,
+                        RecruitTypeDetail.REFILL
+                );
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #529
Parent: #427

## 📝 작업 내용

- `RecruitType`에 신규 모집 유형 `SEMESTER`, `MAKERS`, `SUPPORTERS`를 추가했습니다.
- 기존 모집 유형 `REGULAR`, `REGULAR_WAITLIST`, `BACKFILL`, `MANUAL`은 하위 호환을 위해 유지했습니다.
- `RecruitTypeDetail`에 모집 사유/회차 성격 `REGULAR`, `NEW`, `REFILL`을 추가했습니다.
- `Recruit`에 `recruitTypeDetail` 필드를 추가하고 기본값을 `REGULAR`로 설정했습니다.
- `recruit_type_detail` 컬럼 추가 migration을 작성하고 기존 데이터는 `BACKFILL`만 `REFILL`, 나머지는 `REGULAR`로 채우도록 했습니다.
- enum 값과 `Recruit` 기본값을 검증하는 도메인 테스트를 추가했습니다.

## 🙏 리뷰 요구사항 (선택)

- `RecruitType`과 `RecruitTypeDetail`의 역할 분리가 적절한지 확인 부탁드립니다.
- 기존 데이터 backfill 정책이 현재 단계의 호환성 기준에 맞는지 확인 부탁드립니다.
- 이번 PR은 기본 모델 확장까지만 포함하며, 허용 조합 validation과 API 변경은 후속 PR에서 처리합니다.

## 검증

- 성공: `./gradlew test --tests 'org.ject.support.domain.recruit.domain.RecruitTypeTest' --tests 'org.ject.support.domain.recruit.domain.RecruitTest' -x jacocoTestCoverageVerification --rerun-tasks`
- 성공: `./gradlew test --tests 'org.ject.support.domain.recruit.repository.RecruitRepositoryTest' -x jacocoTestCoverageVerification --rerun-tasks`
- 참고: 전체 테스트는 이전 확인에서 로컬 Docker/Testcontainers Redis 초기화 실패와 기존 admin query 정렬 assertion 실패가 있어 별도 이슈로 남아 있습니다.