### PR TITLE
feat: 모집 공고 API 리팩토링

### DIFF
--- a/src/main/java/org/ject/support/domain/recruit/controller/QuestionApiSpec.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/QuestionApiSpec.java
@@ -11,6 +11,7 @@ public interface QuestionApiSpec {
 
     @Operation(
             summary = "지원서 문항 목록 조회",
-            description = "현재 모집 중인 지원서에 한해, 전달된 직군에 해당하는 문항을 모두 조회합니다.")
-    QuestionResponses findQuestions(@RequestParam JobFamily jobFamily);
+            description = "현재 모집 중인 지원서에 한해, 전달된 모집 공고 또는 직군에 해당하는 문항을 모두 조회합니다.")
+    QuestionResponses findQuestions(@RequestParam(required = false) JobFamily jobFamily,
+                                    @RequestParam(required = false) Long recruitId);
 }

--- a/src/main/java/org/ject/support/domain/recruit/controller/QuestionApiSpec.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/QuestionApiSpec.java
@@ -2,7 +2,6 @@ package org.ject.support.domain.recruit.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.dto.QuestionResponses;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -11,7 +10,6 @@ public interface QuestionApiSpec {
 
     @Operation(
             summary = "지원서 문항 목록 조회",
-            description = "현재 모집 중인 지원서에 한해, 전달된 모집 공고 또는 직군에 해당하는 문항을 모두 조회합니다.")
-    QuestionResponses findQuestions(@RequestParam(required = false) JobFamily jobFamily,
-                                    @RequestParam(required = false) Long recruitId);
+            description = "현재 모집 중인 지원서에 한해, 전달된 모집 공고에 해당하는 문항을 모두 조회합니다.")
+    QuestionResponses findQuestions(@RequestParam Long recruitId);
 }

--- a/src/main/java/org/ject/support/domain/recruit/controller/QuestionController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/QuestionController.java
@@ -1,9 +1,6 @@
 package org.ject.support.domain.recruit.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.ject.support.common.exception.GlobalErrorCode;
-import org.ject.support.common.exception.GlobalException;
-import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.dto.QuestionResponses;
 import org.ject.support.domain.recruit.service.QuestionService;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -22,15 +19,7 @@ public class QuestionController implements QuestionApiSpec {
     @Override
     @GetMapping
     @PreAuthorize("hasRole('ROLE_APPLY')")
-    public QuestionResponses findQuestions(@RequestParam(required = false) JobFamily jobFamily,
-                                           @RequestParam(required = false) Long recruitId) {
-        if (recruitId != null) {
-            return questionService.findQuestions(recruitId, jobFamily);
-        }
-        if (jobFamily == null) {
-            throw new GlobalException(GlobalErrorCode.MISS_REQUIRED_REQUEST_PARAMETER);
-        }
-
-        return questionService.findQuestions(jobFamily);
+    public QuestionResponses findQuestions(@RequestParam Long recruitId) {
+        return questionService.findQuestions(recruitId);
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/controller/QuestionController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/QuestionController.java
@@ -1,6 +1,8 @@
 package org.ject.support.domain.recruit.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.exception.GlobalErrorCode;
+import org.ject.support.common.exception.GlobalException;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.dto.QuestionResponses;
 import org.ject.support.domain.recruit.service.QuestionService;
@@ -20,7 +22,15 @@ public class QuestionController implements QuestionApiSpec {
     @Override
     @GetMapping
     @PreAuthorize("hasRole('ROLE_APPLY')")
-    public QuestionResponses findQuestions(@RequestParam JobFamily jobFamily) {
+    public QuestionResponses findQuestions(@RequestParam(required = false) JobFamily jobFamily,
+                                           @RequestParam(required = false) Long recruitId) {
+        if (recruitId != null) {
+            return questionService.findQuestions(recruitId, jobFamily);
+        }
+        if (jobFamily == null) {
+            throw new GlobalException(GlobalErrorCode.MISS_REQUIRED_REQUEST_PARAMETER);
+        }
+
         return questionService.findQuestions(jobFamily);
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/controller/RecruitApiSpec.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/RecruitApiSpec.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.ject.support.domain.recruit.dto.ActiveRecruitmentResponses;
 
-@Tag(name = "Recruitment", description = "모집 공고 API")
+@Tag(name = "Recruit", description = "모집 공고 API")
 public interface RecruitApiSpec {
 
     @Operation(

--- a/src/main/java/org/ject/support/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/RecruitController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/recruit")
+@RequestMapping("/recruits")
 @RequiredArgsConstructor
 public class RecruitController implements RecruitApiSpec {
 

--- a/src/main/java/org/ject/support/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/RecruitController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/recruitments")
+@RequestMapping("/recruit")
 @RequiredArgsConstructor
 public class RecruitController implements RecruitApiSpec {
 

--- a/src/main/java/org/ject/support/domain/recruit/exception/RecruitErrorCode.java
+++ b/src/main/java/org/ject/support/domain/recruit/exception/RecruitErrorCode.java
@@ -15,7 +15,8 @@ public enum RecruitErrorCode implements ErrorCode {
     NOT_FOUND_RECRUIT(NOT_FOUND, "RECRUIT-1", "모집 공고를 찾을 수 없습니다."),
     DUPLICATED_JOB_FAMILY(CONFLICT, "RECRUIT-2", "이미 모집중인 직군입니다."),
     UPDATE_NOT_ALLOW_FOR_CLOSED(CONFLICT, "RECRUIT-3", "마감된 모집 정보는 수정할 수 없습니다."),
-    INVALID_RECRUIT_TYPE_DETAIL(BAD_REQUEST, "RECRUIT-4", "모집 유형과 모집 사유 조합이 올바르지 않습니다.");
+    INVALID_RECRUIT_TYPE_DETAIL(BAD_REQUEST, "RECRUIT-4", "모집 유형과 모집 사유 조합이 올바르지 않습니다."),
+    INVALID_RECRUIT_QUESTION_CONDITION(BAD_REQUEST, "RECRUIT-5", "모집 공고와 직군이 일치하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/ject/support/domain/recruit/exception/RecruitErrorCode.java
+++ b/src/main/java/org/ject/support/domain/recruit/exception/RecruitErrorCode.java
@@ -15,8 +15,7 @@ public enum RecruitErrorCode implements ErrorCode {
     NOT_FOUND_RECRUIT(NOT_FOUND, "RECRUIT-1", "모집 공고를 찾을 수 없습니다."),
     DUPLICATED_JOB_FAMILY(CONFLICT, "RECRUIT-2", "이미 모집중인 직군입니다."),
     UPDATE_NOT_ALLOW_FOR_CLOSED(CONFLICT, "RECRUIT-3", "마감된 모집 정보는 수정할 수 없습니다."),
-    INVALID_RECRUIT_TYPE_DETAIL(BAD_REQUEST, "RECRUIT-4", "모집 유형과 모집 사유 조합이 올바르지 않습니다."),
-    INVALID_RECRUIT_QUESTION_CONDITION(BAD_REQUEST, "RECRUIT-5", "모집 공고와 직군이 일치하지 않습니다.");
+    INVALID_RECRUIT_TYPE_DETAIL(BAD_REQUEST, "RECRUIT-4", "모집 유형과 모집 사유 조합이 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/ject/support/domain/recruit/repository/QuestionQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/QuestionQueryRepository.java
@@ -1,14 +1,11 @@
 package org.ject.support.domain.recruit.repository;
 
-import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.dto.QuestionResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface QuestionQueryRepository {
-
-    List<QuestionResponse> findByJobFamilyOfActiveRecruit(LocalDateTime now, JobFamily jobFamily);
 
     List<QuestionResponse> findByRecruitIdOfActiveRecruit(LocalDateTime now, Long recruitId);
 }

--- a/src/main/java/org/ject/support/domain/recruit/repository/QuestionQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/QuestionQueryRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface QuestionQueryRepository {
 
     List<QuestionResponse> findByJobFamilyOfActiveRecruit(LocalDateTime now, JobFamily jobFamily);
+
+    List<QuestionResponse> findByRecruitIdOfActiveRecruit(LocalDateTime now, Long recruitId);
 }

--- a/src/main/java/org/ject/support/domain/recruit/repository/QuestionQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/QuestionQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.recruit.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.member.JobFamily;
@@ -23,6 +24,22 @@ public class QuestionQueryRepositoryImpl implements QuestionQueryRepository {
     @Override
     public List<QuestionResponse> findByJobFamilyOfActiveRecruit(final LocalDateTime now,
                                                                  final JobFamily jobFamily) {
+        return selectQuestions()
+                .where(isWithinRecruitPeriod(now), recruit.jobFamily.eq(jobFamily))
+                .orderBy(question.sequence.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<QuestionResponse> findByRecruitIdOfActiveRecruit(final LocalDateTime now,
+                                                                final Long recruitId) {
+        return selectQuestions()
+                .where(isWithinRecruitPeriod(now), recruit.id.eq(recruitId))
+                .orderBy(question.sequence.asc())
+                .fetch();
+    }
+
+    private JPAQuery<QuestionResponse> selectQuestions() {
         return queryFactory.select(new QQuestionResponse(
                         question.id,
                         question.sequence,
@@ -36,10 +53,7 @@ public class QuestionQueryRepositoryImpl implements QuestionQueryRepository {
                         question.maxTextLength,
                         question.maxFileSize))
                 .from(question)
-                .leftJoin(question.recruit, recruit)
-                .where(isWithinRecruitPeriod(now), recruit.jobFamily.eq(jobFamily))
-                .orderBy(question.sequence.asc())
-                .fetch();
+                .leftJoin(question.recruit, recruit);
     }
 
     private BooleanExpression isWithinRecruitPeriod(LocalDateTime now) {

--- a/src/main/java/org/ject/support/domain/recruit/repository/QuestionQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/QuestionQueryRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.dto.QQuestionResponse;
 import org.ject.support.domain.recruit.dto.QuestionResponse;
 import org.springframework.stereotype.Repository;
@@ -20,15 +19,6 @@ import static org.ject.support.domain.recruit.domain.QRecruit.recruit;
 public class QuestionQueryRepositoryImpl implements QuestionQueryRepository {
 
     private final JPAQueryFactory queryFactory;
-
-    @Override
-    public List<QuestionResponse> findByJobFamilyOfActiveRecruit(final LocalDateTime now,
-                                                                 final JobFamily jobFamily) {
-        return selectQuestions()
-                .where(isWithinRecruitPeriod(now), recruit.jobFamily.eq(jobFamily))
-                .orderBy(question.sequence.asc())
-                .fetch();
-    }
 
     @Override
     public List<QuestionResponse> findByRecruitIdOfActiveRecruit(final LocalDateTime now,

--- a/src/main/java/org/ject/support/domain/recruit/service/QuestionService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/QuestionService.java
@@ -1,26 +1,51 @@
 package org.ject.support.domain.recruit.service;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.common.exception.GlobalErrorCode;
+import org.ject.support.common.exception.GlobalException;
 import org.ject.support.common.util.PeriodAccessible;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.dto.QuestionResponses;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
 import org.ject.support.domain.recruit.repository.QuestionRepository;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class QuestionService {
 
     private final QuestionRepository questionRepository;
+    private final RecruitRepository recruitRepository;
 
     @Cacheable(value = "question", key = "#jobFamily")
     @PeriodAccessible
     @Transactional(readOnly = true)
     public QuestionResponses findQuestions(final JobFamily jobFamily) {
+        if (jobFamily == null) {
+            throw new GlobalException(GlobalErrorCode.MISS_REQUIRED_REQUEST_PARAMETER);
+        }
+
         return new QuestionResponses(questionRepository.findByJobFamilyOfActiveRecruit(LocalDateTime.now(), jobFamily));
+    }
+
+    @Cacheable(value = "question", key = "'RECRUIT:' + #recruitId + ':' + (#jobFamily == null ? 'NONE' : #jobFamily.name())")
+    @Transactional(readOnly = true)
+    public QuestionResponses findQuestions(final Long recruitId, final JobFamily jobFamily) {
+        LocalDateTime now = LocalDateTime.now();
+        Recruit recruit = Optional.ofNullable(recruitRepository.findActiveRecruitById(recruitId, now))
+                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
+        if (jobFamily != null && recruit.getJobFamily() != jobFamily) {
+            throw new RecruitException(RecruitErrorCode.INVALID_RECRUIT_QUESTION_CONDITION);
+        }
+
+        return new QuestionResponses(questionRepository.findByRecruitIdOfActiveRecruit(now, recruitId));
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/QuestionService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/QuestionService.java
@@ -1,11 +1,6 @@
 package org.ject.support.domain.recruit.service;
 
 import lombok.RequiredArgsConstructor;
-import org.ject.support.common.exception.GlobalErrorCode;
-import org.ject.support.common.exception.GlobalException;
-import org.ject.support.common.util.PeriodAccessible;
-import org.ject.support.domain.member.JobFamily;
-import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.dto.QuestionResponses;
 import org.ject.support.domain.recruit.exception.RecruitErrorCode;
 import org.ject.support.domain.recruit.exception.RecruitException;
@@ -25,26 +20,12 @@ public class QuestionService {
     private final QuestionRepository questionRepository;
     private final RecruitRepository recruitRepository;
 
-    @Cacheable(value = "question", key = "#jobFamily")
-    @PeriodAccessible
+    @Cacheable(value = "question", key = "'RECRUIT:' + #recruitId")
     @Transactional(readOnly = true)
-    public QuestionResponses findQuestions(final JobFamily jobFamily) {
-        if (jobFamily == null) {
-            throw new GlobalException(GlobalErrorCode.MISS_REQUIRED_REQUEST_PARAMETER);
-        }
-
-        return new QuestionResponses(questionRepository.findByJobFamilyOfActiveRecruit(LocalDateTime.now(), jobFamily));
-    }
-
-    @Cacheable(value = "question", key = "'RECRUIT:' + #recruitId + ':' + (#jobFamily == null ? 'NONE' : #jobFamily.name())")
-    @Transactional(readOnly = true)
-    public QuestionResponses findQuestions(final Long recruitId, final JobFamily jobFamily) {
+    public QuestionResponses findQuestions(final Long recruitId) {
         LocalDateTime now = LocalDateTime.now();
-        Recruit recruit = Optional.ofNullable(recruitRepository.findActiveRecruitById(recruitId, now))
+        Optional.ofNullable(recruitRepository.findActiveRecruitById(recruitId, now))
                 .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
-        if (jobFamily != null && recruit.getJobFamily() != jobFamily) {
-            throw new RecruitException(RecruitErrorCode.INVALID_RECRUIT_QUESTION_CONDITION);
-        }
 
         return new QuestionResponses(questionRepository.findByRecruitIdOfActiveRecruit(now, recruitId));
     }

--- a/src/test/java/org/ject/support/common/data/redis/resilience/CacheFallbackIntegrationTest.java
+++ b/src/test/java/org/ject/support/common/data/redis/resilience/CacheFallbackIntegrationTest.java
@@ -52,6 +52,8 @@ class CacheFallbackIntegrationTest {
     @Autowired
     private RedisCacheCircuitBreakerProvider circuitBreakerProvider;
 
+    private Recruit recruit;
+
     @BeforeEach
     void setUp() {
         String uniqueSuffix = String.valueOf(System.currentTimeMillis());
@@ -64,7 +66,7 @@ class CacheFallbackIntegrationTest {
                 .isRecruiting(true)
                 .build());
 
-        Recruit recruit = Recruit.builder()
+        recruit = Recruit.builder()
                 .startDate(LocalDateTime.now().minusDays(1))
                 .endDate(LocalDateTime.now().plusDays(1))
                 .semester(savedSemester)
@@ -104,7 +106,7 @@ class CacheFallbackIntegrationTest {
 
         // when: 캐시가 적용된 서비스 메서드 호출
         // Redis가 죽어있으므로 CacheErrorHandler가 예외를 잡고, DB에서 데이터를 가져와야 함
-        QuestionResponses response = questionService.findQuestions(JobFamily.BE);
+        QuestionResponses response = questionService.findQuestions(recruit.getId());
 
         // then
         assertThat(response).isNotNull();

--- a/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
@@ -1,6 +1,5 @@
 package org.ject.support.domain.recruit.controller;
 
-import org.assertj.core.api.Assertions;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Role;
@@ -15,7 +14,6 @@ import org.ject.support.domain.recruit.repository.SemesterRepository;
 import org.ject.support.testconfig.AuthenticatedUser;
 import org.ject.support.testconfig.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -26,11 +24,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.ject.support.domain.recruit.domain.Question.InputType.TEXT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @IntegrationTest
@@ -57,9 +57,11 @@ class QuestionControllerTest {
     RedisTemplate<String, String> redisTemplate;
 
     Member member;
+    Recruit recruit;
 
     @BeforeEach
     void setUp() {
+        String uniqueSuffix = String.valueOf(System.nanoTime());
         List<Question> questions = List.of(
                 Question.builder().sequence(1).inputType(TEXT).isRequired(true).title("title1").label("label").selectOptions(List.of("a", "b", "c")).build(),
                 Question.builder().sequence(2).inputType(TEXT).isRequired(true).title("title2").label("label").build(),
@@ -69,11 +71,11 @@ class QuestionControllerTest {
         );
 
         Semester savedSemester = semesterRepository.save(Semester.builder()
-                .name("1기")
+                .name("1기" + uniqueSuffix)
                 .isRecruiting(true)
                 .build());
 
-        Recruit recruit = Recruit.builder()
+        recruit = Recruit.builder()
                 .startDate(LocalDateTime.now().minusDays(1))
                 .endDate(LocalDateTime.now().plusDays(1))
                 .semester(savedSemester)
@@ -87,7 +89,7 @@ class QuestionControllerTest {
         recruitRepository.save(recruit);
 
         member = Member.builder()
-                .email("test32@gmail.com")
+                .email("test32" + uniqueSuffix + "@gmail.com")
                 .semesterId(1L)
                 .jobFamily(JobFamily.BE)
                 .name("김젝트")
@@ -100,9 +102,8 @@ class QuestionControllerTest {
     }
 
     @Test
-    @DisplayName("지원서 문항 조회 시 redis에 캐싱")
     @AuthenticatedUser
-    void find_questions_cache() throws Exception {
+    void 지원서_문항_조회_시_redis에_캐싱한다() throws Exception {
         // when
         mockMvc.perform(get("/apply/questions")
                         .param("jobFamily", "BE"))
@@ -112,6 +113,29 @@ class QuestionControllerTest {
 
         // then
         Long countExistingKeys = redisTemplate.countExistingKeys(List.of("cache::question::BE"));
-        Assertions.assertThat(countExistingKeys).isEqualTo(1);
+        assertThat(countExistingKeys).isEqualTo(1);
+    }
+
+    @Test
+    @AuthenticatedUser
+    void 모집_공고_기준으로_지원서_문항을_조회한다() throws Exception {
+        // when, then
+        mockMvc.perform(get("/apply/questions")
+                        .param("recruitId", recruit.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.questionResponses[0].title").value("title1"))
+                .andExpect(jsonPath("$.data.questionResponses[4].title").value("title5"));
+    }
+
+    @Test
+    @AuthenticatedUser
+    void 모집_공고와_직군이_다르면_에러를_반환한다() throws Exception {
+        // when, then
+        mockMvc.perform(get("/apply/questions")
+                        .param("recruitId", recruit.getId().toString())
+                        .param("jobFamily", "FE"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("RECRUIT-5"));
     }
 }

--- a/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
@@ -106,13 +106,13 @@ class QuestionControllerTest {
     void 지원서_문항_조회_시_redis에_캐싱한다() throws Exception {
         // when
         mockMvc.perform(get("/apply/questions")
-                        .param("jobFamily", "BE"))
+                        .param("recruitId", recruit.getId().toString()))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("SUCCESS")))
                 .andDo(print());
 
         // then
-        Long countExistingKeys = redisTemplate.countExistingKeys(List.of("cache::question::BE"));
+        Long countExistingKeys = redisTemplate.countExistingKeys(List.of("cache::question::RECRUIT:" + recruit.getId()));
         assertThat(countExistingKeys).isEqualTo(1);
     }
 
@@ -130,12 +130,10 @@ class QuestionControllerTest {
 
     @Test
     @AuthenticatedUser
-    void 모집_공고와_직군이_다르면_에러를_반환한다() throws Exception {
+    void 모집_공고_식별자가_없으면_에러를_반환한다() throws Exception {
         // when, then
-        mockMvc.perform(get("/apply/questions")
-                        .param("recruitId", recruit.getId().toString())
-                        .param("jobFamily", "FE"))
+        mockMvc.perform(get("/apply/questions"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value("RECRUIT-5"));
+                .andExpect(jsonPath("$.status").value("GLOBAL-10"));
     }
 }

--- a/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
@@ -134,6 +134,6 @@ class QuestionControllerTest {
         // when, then
         mockMvc.perform(get("/apply/questions"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value("GLOBAL-10"));
+                .andExpect(jsonPath("$.code").value("GLOBAL-10"));
     }
 }

--- a/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
@@ -134,6 +134,6 @@ class QuestionControllerTest {
         // when, then
         mockMvc.perform(get("/apply/questions"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("GLOBAL-10"));
+                .andExpect(jsonPath("$.status").value("GLOBAL-10"));
     }
 }

--- a/src/test/java/org/ject/support/domain/recruit/controller/RecruitControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/RecruitControllerTest.java
@@ -62,7 +62,7 @@ class RecruitControllerTest {
         given(recruitUsecase.findActiveRecruitments()).willReturn(responses);
 
         // when, then
-        mockMvc.perform(get("/recruit/active"))
+        mockMvc.perform(get("/recruits/active"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.recruitments", hasSize(2)))
@@ -82,7 +82,7 @@ class RecruitControllerTest {
         given(recruitUsecase.findActiveRecruitments()).willReturn(new ActiveRecruitmentResponses(List.of()));
 
         // when, then
-        mockMvc.perform(get("/recruit/active"))
+        mockMvc.perform(get("/recruits/active"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.recruitments", hasSize(0)));

--- a/src/test/java/org/ject/support/domain/recruit/controller/RecruitControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/RecruitControllerTest.java
@@ -62,7 +62,7 @@ class RecruitControllerTest {
         given(recruitUsecase.findActiveRecruitments()).willReturn(responses);
 
         // when, then
-        mockMvc.perform(get("/recruitments/active"))
+        mockMvc.perform(get("/recruit/active"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.recruitments", hasSize(2)))
@@ -82,7 +82,7 @@ class RecruitControllerTest {
         given(recruitUsecase.findActiveRecruitments()).willReturn(new ActiveRecruitmentResponses(List.of()));
 
         // when, then
-        mockMvc.perform(get("/recruitments/active"))
+        mockMvc.perform(get("/recruit/active"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.recruitments", hasSize(0)));

--- a/src/test/java/org/ject/support/domain/recruit/repository/QuestionQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/repository/QuestionQueryRepositoryTest.java
@@ -34,35 +34,6 @@ class QuestionQueryRepositoryTest {
     private SemesterRepository semesterRepository;
 
     @Test
-    void 현재_모집중인_직군의_지원서_문항을_조회한다() {
-        // given
-        Semester savedSemester = semesterRepository.save(Semester.builder()
-                .name("1기")
-                .isRecruiting(true)
-                .build());
-
-        LocalDateTime now = LocalDateTime.now();
-        Recruit feRecruit = createRecruit(savedSemester, now, FE);
-        Recruit beRecruit = createRecruit(savedSemester, now, BE);
-        recruitRepository.saveAll(List.of(feRecruit, beRecruit));
-
-        Question feQuestion1 = createQuestion(1, TEXT, feRecruit);
-        Question feQuestion2 = createQuestion(2, FILE, feRecruit);
-        Question beQuestion1 = createQuestion(1, TEXT, beRecruit);
-        Question beQuestion2 = createQuestion(2, TEXT, beRecruit);
-        Question beQuestion3 = createQuestion(3, FILE, beRecruit);
-        questionRepository.saveAll(List.of(feQuestion1, feQuestion2, beQuestion3, beQuestion1, beQuestion2));
-
-        // when
-        List<QuestionResponse> result = questionRepository.findByJobFamilyOfActiveRecruit(now, BE);
-
-        // then
-        assertThat(result).hasSize(3);
-        assertThat(result).extracting(QuestionResponse::sequence)
-                .containsExactly(1, 2, 3);
-    }
-
-    @Test
     void 현재_모집중인_모집_공고의_지원서_문항을_조회한다() {
         // given
         Semester savedSemester = semesterRepository.save(Semester.builder()

--- a/src/test/java/org/ject/support/domain/recruit/repository/QuestionQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/repository/QuestionQueryRepositoryTest.java
@@ -6,7 +6,6 @@ import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.dto.QuestionResponse;
 import org.ject.support.testconfig.QueryDslTestConfig;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -35,8 +34,7 @@ class QuestionQueryRepositoryTest {
     private SemesterRepository semesterRepository;
 
     @Test
-    @DisplayName("현재 모집중인 직군의 지원서 문항 조회")
-    void find_by_job_family() {
+    void 현재_모집중인_직군의_지원서_문항을_조회한다() {
         // given
         Semester savedSemester = semesterRepository.save(Semester.builder()
                 .name("1기")
@@ -65,8 +63,34 @@ class QuestionQueryRepositoryTest {
     }
 
     @Test
-    @DisplayName("selectOptions가 List<String>와 JSON 문자열 간 정상 변환됨")
-    void convert_select_options() {
+    void 현재_모집중인_모집_공고의_지원서_문항을_조회한다() {
+        // given
+        Semester savedSemester = semesterRepository.save(Semester.builder()
+                .name("1기")
+                .isRecruiting(true)
+                .build());
+
+        LocalDateTime now = LocalDateTime.now();
+        Recruit feRecruit = createRecruit(savedSemester, now, FE);
+        Recruit beRecruit = createRecruit(savedSemester, now, BE);
+        recruitRepository.saveAll(List.of(feRecruit, beRecruit));
+
+        Question feQuestion1 = createQuestion(1, TEXT, feRecruit);
+        Question feQuestion2 = createQuestion(2, FILE, feRecruit);
+        Question beQuestion1 = createQuestion(1, TEXT, beRecruit);
+        questionRepository.saveAll(List.of(beQuestion1, feQuestion2, feQuestion1));
+
+        // when
+        List<QuestionResponse> result = questionRepository.findByRecruitIdOfActiveRecruit(now, feRecruit.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(QuestionResponse::sequence)
+                .containsExactly(1, 2);
+    }
+
+    @Test
+    void selectOptions가_List_String과_JSON_문자열_간_정상_변환된다() {
         // given
         List<String> selectOptions = List.of("재직", "재학", "졸업", "휴학");
 

--- a/src/test/java/org/ject/support/domain/recruit/service/QuestionServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/QuestionServiceTest.java
@@ -1,0 +1,101 @@
+package org.ject.support.domain.recruit.service;
+
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.common.exception.GlobalException;
+import org.ject.support.domain.recruit.domain.Question;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.Semester;
+import org.ject.support.domain.recruit.dto.QuestionResponse;
+import org.ject.support.domain.recruit.dto.QuestionResponses;
+import org.ject.support.domain.recruit.exception.RecruitException;
+import org.ject.support.domain.recruit.repository.QuestionRepository;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ject.support.domain.member.JobFamily.BE;
+import static org.ject.support.domain.member.JobFamily.FE;
+import static org.ject.support.domain.recruit.domain.Question.InputType.TEXT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class QuestionServiceTest extends UnitTestSupport {
+
+    @InjectMocks
+    QuestionService questionService;
+
+    @Mock
+    QuestionRepository questionRepository;
+
+    @Mock
+    RecruitRepository recruitRepository;
+
+    @Test
+    void 모집_공고_기준으로_지원서_문항을_조회한다() {
+        // given
+        Recruit recruit = createRecruit();
+        QuestionResponse questionResponse = QuestionResponse.builder()
+                .id(1L)
+                .sequence(1)
+                .inputType(TEXT)
+                .isRequired(true)
+                .title("title")
+                .label("label")
+                .build();
+        when(recruitRepository.findActiveRecruitById(eq(1L), any(LocalDateTime.class))).thenReturn(recruit);
+        when(questionRepository.findByRecruitIdOfActiveRecruit(any(LocalDateTime.class), eq(1L)))
+                .thenReturn(List.of(questionResponse));
+
+        // when
+        QuestionResponses result = questionService.findQuestions(1L, BE);
+
+        // then
+        assertThat(result.questionResponses()).hasSize(1);
+        assertThat(result.questionResponses().get(0).title()).isEqualTo("title");
+    }
+
+    @Test
+    void 모집_공고와_직군이_다르면_지원서_문항_조회에_실패한다() {
+        // given
+        when(recruitRepository.findActiveRecruitById(eq(1L), any(LocalDateTime.class))).thenReturn(createRecruit());
+
+        // when, then
+        assertThatThrownBy(() -> questionService.findQuestions(1L, FE))
+                .isInstanceOf(RecruitException.class);
+        verify(questionRepository, never()).findByRecruitIdOfActiveRecruit(any(), any());
+    }
+
+    @Test
+    void 모집_공고와_직군이_모두_없으면_지원서_문항_조회에_실패한다() {
+        // when, then
+        assertThatThrownBy(() -> questionService.findQuestions(null))
+                .isInstanceOf(GlobalException.class);
+    }
+
+    private Recruit createRecruit() {
+        return Recruit.builder()
+                .id(1L)
+                .semester(Semester.builder().id(1L).name("1기").isRecruiting(true).build())
+                .jobFamily(BE)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .questions(List.of(Question.builder()
+                        .id(1L)
+                        .sequence(1)
+                        .inputType(TEXT)
+                        .isRequired(true)
+                        .title("title")
+                        .label("label")
+                        .build()))
+                .build();
+    }
+}

--- a/src/test/java/org/ject/support/domain/recruit/service/QuestionServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/QuestionServiceTest.java
@@ -1,7 +1,6 @@
 package org.ject.support.domain.recruit.service;
 
 import org.ject.support.base.UnitTestSupport;
-import org.ject.support.common.exception.GlobalException;
 import org.ject.support.domain.recruit.domain.Question;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.domain.Semester;
@@ -20,7 +19,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.ject.support.domain.member.JobFamily.BE;
-import static org.ject.support.domain.member.JobFamily.FE;
 import static org.ject.support.domain.recruit.domain.Question.InputType.TEXT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -56,7 +54,7 @@ class QuestionServiceTest extends UnitTestSupport {
                 .thenReturn(List.of(questionResponse));
 
         // when
-        QuestionResponses result = questionService.findQuestions(1L, BE);
+        QuestionResponses result = questionService.findQuestions(1L);
 
         // then
         assertThat(result.questionResponses()).hasSize(1);
@@ -64,21 +62,14 @@ class QuestionServiceTest extends UnitTestSupport {
     }
 
     @Test
-    void 모집_공고와_직군이_다르면_지원서_문항_조회에_실패한다() {
+    void 모집_공고를_찾을_수_없으면_지원서_문항_조회에_실패한다() {
         // given
-        when(recruitRepository.findActiveRecruitById(eq(1L), any(LocalDateTime.class))).thenReturn(createRecruit());
+        when(recruitRepository.findActiveRecruitById(eq(1L), any(LocalDateTime.class))).thenReturn(null);
 
         // when, then
-        assertThatThrownBy(() -> questionService.findQuestions(1L, FE))
+        assertThatThrownBy(() -> questionService.findQuestions(1L))
                 .isInstanceOf(RecruitException.class);
         verify(questionRepository, never()).findByRecruitIdOfActiveRecruit(any(), any());
-    }
-
-    @Test
-    void 모집_공고와_직군이_모두_없으면_지원서_문항_조회에_실패한다() {
-        // when, then
-        assertThatThrownBy(() -> questionService.findQuestions(null))
-                .isInstanceOf(GlobalException.class);
     }
 
     private Recruit createRecruit() {


### PR DESCRIPTION
## #️⃣연관된 이슈

close #536
Parent: #427

## 📝 작업 내용

- 활성 모집 공고 목록 API base path를 `/recruits`로 정리
- `GET /apply/questions` 문항 조회를 `recruitId` 필수 기준으로 정리
- `jobFamily` 병행 조회와 `recruitId`/`jobFamily` 불일치 검증 제거
- 모집 공고 기준 문항 조회 쿼리와 서비스/리포지토리 테스트 정리

## 🙏 리뷰 요구사항 (선택)

- 신규 URL을 만들지 않고 기존 `/apply/questions?recruitId=...` 형태로 유지했습니다.
- 응답 바디의 `data.recruitments`는 프론트 payload 변경 범위를 늘리지 않기 위해 유지했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **API 변경**
  * 모집 공고 엔드포인트 경로가 `/recruitments`에서 `/recruits`로 변경되었습니다
  * 지원서 문항 조회 API의 요청 파라미터가 `jobFamily`에서 `recruitId`로 변경되었습니다
  * Swagger 문서 태그명이 "Recruitment"에서 "Recruit"로 업데이트되었습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->