### PR TITLE
feat: 확장된 모집 공고 기준으로 지원 프로필 저장 

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
@@ -52,9 +52,9 @@ public interface ApplyApiSpec {
 
     @Operation(
             summary = "프로필 작성(저장)",
-            description = "지원자의 특정 공고에 대한 프로필을 작성(저장)합니다. 모집 공고 식별자가 없으면 기존 방식대로 직군을 기준으로 저장합니다."
+            description = "지원자의 특정 공고에 대한 프로필을 작성(저장)합니다."
     )
     void saveProfile(@AuthPrincipal Long memberId,
-                     @RequestParam(required = false) Long recruitId,
+                     @RequestParam Long recruitId,
                      @RequestBody @Valid ApplyProfileRequest request);
 }

--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
@@ -52,9 +52,9 @@ public interface ApplyApiSpec {
 
     @Operation(
             summary = "프로필 작성(저장)",
-            description = "지원자의 특정 공고에 대한 프로필을 작성(저장)합니다."
+            description = "지원자의 특정 공고에 대한 프로필을 작성(저장)합니다. 모집 공고 식별자가 없으면 기존 방식대로 직군을 기준으로 저장합니다."
     )
     void saveProfile(@AuthPrincipal Long memberId,
-                     @RequestParam Long recruitId,
+                     @RequestParam(required = false) Long recruitId,
                      @RequestBody @Valid ApplyProfileRequest request);
 }

--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
@@ -52,8 +52,9 @@ public interface ApplyApiSpec {
 
     @Operation(
             summary = "프로필 작성(저장)",
-            description = "지원자의 프로필을 작성(저장)합니다."
+            description = "지원자의 특정 공고에 대한 프로필을 작성(저장)합니다."
     )
     void saveProfile(@AuthPrincipal Long memberId,
+                     @RequestParam Long recruitId,
                      @RequestBody @Valid ApplyProfileRequest request);
 }

--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
@@ -68,7 +68,7 @@ public class ApplyController implements ApplyApiSpec {
     @PostMapping("/profile")
     @PreAuthorize("hasRole('ROLE_APPLY')")
     public void saveProfile(@AuthPrincipal Long memberId,
-                            @RequestParam Long recruitId,
+                            @RequestParam(required = false) Long recruitId,
                             @RequestBody @Valid ApplyProfileRequest request
     ) {
         applyUsecase.saveProfile(memberId, recruitId, request);

--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
@@ -68,7 +68,7 @@ public class ApplyController implements ApplyApiSpec {
     @PostMapping("/profile")
     @PreAuthorize("hasRole('ROLE_APPLY')")
     public void saveProfile(@AuthPrincipal Long memberId,
-                            @RequestParam(required = false) Long recruitId,
+                            @RequestParam Long recruitId,
                             @RequestBody @Valid ApplyProfileRequest request
     ) {
         applyUsecase.saveProfile(memberId, recruitId, request);

--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
@@ -68,8 +68,9 @@ public class ApplyController implements ApplyApiSpec {
     @PostMapping("/profile")
     @PreAuthorize("hasRole('ROLE_APPLY')")
     public void saveProfile(@AuthPrincipal Long memberId,
+                            @RequestParam Long recruitId,
                             @RequestBody @Valid ApplyProfileRequest request
     ) {
-        applyUsecase.saveProfile(memberId, request);
+        applyUsecase.saveProfile(memberId, recruitId, request);
     }
 }

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -29,10 +29,13 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
     @Query("select count(a) > 0 from Apply a join a.recruit r where a.member.id = :memberId and r.startDate <= :now and r.endDate >= :now")
     boolean existsByMemberIdInActiveRecruit(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
 
-    @Query("select count(a) > 0 from Apply a join a.recruit r where a.member.id = :memberId and r.id = :recruitId and r.startDate <= :now and r.endDate >= :now")
-    boolean existsByMemberIdAndRecruitIdInActiveRecruit(@Param("memberId") Long memberId,
-                                                        @Param("recruitId") Long recruitId,
-                                                        @Param("now") LocalDateTime now);
+    default boolean existsByMemberIdAndRecruitIdInActiveRecruit(Long memberId, Long recruitId, LocalDateTime now) {
+        return existsByMemberIdAndRecruitIdAndRecruitStartDateLessThanEqualAndRecruitEndDateGreaterThanEqual(
+                memberId, recruitId, now, now);
+    }
+
+    boolean existsByMemberIdAndRecruitIdAndRecruitStartDateLessThanEqualAndRecruitEndDateGreaterThanEqual(
+            Long memberId, Long recruitId, LocalDateTime startDate, LocalDateTime endDate);
 
     List<Apply> findByRecruitAndStatus(Recruit recruit, ApplyStatus status);
 

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -5,11 +5,11 @@ import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.repository.query.Param;
 
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
@@ -28,6 +28,11 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
     @Query("select count(a) > 0 from Apply a join a.recruit r where a.member.id = :memberId and r.startDate <= :now and r.endDate >= :now")
     boolean existsByMemberIdInActiveRecruit(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
+
+    @Query("select count(a) > 0 from Apply a join a.recruit r where a.member.id = :memberId and r.id = :recruitId and r.startDate <= :now and r.endDate >= :now")
+    boolean existsByMemberIdAndRecruitIdInActiveRecruit(@Param("memberId") Long memberId,
+                                                        @Param("recruitId") Long recruitId,
+                                                        @Param("now") LocalDateTime now);
 
     List<Apply> findByRecruitAndStatus(Recruit recruit, ApplyStatus status);
 

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -29,13 +29,15 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
     @Query("select count(a) > 0 from Apply a join a.recruit r where a.member.id = :memberId and r.startDate <= :now and r.endDate >= :now")
     boolean existsByMemberIdInActiveRecruit(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
 
-    default boolean existsByMemberIdAndRecruitIdInActiveRecruit(Long memberId, Long recruitId, LocalDateTime now) {
-        return existsByMemberIdAndRecruitIdAndRecruitStartDateLessThanEqualAndRecruitEndDateGreaterThanEqual(
-                memberId, recruitId, now, now);
-    }
-
-    boolean existsByMemberIdAndRecruitIdAndRecruitStartDateLessThanEqualAndRecruitEndDateGreaterThanEqual(
-            Long memberId, Long recruitId, LocalDateTime startDate, LocalDateTime endDate);
+    @Query("""
+            select exists (
+                select 1 from Apply a join a.recruit r
+                where a.member.id = :memberId and r.id = :recruitId and r.startDate <= :now and r.endDate >= :now
+            )
+            """)
+    boolean existsByMemberIdAndRecruitIdInActiveRecruit(@Param("memberId") Long memberId,
+                                                        @Param("recruitId") Long recruitId,
+                                                        @Param("now") LocalDateTime now);
 
     List<Apply> findByRecruitAndStatus(Recruit recruit, ApplyStatus status);
 

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -196,16 +196,15 @@ public class ApplyService implements ApplyUsecase {
     public void saveProfile(Long memberId, Long recruitId, ApplyProfileRequest request) {
         var member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
-        Recruit recruit = getActiveRecruit(recruitId);
+        Recruit recruit = getActiveRecruit(recruitId, request.jobFamily());
 
-        validateRecruitJobFamily(recruit, request.jobFamily());
         createApplyIfNotExists(member, recruit);
 
         var memberEditorBuilder = member.toEditor();
         var memberEditor = memberEditorBuilder
                 .name(request.name())
                 .phoneNumber(request.phoneNumber())
-                .jobFamily(request.jobFamily())
+                .jobFamily(recruit.getJobFamily())
                 .region(request.region())
                 .careerDetails(request.careerDetails())
                 .experiencePeriod(request.experiencePeriod())
@@ -223,15 +222,9 @@ public class ApplyService implements ApplyUsecase {
                 var newApply = Apply.createApply(member, recruit);
                 applyRepository.save(newApply);
             } catch (DataIntegrityViolationException e) {
-                log.warn("지원서 생성 중 레이스 컨디션 발생. memberId: {}, recruitId: {}. 이미 지원서가 존재합니다.",
+                log.warn("지원서 생성 중 중복 생성 충돌 발생. memberId: {}, recruitId: {}. 이미 지원서가 존재합니다.",
                         member.getId(), recruit.getId());
             }
-        }
-    }
-
-    private void validateRecruitJobFamily(Recruit recruit, JobFamily jobFamily) {
-        if (recruit.getJobFamily() != jobFamily) {
-            throw new RecruitException(RecruitErrorCode.INVALID_RECRUIT_JOB_FAMILY);
         }
     }
 
@@ -249,7 +242,11 @@ public class ApplyService implements ApplyUsecase {
                 .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
     }
 
-    private Recruit getActiveRecruit(final Long recruitId) {
+    private Recruit getActiveRecruit(final Long recruitId, final JobFamily jobFamily) {
+        if (recruitId == null) {
+            return getPeriodRecruit(jobFamily);
+        }
+
         return Optional.ofNullable(recruitRepository.findActiveRecruitById(recruitId, LocalDateTime.now()))
                 .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
     }

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -36,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.ject.support.domain.apply.domain.ApplyStatus.JOINED;
 import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
@@ -192,11 +193,13 @@ public class ApplyService implements ApplyUsecase {
     @Override
     @PeriodAccessible(permitAllJob = true)
     @Transactional
-    public void saveProfile(Long memberId, ApplyProfileRequest request) {
+    public void saveProfile(Long memberId, Long recruitId, ApplyProfileRequest request) {
         var member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
+        Recruit recruit = getActiveRecruit(recruitId);
 
-        createApplyIfNotExists(member, request.jobFamily());
+        validateRecruitJobFamily(recruit, request.jobFamily());
+        createApplyIfNotExists(member, recruit);
 
         var memberEditorBuilder = member.toEditor();
         var memberEditor = memberEditorBuilder
@@ -212,15 +215,23 @@ public class ApplyService implements ApplyUsecase {
         member.edit(memberEditor);
     }
 
-    private void createApplyIfNotExists(Member member, JobFamily jobFamily) {
-        if (!applyRepository.existsByMemberIdInActiveRecruit(member.getId(), LocalDateTime.now())) {
+    private void createApplyIfNotExists(Member member, Recruit recruit) {
+        boolean exists = applyRepository.existsByMemberIdAndRecruitIdInActiveRecruit(
+                member.getId(), recruit.getId(), LocalDateTime.now());
+        if (!exists) {
             try {
-                var recruit = getPeriodRecruit(jobFamily);
                 var newApply = Apply.createApply(member, recruit);
                 applyRepository.save(newApply);
             } catch (DataIntegrityViolationException e) {
-                log.warn("지원서 생성 중 레이스 컨디션 발생. memberId: {}. 이미 지원서가 존재합니다.", member.getId());
+                log.warn("지원서 생성 중 레이스 컨디션 발생. memberId: {}, recruitId: {}. 이미 지원서가 존재합니다.",
+                        member.getId(), recruit.getId());
             }
+        }
+    }
+
+    private void validateRecruitJobFamily(Recruit recruit, JobFamily jobFamily) {
+        if (recruit.getJobFamily() != jobFamily) {
+            throw new RecruitException(RecruitErrorCode.INVALID_RECRUIT_JOB_FAMILY);
         }
     }
 
@@ -235,6 +246,11 @@ public class ApplyService implements ApplyUsecase {
 
     private Recruit getPeriodRecruit(final JobFamily jobFamily) {
         return recruitRepository.findActiveRecruitByJobFamily(jobFamily, LocalDateTime.now())
+                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
+    }
+
+    private Recruit getActiveRecruit(final Long recruitId) {
+        return Optional.ofNullable(recruitRepository.findActiveRecruitById(recruitId, LocalDateTime.now()))
                 .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
     }
 

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -196,7 +196,9 @@ public class ApplyService implements ApplyUsecase {
     public void saveProfile(Long memberId, Long recruitId, ApplyProfileRequest request) {
         var member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
-        Recruit recruit = getActiveRecruit(recruitId, request.jobFamily());
+        Recruit recruit = recruitId == null
+                ? getPeriodRecruit(request.jobFamily())
+                : getActiveRecruit(recruitId);
 
         createApplyIfNotExists(member, recruit);
 
@@ -242,11 +244,7 @@ public class ApplyService implements ApplyUsecase {
                 .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
     }
 
-    private Recruit getActiveRecruit(final Long recruitId, final JobFamily jobFamily) {
-        if (recruitId == null) {
-            return getPeriodRecruit(jobFamily);
-        }
-
+    private Recruit getActiveRecruit(final Long recruitId) {
         return Optional.ofNullable(recruitRepository.findActiveRecruitById(recruitId, LocalDateTime.now()))
                 .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
     }

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -196,9 +196,7 @@ public class ApplyService implements ApplyUsecase {
     public void saveProfile(Long memberId, Long recruitId, ApplyProfileRequest request) {
         var member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));
-        Recruit recruit = recruitId == null
-                ? getPeriodRecruit(request.jobFamily())
-                : getActiveRecruit(recruitId);
+        Recruit recruit = getActiveRecruit(recruitId);
 
         createApplyIfNotExists(member, recruit);
 

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
@@ -26,5 +26,5 @@ public interface ApplyUsecase {
 
     ApplyStatusResponse checkApplyStatus(Long memberId, Long recruitId);
 
-    void saveProfile(Long memberId, ApplyProfileRequest request);
+    void saveProfile(Long memberId, Long recruitId, ApplyProfileRequest request);
 }

--- a/src/main/java/org/ject/support/domain/recruit/exception/RecruitErrorCode.java
+++ b/src/main/java/org/ject/support/domain/recruit/exception/RecruitErrorCode.java
@@ -15,7 +15,8 @@ public enum RecruitErrorCode implements ErrorCode {
     NOT_FOUND_RECRUIT(NOT_FOUND, "RECRUIT-1", "모집 공고를 찾을 수 없습니다."),
     DUPLICATED_JOB_FAMILY(CONFLICT, "RECRUIT-2", "이미 모집중인 직군입니다."),
     UPDATE_NOT_ALLOW_FOR_CLOSED(CONFLICT, "RECRUIT-3", "마감된 모집 정보는 수정할 수 없습니다."),
-    INVALID_RECRUIT_TYPE_DETAIL(BAD_REQUEST, "RECRUIT-4", "모집 유형과 모집 사유 조합이 올바르지 않습니다.");
+    INVALID_RECRUIT_TYPE_DETAIL(BAD_REQUEST, "RECRUIT-4", "모집 유형과 모집 사유 조합이 올바르지 않습니다."),
+    INVALID_RECRUIT_JOB_FAMILY(BAD_REQUEST, "RECRUIT-5", "모집 공고와 직군이 일치하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/ject/support/domain/recruit/exception/RecruitErrorCode.java
+++ b/src/main/java/org/ject/support/domain/recruit/exception/RecruitErrorCode.java
@@ -15,8 +15,7 @@ public enum RecruitErrorCode implements ErrorCode {
     NOT_FOUND_RECRUIT(NOT_FOUND, "RECRUIT-1", "모집 공고를 찾을 수 없습니다."),
     DUPLICATED_JOB_FAMILY(CONFLICT, "RECRUIT-2", "이미 모집중인 직군입니다."),
     UPDATE_NOT_ALLOW_FOR_CLOSED(CONFLICT, "RECRUIT-3", "마감된 모집 정보는 수정할 수 없습니다."),
-    INVALID_RECRUIT_TYPE_DETAIL(BAD_REQUEST, "RECRUIT-4", "모집 유형과 모집 사유 조합이 올바르지 않습니다."),
-    INVALID_RECRUIT_JOB_FAMILY(BAD_REQUEST, "RECRUIT-5", "모집 공고와 직군이 일치하지 않습니다.");
+    INVALID_RECRUIT_TYPE_DETAIL(BAD_REQUEST, "RECRUIT-4", "모집 유형과 모집 사유 조합이 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
+++ b/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
@@ -1,0 +1,93 @@
+package org.ject.support.domain.apply.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.common.response.ResponseWrapper;
+import org.ject.support.common.security.AuthenticatedMemberIdResolver;
+import org.ject.support.common.security.CustomUserDetails;
+import org.ject.support.domain.apply.dto.ApplyProfileRequest;
+import org.ject.support.domain.apply.service.ApplyUsecase;
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.InterestedDomain;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Region;
+import org.ject.support.domain.member.Role;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ApplyControllerTest extends UnitTestSupport {
+
+    @InjectMocks
+    ApplyController applyController;
+
+    @Mock
+    ApplyUsecase applyUsecase;
+
+    MockMvc mockMvc;
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        mockMvc = MockMvcBuilders.standaloneSetup(applyController)
+                .setControllerAdvice(new ResponseWrapper())
+                .setCustomArgumentResolvers(new AuthenticatedMemberIdResolver())
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 프로필을_모집_공고_기준으로_저장한다() throws Exception {
+        // given
+        long memberId = 1L;
+        long recruitId = 10L;
+        setAuthentication(memberId);
+        ApplyProfileRequest request = new ApplyProfileRequest(
+                "김젝트",
+                "010-1234-5678",
+                JobFamily.FE,
+                Region.SEOUL,
+                CareerDetails.STUDENT,
+                ExperiencePeriod.NONE,
+                List.of(InterestedDomain.GAME.getDescription())
+        );
+
+        // when, then
+        mockMvc.perform(post("/apply/profile")
+                        .param("recruitId", String.valueOf(recruitId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+
+        verify(applyUsecase).saveProfile(eq(memberId), eq(recruitId), any(ApplyProfileRequest.class));
+    }
+
+    private void setAuthentication(final Long memberId) {
+        CustomUserDetails userDetails = new CustomUserDetails("apply@ject.kr", memberId, Role.APPLY);
+        var authentication = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
+++ b/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
@@ -28,8 +28,8 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -87,7 +87,7 @@ class ApplyControllerTest extends UnitTestSupport {
     }
 
     @Test
-    void 모집_공고_식별자가_없어도_프로필을_저장한다() throws Exception {
+    void 모집_공고_식별자가_없으면_프로필_저장에_실패한다() throws Exception {
         // given
         long memberId = 1L;
         setAuthentication(memberId);
@@ -105,10 +105,9 @@ class ApplyControllerTest extends UnitTestSupport {
         mockMvc.perform(post("/apply/profile")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("SUCCESS"));
+                .andExpect(status().isBadRequest());
 
-        verify(applyUsecase).saveProfile(eq(memberId), isNull(), any(ApplyProfileRequest.class));
+        verifyNoInteractions(applyUsecase);
     }
 
     private void setAuthentication(final Long memberId) {

--- a/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
+++ b/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -83,6 +84,31 @@ class ApplyControllerTest extends UnitTestSupport {
                 .andExpect(jsonPath("$.status").value("SUCCESS"));
 
         verify(applyUsecase).saveProfile(eq(memberId), eq(recruitId), any(ApplyProfileRequest.class));
+    }
+
+    @Test
+    void 모집_공고_식별자가_없어도_프로필을_저장한다() throws Exception {
+        // given
+        long memberId = 1L;
+        setAuthentication(memberId);
+        ApplyProfileRequest request = new ApplyProfileRequest(
+                "김젝트",
+                "010-1234-5678",
+                JobFamily.FE,
+                Region.SEOUL,
+                CareerDetails.STUDENT,
+                ExperiencePeriod.NONE,
+                List.of(InterestedDomain.GAME.getDescription())
+        );
+
+        // when, then
+        mockMvc.perform(post("/apply/profile")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+
+        verify(applyUsecase).saveProfile(eq(memberId), isNull(), any(ApplyProfileRequest.class));
     }
 
     private void setAuthentication(final Long memberId) {

--- a/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.apply.domain.ApplyStatus.JOINED;
 import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
 import static org.ject.support.domain.apply.domain.ApplyStatus.TEMP_SAVED;
 import static org.ject.support.domain.member.JobFamily.BE;
@@ -104,6 +105,27 @@ class ApplyRepositoryTest {
 
         // then
         assertThat(count).isEqualTo(1L);
+    }
+
+    @Test
+    void 회원과_모집_공고를_바탕으로_활성_지원정보_존재_여부를_조회한다() {
+        // given
+        Member applicant = createMember("email@test.com", Role.APPLY);
+        memberRepository.save(applicant);
+
+        Apply feApply = getApply(applicant, feRecruit, JOINED);
+        Apply beApply = getApply(applicant, beRecruit, JOINED);
+        applyRepository.saveAll(List.of(feApply, beApply));
+
+        // when
+        boolean exists = applyRepository.existsByMemberIdAndRecruitIdInActiveRecruit(
+                applicant.getId(), beRecruit.getId(), LocalDateTime.now());
+        boolean notExists = applyRepository.existsByMemberIdAndRecruitIdInActiveRecruit(
+                applicant.getId(), pdRecruit.getId(), LocalDateTime.now());
+
+        // then
+        assertThat(exists).isTrue();
+        assertThat(notExists).isFalse();
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -27,6 +27,8 @@ import org.ject.support.domain.recruit.domain.Question;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.exception.QuestionException;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -531,6 +533,7 @@ class ApplyServiceTest extends UnitTestSupport {
     void 프로필_저장_성공() {
         // given
         long memberId = 1L;
+        long recruitId = 1L;
         Member member = getApplicant(memberId, "test@example.com");
         ApplyProfileRequest request = new ApplyProfileRequest(
             "New Name",
@@ -544,11 +547,12 @@ class ApplyServiceTest extends UnitTestSupport {
         Recruit recruit = getActiveRecruit(request.jobFamily(), List.of());
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(applyRepository.existsByMemberIdInActiveRecruit(eq(memberId), any())).willReturn(false);
-        given(recruitRepository.findActiveRecruitByJobFamily(any(), any())).willReturn(Optional.of(recruit));
+        given(recruitRepository.findActiveRecruitById(eq(recruitId), any())).willReturn(recruit);
+        given(applyRepository.existsByMemberIdAndRecruitIdInActiveRecruit(eq(memberId), eq(recruitId), any()))
+                .willReturn(false);
 
         // when
-        applyService.saveProfile(memberId, request);
+        applyService.saveProfile(memberId, recruitId, request);
 
         // then
         ArgumentCaptor<Apply> applyCaptor = ArgumentCaptor.forClass(Apply.class);
@@ -568,6 +572,7 @@ class ApplyServiceTest extends UnitTestSupport {
     void 프로필_저장_시_Apply가_존재하면_프로필만_업데이트() {
         // given
         long memberId = 1L;
+        long recruitId = 1L;
         Member member = getApplicant(memberId, "test@example.com");
         ApplyProfileRequest request = new ApplyProfileRequest(
                 "New Name",
@@ -578,12 +583,15 @@ class ApplyServiceTest extends UnitTestSupport {
                 ExperiencePeriod.NONE,
                 List.of(InterestedDomain.GAME.getDescription(), InterestedDomain.EDUCATION.getDescription())
         );
+        Recruit recruit = getActiveRecruit(request.jobFamily(), List.of());
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(applyRepository.existsByMemberIdInActiveRecruit(eq(memberId), any())).willReturn(true);
+        given(recruitRepository.findActiveRecruitById(eq(recruitId), any())).willReturn(recruit);
+        given(applyRepository.existsByMemberIdAndRecruitIdInActiveRecruit(eq(memberId), eq(recruitId), any()))
+                .willReturn(true);
 
         // when
-        applyService.saveProfile(memberId, request);
+        applyService.saveProfile(memberId, recruitId, request);
 
         // then
         verify(applyRepository, never()).save(any(Apply.class));
@@ -593,6 +601,34 @@ class ApplyServiceTest extends UnitTestSupport {
         assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
         assertThat(member.getCareerDetails()).isEqualTo(request.careerDetails());
         assertThat(member.getExperiencePeriod()).isEqualTo(request.experiencePeriod());
+    }
+
+    @Test
+    void 프로필_저장_시_모집_공고와_직군이_다르면_실패() {
+        // given
+        long memberId = 1L;
+        long recruitId = 1L;
+        Member member = getApplicant(memberId, "test@example.com");
+        ApplyProfileRequest request = new ApplyProfileRequest(
+                "New Name",
+                "010-1234-5678",
+                JobFamily.FE,
+                Region.SEOUL,
+                CareerDetails.STUDENT,
+                ExperiencePeriod.NONE,
+                List.of(InterestedDomain.GAME.getDescription(), InterestedDomain.EDUCATION.getDescription())
+        );
+        Recruit recruit = getActiveRecruit(BE, List.of());
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(recruitRepository.findActiveRecruitById(eq(recruitId), any())).willReturn(recruit);
+
+        // when, then
+        assertThatThrownBy(() -> applyService.saveProfile(memberId, recruitId, request))
+                .isInstanceOf(RecruitException.class)
+                .hasFieldOrPropertyWithValue("errorCode", RecruitErrorCode.INVALID_RECRUIT_JOB_FAMILY);
+
+        verify(applyRepository, never()).save(any(Apply.class));
     }
 
     private Recruit getActiveRecruit(JobFamily jobFamily, List<Question> questions) {

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -27,8 +27,6 @@ import org.ject.support.domain.recruit.domain.Question;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.exception.QuestionException;
-import org.ject.support.domain.recruit.exception.RecruitErrorCode;
-import org.ject.support.domain.recruit.exception.RecruitException;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -565,7 +563,7 @@ class ApplyServiceTest extends UnitTestSupport {
 
         assertThat(member.getName()).isEqualTo(request.name());
         assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
-        assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
+        assertThat(member.getJobFamily()).isEqualTo(recruit.getJobFamily());
     }
 
     @Test
@@ -598,13 +596,13 @@ class ApplyServiceTest extends UnitTestSupport {
 
         assertThat(member.getName()).isEqualTo(request.name());
         assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
-        assertThat(member.getJobFamily()).isEqualTo(request.jobFamily());
+        assertThat(member.getJobFamily()).isEqualTo(recruit.getJobFamily());
         assertThat(member.getCareerDetails()).isEqualTo(request.careerDetails());
         assertThat(member.getExperiencePeriod()).isEqualTo(request.experiencePeriod());
     }
 
     @Test
-    void 프로필_저장_시_모집_공고와_직군이_다르면_실패() {
+    void 프로필_저장_시_모집_공고_직군으로_프로필을_저장한다() {
         // given
         long memberId = 1L;
         long recruitId = 1L;
@@ -622,13 +620,45 @@ class ApplyServiceTest extends UnitTestSupport {
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
         given(recruitRepository.findActiveRecruitById(eq(recruitId), any())).willReturn(recruit);
+        given(applyRepository.existsByMemberIdAndRecruitIdInActiveRecruit(eq(memberId), eq(recruitId), any()))
+                .willReturn(false);
 
-        // when, then
-        assertThatThrownBy(() -> applyService.saveProfile(memberId, recruitId, request))
-                .isInstanceOf(RecruitException.class)
-                .hasFieldOrPropertyWithValue("errorCode", RecruitErrorCode.INVALID_RECRUIT_JOB_FAMILY);
+        // when
+        applyService.saveProfile(memberId, recruitId, request);
 
-        verify(applyRepository, never()).save(any(Apply.class));
+        // then
+        assertThat(member.getJobFamily()).isEqualTo(BE);
+    }
+
+    @Test
+    void 프로필_저장_시_모집_공고_식별자가_없으면_직군으로_공고를_조회한다() {
+        // given
+        long memberId = 1L;
+        Member member = getApplicant(memberId, "test@example.com");
+        ApplyProfileRequest request = new ApplyProfileRequest(
+                "New Name",
+                "010-1234-5678",
+                JobFamily.FE,
+                Region.SEOUL,
+                CareerDetails.STUDENT,
+                ExperiencePeriod.NONE,
+                List.of(InterestedDomain.GAME.getDescription(), InterestedDomain.EDUCATION.getDescription())
+        );
+        Recruit recruit = getActiveRecruit(request.jobFamily(), List.of());
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(recruitRepository.findActiveRecruitByJobFamily(eq(request.jobFamily()), any()))
+                .willReturn(Optional.of(recruit));
+        given(applyRepository.existsByMemberIdAndRecruitIdInActiveRecruit(eq(memberId), eq(recruit.getId()), any()))
+                .willReturn(false);
+
+        // when
+        applyService.saveProfile(memberId, null, request);
+
+        // then
+        ArgumentCaptor<Apply> applyCaptor = ArgumentCaptor.forClass(Apply.class);
+        verify(applyRepository).save(applyCaptor.capture());
+        assertThat(applyCaptor.getValue().getRecruit()).isEqualTo(recruit);
     }
 
     private Recruit getActiveRecruit(JobFamily jobFamily, List<Question> questions) {

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -27,6 +27,8 @@ import org.ject.support.domain.recruit.domain.Question;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.exception.QuestionException;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -631,9 +633,10 @@ class ApplyServiceTest extends UnitTestSupport {
     }
 
     @Test
-    void 프로필_저장_시_모집_공고_식별자가_없으면_직군으로_공고를_조회한다() {
+    void 프로필_저장_시_유효하지_않은_모집_공고_식별자면_실패한다() {
         // given
         long memberId = 1L;
+        long invalidRecruitId = 999L;
         Member member = getApplicant(memberId, "test@example.com");
         ApplyProfileRequest request = new ApplyProfileRequest(
                 "New Name",
@@ -644,21 +647,17 @@ class ApplyServiceTest extends UnitTestSupport {
                 ExperiencePeriod.NONE,
                 List.of(InterestedDomain.GAME.getDescription(), InterestedDomain.EDUCATION.getDescription())
         );
-        Recruit recruit = getActiveRecruit(request.jobFamily(), List.of());
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(recruitRepository.findActiveRecruitByJobFamily(eq(request.jobFamily()), any()))
-                .willReturn(Optional.of(recruit));
-        given(applyRepository.existsByMemberIdAndRecruitIdInActiveRecruit(eq(memberId), eq(recruit.getId()), any()))
-                .willReturn(false);
+        given(recruitRepository.findActiveRecruitById(eq(invalidRecruitId), any())).willReturn(null);
 
-        // when
-        applyService.saveProfile(memberId, null, request);
+        // when, then
+        assertThatThrownBy(() -> applyService.saveProfile(memberId, invalidRecruitId, request))
+                .isInstanceOf(RecruitException.class)
+                .extracting("errorCode")
+                .isEqualTo(RecruitErrorCode.NOT_FOUND_RECRUIT);
 
-        // then
-        ArgumentCaptor<Apply> applyCaptor = ArgumentCaptor.forClass(Apply.class);
-        verify(applyRepository).save(applyCaptor.capture());
-        assertThat(applyCaptor.getValue().getRecruit()).isEqualTo(recruit);
+        verify(applyRepository, never()).save(any(Apply.class));
     }
 
     private Recruit getActiveRecruit(JobFamily jobFamily, List<Question> questions) {


### PR DESCRIPTION
## #️⃣연관된 이슈

close #542
Parent: #427

## 📝 작업 내용

- `/apply/profile`에 `recruitId` query parameter를 추가해 모집 공고 기준으로 프로필을 저장합니다.
- `recruitId`를 필수 값으로 받고, 공고 조회는 `recruitId` 기준으로만 수행합니다.
- `memberId + recruitId` 기준 지원 정보 존재 여부 조회를 추가하고, 해당 공고의 Apply가 없을 때만 생성합니다.
- 프로필 저장 시 회원 직군은 요청 body의 `jobFamily`가 아니라 모집 공고의 `jobFamily`를 기준으로 저장합니다.
- 컨트롤러, 서비스, Repository 테스트를 보강합니다.

## 🙏 리뷰 요구사항 (선택)

- 기존 URL은 유지하고 `recruitId`를 query parameter로 받은 결정이 현재 프론트 전환 전략과 맞는지 확인해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 프로필 저장 시 특정 공고를 지정하도록 변경되었습니다. 지원 공고의 활성 여부를 검증합니다.

* **테스트**
  * 프로필 저장 엔드포인트 및 공고 존재 여부 확인 기능에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->