### PR TITLE
fix:관리자 계정 수정 - 이메일 수정 제외

### DIFF
--- a/src/main/java/org/ject/support/admin/account/dto/AdminAccountUpdateRequest.java
+++ b/src/main/java/org/ject/support/admin/account/dto/AdminAccountUpdateRequest.java
@@ -1,20 +1,12 @@
 package org.ject.support.admin.account.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.ject.support.domain.member.Role;
 
 @Schema(description = "관리자 계정 정보 수정 요청")
 public record AdminAccountUpdateRequest(
-        @Schema(description = "관리자 계정 이메일", example = "admin@ject.kr", maxLength = 30)
-        @NotBlank
-        @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Size(max = 30, message = "이메일 길이는 최대 30자리 까지 가능합니다.")
-        String email,
-
         @Schema(description = "관리자 이름", example = "김젝트", maxLength = 20, nullable = true)
         @Size(max = 20, message = "이름 길이는 최대 20자리 까지 가능합니다.")
         String name,

--- a/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
+++ b/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
@@ -44,11 +44,9 @@ public class AdminAccountService {
         validateNotChangingOwnAdminRole(requesterId, memberId, request.role());
 
         final Member member = adminMemberComponent.getRequiredBackofficeMemberById(memberId);
-        validateEmailUniqueness(memberId, request.email());
 
         final MemberStatus status = request.active() ? MemberStatus.ACTIVE : MemberStatus.LOCKED;
         final MemberEditor editor = member.toEditor()
-                .email(request.email())
                 .name(request.normalizeName())
                 .role(request.role())
                 .status(status)
@@ -110,11 +108,4 @@ public class AdminAccountService {
         }
     }
 
-    private void validateEmailUniqueness(final Long memberId, final String email) {
-        memberRepository.findByEmail(email)
-                .filter(member -> !member.getId().equals(memberId))
-                .ifPresent(member -> {
-                    throw new AdminException(AdminErrorCode.DUPLICATE_ADMIN_EMAIL);
-                });
-    }
 }

--- a/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
+++ b/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
@@ -94,7 +94,7 @@ class AdminAccountControllerTest extends UnitTestSupport {
         // given
         var requesterId = 2L;
         var memberId = 1L;
-        var request = new AdminAccountUpdateRequest("updated@ject.kr", "이젝트", Role.SUPPORTER, false);
+        var request = new AdminAccountUpdateRequest("이젝트", Role.SUPPORTER, false);
         setAuthentication(requesterId);
 
         doNothing().when(adminAccountService)
@@ -124,25 +124,9 @@ class AdminAccountControllerTest extends UnitTestSupport {
     }
 
     @Test
-    void 관리자_계정_정보_수정_실패_올바르지_않은_이메일_형식() throws Exception {
-        // given
-        var request = new AdminAccountUpdateRequest("invalid-email", "김젝트", Role.OPERATIONS, true);
-        setAuthentication(2L);
-
-        // when, then
-        mockMvc.perform(patch("/admin/accounts/{memberId}", 1L)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(GlobalErrorCode.METHOD_VALIDATION_FAILED.getCode()))
-                .andExpect(jsonPath("$.messages[0]").value("올바른 이메일 형식이 아닙니다."))
-                .andDo(print());
-    }
-
-    @Test
     void 관리자_계정_정보_수정_실패_role_누락() throws Exception {
         // given
-        var request = new AdminAccountUpdateRequest("admin@ject.kr", "김젝트", null, true);
+        var request = new AdminAccountUpdateRequest("김젝트", null, true);
         setAuthentication(2L);
 
         // when, then
@@ -150,14 +134,13 @@ class AdminAccountControllerTest extends UnitTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(GlobalErrorCode.METHOD_VALIDATION_FAILED.getCode()))
                 .andDo(print());
     }
 
     @Test
     void 관리자_계정_정보_수정_실패_active_누락() throws Exception {
         // given
-        var request = new AdminAccountUpdateRequest("admin@ject.kr", "김젝트", Role.OPERATIONS, null);
+        var request = new AdminAccountUpdateRequest("김젝트", Role.OPERATIONS, null);
         setAuthentication(2L);
 
         // when, then
@@ -165,7 +148,6 @@ class AdminAccountControllerTest extends UnitTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(GlobalErrorCode.METHOD_VALIDATION_FAILED.getCode()))
                 .andDo(print());
     }
 

--- a/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
+++ b/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
@@ -18,8 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -146,7 +144,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
         // given
         var requesterId = 2L;
         var memberId = 1L;
-        var request = new AdminAccountUpdateRequest("updated@ject.kr", "이젝트", Role.SUPPORTER, false);
+        var request = new AdminAccountUpdateRequest("이젝트", Role.SUPPORTER, false);
         var member = Member.builder()
                 .id(memberId)
                 .email(TEST_EMAIL)
@@ -158,15 +156,14 @@ class AdminAccountServiceTest extends UnitTestSupport {
                 .build();
 
         given(adminMemberComponent.getRequiredBackofficeMemberById(memberId)).willReturn(member);
-        given(memberRepository.findByEmail("updated@ject.kr")).willReturn(Optional.empty());
 
         // when
         adminAccountService.updateAccount(requesterId, memberId, request);
 
         // then
         verify(adminMemberComponent).getRequiredBackofficeMemberById(memberId);
-        verify(memberRepository).findByEmail("updated@ject.kr");
-        assertThat(member.getEmail()).isEqualTo("updated@ject.kr");
+        verify(memberRepository, never()).findByEmail(anyString());
+        assertThat(member.getEmail()).isEqualTo(TEST_EMAIL);
         assertThat(member.getName()).isEqualTo("이젝트");
         assertThat(member.getRole()).isEqualTo(Role.SUPPORTER);
         assertThat(member.getStatus()).isEqualTo(MemberStatus.LOCKED);
@@ -179,7 +176,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
         // given
         var requesterId = 2L;
         var memberId = 1L;
-        var request = new AdminAccountUpdateRequest(TEST_EMAIL, "   ", Role.ADMIN, true);
+        var request = new AdminAccountUpdateRequest("   ", Role.ADMIN, true);
         var member = Member.builder()
                 .id(memberId)
                 .email(TEST_EMAIL)
@@ -190,7 +187,6 @@ class AdminAccountServiceTest extends UnitTestSupport {
                 .build();
 
         given(adminMemberComponent.getRequiredBackofficeMemberById(memberId)).willReturn(member);
-        given(memberRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(member));
 
         // when
         adminAccountService.updateAccount(requesterId, memberId, request);
@@ -203,44 +199,9 @@ class AdminAccountServiceTest extends UnitTestSupport {
     }
 
     @Test
-    void 관리자_계정_정보_수정_실패_이미_사용중인_이메일() {
-        // given
-        var requesterId = 2L;
-        var memberId = 1L;
-        var request = new AdminAccountUpdateRequest("duplicated@ject.kr", "김젝트", Role.ADMIN, true);
-        var member = Member.builder()
-                .id(memberId)
-                .email(TEST_EMAIL)
-                .role(Role.OPERATIONS)
-                .status(MemberStatus.ACTIVE)
-                .semesterId(1L)
-                .build();
-        var duplicatedMember = Member.builder()
-                .id(3L)
-                .email("duplicated@ject.kr")
-                .role(Role.SUPPORTER)
-                .status(MemberStatus.ACTIVE)
-                .semesterId(1L)
-                .build();
-
-        given(adminMemberComponent.getRequiredBackofficeMemberById(memberId)).willReturn(member);
-        given(memberRepository.findByEmail("duplicated@ject.kr")).willReturn(Optional.of(duplicatedMember));
-
-        // when, then
-        assertThatThrownBy(() -> adminAccountService.updateAccount(requesterId, memberId, request))
-                .isInstanceOf(AdminException.class)
-                .extracting(e -> ((AdminException) e).getErrorCode())
-                .isEqualTo(AdminErrorCode.DUPLICATE_ADMIN_EMAIL);
-
-        assertThat(member.getEmail()).isEqualTo(TEST_EMAIL);
-        assertThat(member.getRole()).isEqualTo(Role.OPERATIONS);
-        assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
-    }
-
-    @Test
     void 관리자_계정_정보_수정_실패_관리자_계정_유형이_아닌_role() {
         // given
-        var request = new AdminAccountUpdateRequest(TEST_EMAIL, "김젝트", Role.SEMESTER, true);
+        var request = new AdminAccountUpdateRequest("김젝트", Role.SEMESTER, true);
 
         // when, then
         assertThatThrownBy(() -> adminAccountService.updateAccount(2L, 1L, request))
@@ -255,7 +216,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
     @Test
     void 관리자_계정_정보_수정_실패_본인_계정_비활성화() {
         // given
-        var request = new AdminAccountUpdateRequest(TEST_EMAIL, "김젝트", Role.ADMIN, false);
+        var request = new AdminAccountUpdateRequest("김젝트", Role.ADMIN, false);
 
         // when, then
         assertThatThrownBy(() -> adminAccountService.updateAccount(1L, 1L, request))
@@ -270,7 +231,7 @@ class AdminAccountServiceTest extends UnitTestSupport {
     @Test
     void 관리자_계정_정보_수정_실패_본인_관리자_권한_제거() {
         // given
-        var request = new AdminAccountUpdateRequest(TEST_EMAIL, "김젝트", Role.OPERATIONS, true);
+        var request = new AdminAccountUpdateRequest("김젝트", Role.OPERATIONS, true);
 
         // when, then
         assertThatThrownBy(() -> adminAccountService.updateAccount(1L, 1L, request))


### PR DESCRIPTION
## #️⃣연관된 이슈

close #532 

## 📝 작업 내용

관리자 계정 관리 정책 변경에 따라 이메일은 제외했습니다.

### 관리자 계정 관리 - 계정 수정하기
 - 이메일 수정 제외
 - 관련 코드 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경사항**
  * 관리자 계정 업데이트 시 이메일 필드 편집 기능이 제거되었습니다. 이메일은 이제 계정 생성 시에만 설정할 수 있습니다.
  * 계정 업데이트 과정에서 이메일 중복 검증이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->