### PR TITLE
feat: 모집 공고 기준으로 임시저장 API

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
@@ -17,20 +17,23 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface ApplyApiSpec {
 
     @Operation(
-            summary = "가장 최근에 저장된 임시 지원서 조회",
-            description = "가장 최근에 저장된 임시 지원서를 조회합니다.")
-    TempApplicationFormResponse findTempApplicationForm(@AuthPrincipal Long memberId);
+            summary = "지원서 임시 저장 조회",
+            description = "지원자의 특정 공고에 대한 임시 저장 지원서를 조회합니다.")
+    TempApplicationFormResponse findTempApplicationForm(@AuthPrincipal Long memberId,
+                                                        @RequestParam Long recruitId);
 
     @Operation(
             summary = "지원서 임시 저장",
-            description = "지원서를 임시 저장합니다.")
+            description = "지원자의 특정 공고에 대한 지원서를 임시 저장합니다.")
     void saveApplicationTemporarily(@AuthPrincipal Long memberId,
+                                    @RequestParam Long recruitId,
                                     @RequestBody ApplyTemporaryRequest request);
 
     @Operation(
             summary = "지원서 초기화",
-            description = "해당 지원자의 프로필과 임시 지원서를 제거합니다.")
-    void deleteProfileAndTempApplicationForm(@AuthPrincipal Long memberId);
+            description = "지원자의 특정 공고에 대한 프로필과 임시 지원서를 제거합니다.")
+    void deleteProfileAndTempApplicationForm(@AuthPrincipal Long memberId,
+                                             @RequestParam Long recruitId);
 
     @Operation(
             summary = "지원서 제출",

--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
@@ -28,23 +28,26 @@ public class ApplyController implements ApplyApiSpec {
     @Override
     @GetMapping("/temp")
     @PreAuthorize("hasRole('ROLE_APPLY')")
-    public TempApplicationFormResponse findTempApplicationForm(@AuthPrincipal Long memberId) {
-        return applyUsecase.findTempApplicationForm(memberId);
+    public TempApplicationFormResponse findTempApplicationForm(@AuthPrincipal Long memberId,
+                                                               @RequestParam Long recruitId) {
+        return applyUsecase.findTempApplicationForm(memberId, recruitId);
     }
 
     @Override
     @PostMapping("/temp")
     @PreAuthorize("hasRole('ROLE_APPLY')")
     public void saveApplicationTemporarily(@AuthPrincipal Long memberId,
+                                           @RequestParam Long recruitId,
                                            @RequestBody ApplyTemporaryRequest request) {
-        applyUsecase.saveApplicationTemporarily(memberId, request.answers(), request.portfolios());
+        applyUsecase.saveApplicationTemporarily(memberId, recruitId, request.answers(), request.portfolios());
     }
 
     @Override
     @DeleteMapping("/temp")
     @PreAuthorize("hasRole('ROLE_APPLY')")
-    public void deleteProfileAndTempApplicationForm(@AuthPrincipal Long memberId) {
-        applyUsecase.deleteProfileAndTempApplicationForm(memberId);
+    public void deleteProfileAndTempApplicationForm(@AuthPrincipal Long memberId,
+                                                    @RequestParam Long recruitId) {
+        applyUsecase.deleteProfileAndTempApplicationForm(memberId, recruitId);
     }
 
     @Override

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -58,8 +58,8 @@ public class ApplyService implements ApplyUsecase {
     @Override
     @PeriodAccessible(permitAllJob = true)
     @Transactional(readOnly = true)
-    public TempApplicationFormResponse findTempApplicationForm(final Long memberId) {
-        Apply apply = applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
+    public TempApplicationFormResponse findTempApplicationForm(final Long memberId, final Long recruitId) {
+        Apply apply = applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(memberId, recruitId, LocalDateTime.now())
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
 
         if (apply.isNotTempSaved()) {
@@ -80,10 +80,11 @@ public class ApplyService implements ApplyUsecase {
     @PeriodAccessible(permitAllJob = true)
     @Transactional
     public void saveApplicationTemporarily(Long memberId,
+                                           Long recruitId,
                                            Map<String, String> answers,
                                            List<ApplyPortfolioDto> portfolios) {
-        // 1. memberId를 바탕으로 apply 조회
-        Apply apply = applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
+        // 1. memberId와 recruitId를 바탕으로 apply 조회
+        Apply apply = applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(memberId, recruitId, LocalDateTime.now())
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
 
         ApplyStatus applyStatus = apply.getStatus();
@@ -118,9 +119,9 @@ public class ApplyService implements ApplyUsecase {
     @Override
     @PeriodAccessible(permitAllJob = true)
     @Transactional
-    public void deleteProfileAndTempApplicationForm(Long memberId) {
+    public void deleteProfileAndTempApplicationForm(Long memberId, Long recruitId) {
         // 지원 정보 조회
-        Apply apply = applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
+        Apply apply = applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(memberId, recruitId, LocalDateTime.now())
                 .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
 
         // 지원서를 임시 저장하지 않은 경우 실패

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
@@ -10,14 +10,15 @@ import java.util.List;
 import java.util.Map;
 
 public interface ApplyUsecase {
-    TempApplicationFormResponse findTempApplicationForm(Long memberId);
+    TempApplicationFormResponse findTempApplicationForm(Long memberId, Long recruitId);
 
     void saveApplicationTemporarily(Long memberId,
+                                    Long recruitId,
                                     Map<String, String> answers,
                                     List<ApplyPortfolioDto> portfolios);
 
 
-    void deleteProfileAndTempApplicationForm(Long memberId);
+    void deleteProfileAndTempApplicationForm(Long memberId, Long recruitId);
 
     void submitApplication(Long memberId,
                            JobFamily jobFamily,

--- a/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
+++ b/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
@@ -6,6 +6,8 @@ import org.ject.support.common.response.ResponseWrapper;
 import org.ject.support.common.security.AuthenticatedMemberIdResolver;
 import org.ject.support.common.security.CustomUserDetails;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
+import org.ject.support.domain.apply.dto.ApplyTemporaryRequest;
+import org.ject.support.domain.apply.dto.TempApplicationFormResponse;
 import org.ject.support.domain.apply.service.ApplyUsecase;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
@@ -25,11 +27,15 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -57,6 +63,60 @@ class ApplyControllerTest extends UnitTestSupport {
     @AfterEach
     void tearDown() {
         SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 임시저장_지원서를_모집_공고_기준으로_조회한다() throws Exception {
+        // given
+        long memberId = 1L;
+        long recruitId = 10L;
+        setAuthentication(memberId);
+        given(applyUsecase.findTempApplicationForm(memberId, recruitId))
+                .willReturn(new TempApplicationFormResponse(JobFamily.FE, Map.of("1", "답변"), List.of()));
+
+        // when, then
+        mockMvc.perform(get("/apply/temp")
+                        .param("recruitId", String.valueOf(recruitId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+
+        verify(applyUsecase).findTempApplicationForm(memberId, recruitId);
+    }
+
+    @Test
+    void 지원서를_모집_공고_기준으로_임시저장한다() throws Exception {
+        // given
+        long memberId = 1L;
+        long recruitId = 10L;
+        setAuthentication(memberId);
+        ApplyTemporaryRequest request = new ApplyTemporaryRequest(Map.of("1", "답변"), List.of());
+
+        // when, then
+        mockMvc.perform(post("/apply/temp")
+                        .param("recruitId", String.valueOf(recruitId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+
+        verify(applyUsecase).saveApplicationTemporarily(
+                eq(memberId), eq(recruitId), eq(request.answers()), eq(request.portfolios()));
+    }
+
+    @Test
+    void 모집_공고_기준으로_프로필과_임시저장_지원서를_제거한다() throws Exception {
+        // given
+        long memberId = 1L;
+        long recruitId = 10L;
+        setAuthentication(memberId);
+
+        // when, then
+        mockMvc.perform(delete("/apply/temp")
+                        .param("recruitId", String.valueOf(recruitId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+
+        verify(applyUsecase).deleteProfileAndTempApplicationForm(memberId, recruitId);
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
@@ -129,6 +129,25 @@ class ApplyRepositoryTest {
     }
 
     @Test
+    void 회원과_모집_공고를_바탕으로_활성_지원정보를_조회한다() {
+        // given
+        Member applicant = createMember("email@test.com", Role.APPLY);
+        memberRepository.save(applicant);
+
+        Apply feApply = getApply(applicant, feRecruit, JOINED);
+        Apply beApply = getApply(applicant, beRecruit, TEMP_SAVED);
+        applyRepository.saveAll(List.of(feApply, beApply));
+
+        // when
+        Apply result = applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(
+                applicant.getId(), beRecruit.getId(), LocalDateTime.now()).orElseThrow();
+
+        // then
+        assertThat(result).isEqualTo(beApply);
+        assertThat(result.getRecruit()).isEqualTo(beRecruit);
+    }
+
+    @Test
     void 지원ID와_지원서의_상태로_지원서를_상세_조회한다() {
         // given
         Member feApplicant = createMember("emailFE@test.com", Role.APPLY);

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -317,11 +317,12 @@ class ApplyServiceTest extends UnitTestSupport {
 
         String content = "newContent";
 
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(applicant.getId()), eq(recruit.getId()), any()))
+                .thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(content);
 
         // when
-        applyService.saveApplicationTemporarily(1L, answers, List.of());
+        applyService.saveApplicationTemporarily(1L, recruit.getId(), answers, List.of());
 
         // then
         ArgumentCaptor<ApplicationForm> captor = ArgumentCaptor.forClass(ApplicationForm.class);
@@ -358,10 +359,11 @@ class ApplyServiceTest extends UnitTestSupport {
 
         Apply apply = getApply(1L, recruit, applicant, applicationForm, SUBMITTED);
 
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(applicant.getId()), eq(recruit.getId()), any()))
+                .thenReturn(Optional.of(apply));
 
         // when, then
-        assertThatThrownBy(() -> applyService.saveApplicationTemporarily(1L, answers, List.of()))
+        assertThatThrownBy(() -> applyService.saveApplicationTemporarily(1L, recruit.getId(), answers, List.of()))
                 .isInstanceOf(ApplyException.class);
     }
 
@@ -369,12 +371,14 @@ class ApplyServiceTest extends UnitTestSupport {
     void 프로필_저장_전에_임시저장_시도_시_실패() {
         // given
         long memberId = 1L;
+        long recruitId = 1L;
         Map<String, String> answers = Map.of("1", "답변1");
 
-        given(applyRepository.findByMemberIdInActiveRecruit(eq(memberId), any())).willReturn(Optional.empty());
+        given(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(memberId), eq(recruitId), any()))
+                .willReturn(Optional.empty());
 
         // expected
-        assertThatThrownBy(() -> applyService.saveApplicationTemporarily(memberId, answers, List.of()))
+        assertThatThrownBy(() -> applyService.saveApplicationTemporarily(memberId, recruitId, answers, List.of()))
                 .isInstanceOf(ApplyException.class)
                 .extracting("errorCode")
                 .isEqualTo(ApplyErrorCode.NOT_FOUND_APPLY);
@@ -408,11 +412,12 @@ class ApplyServiceTest extends UnitTestSupport {
 
         String newContent = "newContent";
 
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(applicant.getId()), eq(recruit.getId()), any()))
+                .thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(newContent);
 
         // when
-        applyService.saveApplicationTemporarily(1L, answers, List.of());
+        applyService.saveApplicationTemporarily(1L, recruit.getId(), answers, List.of());
 
         // then
         ApplicationForm newApplicationForm = apply.getApplicationForm();
@@ -438,10 +443,11 @@ class ApplyServiceTest extends UnitTestSupport {
 
         Apply apply = getApply(1L, recruit, getApplicant(1L, "email@test.com"), applicationForm, TEMP_SAVED);
 
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(1L), eq(recruit.getId()), any()))
+                .thenReturn(Optional.of(apply));
 
         // when
-        applyService.deleteProfileAndTempApplicationForm(1L);
+        applyService.deleteProfileAndTempApplicationForm(1L, recruit.getId());
 
         // then
         assertThat(apply.getApplicationForm()).isNull();
@@ -473,13 +479,15 @@ class ApplyServiceTest extends UnitTestSupport {
                 .content("content")
                 .build(), SUBMITTED);
 
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply1));
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(2L), any())).thenReturn(Optional.of(apply2));
+        when(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(1L), eq(recruit.getId()), any()))
+                .thenReturn(Optional.of(apply1));
+        when(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(2L), eq(recruit.getId()), any()))
+                .thenReturn(Optional.of(apply2));
 
         // when, then
-        assertThatThrownBy(() -> applyService.deleteProfileAndTempApplicationForm(1L))
+        assertThatThrownBy(() -> applyService.deleteProfileAndTempApplicationForm(1L, recruit.getId()))
                 .isInstanceOf(ApplyException.class);
-        assertThatThrownBy(() -> applyService.deleteProfileAndTempApplicationForm(2L))
+        assertThatThrownBy(() -> applyService.deleteProfileAndTempApplicationForm(2L, recruit.getId()))
                 .isInstanceOf(ApplyException.class);
     }
 
@@ -499,11 +507,12 @@ class ApplyServiceTest extends UnitTestSupport {
 
         Apply apply = getApply(1L, recruit, getApplicant(1L, "email@test.com"), tempApplicationForm, TEMP_SAVED);
 
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(1L), eq(recruit.getId()), any()))
+                .thenReturn(Optional.of(apply));
         when(string2MapSerializer.serializeAsMap(tempApplicationForm.getContent())).thenReturn(answers);
 
         // when
-        TempApplicationFormResponse result = applyService.findTempApplicationForm(1L);
+        TempApplicationFormResponse result = applyService.findTempApplicationForm(1L, recruit.getId());
 
         // then
         assertThat(result.answers()).isEqualTo(answers);
@@ -522,10 +531,11 @@ class ApplyServiceTest extends UnitTestSupport {
 
         Apply apply = getApply(1L, getActiveRecruit(BE, questions), getApplicant(1L, "email@test.com"), null, JOINED);
 
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(1L), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(eq(1L), eq(apply.getRecruit().getId()), any()))
+                .thenReturn(Optional.of(apply));
 
         // when, then
-        assertThatThrownBy(() -> applyService.findTempApplicationForm(1L))
+        assertThatThrownBy(() -> applyService.findTempApplicationForm(1L, apply.getRecruit().getId()))
                 .isInstanceOf(ApplyException.class);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #544
Parent: #427

## 📝 작업 내용

- `/apply/temp` 조회 API에 `recruitId` query parameter를 추가합니다.
- `/apply/temp` 저장 API에 `recruitId` query parameter를 추가합니다.
- `/apply/temp` 삭제 API에 `recruitId` query parameter를 추가합니다.
- 임시저장 조회/저장/삭제가 `memberId + recruitId` 기준 지원 정보만 사용하도록 변경합니다.
- 컨트롤러, 서비스, Repository 테스트를 보강합니다.

## 🙏 리뷰 요구사항 (선택)

- 기존 URL은 유지하고 `recruitId`를 query parameter로 받은 결정이 현재 프론트 전환 전략과 맞는지 확인해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 임시 저장 지원서 관리 기능이 채용공고별로 분리되어 개선되었습니다. 이제 여러 채용공고에 대해 독립적으로 작성 중인 지원서를 관리할 수 있으며, 각 공고별 임시 저장 상태를 별도로 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->