### PR TITLE
feat: 모집 공고 기준으로 지원서 제출 및 상태 API 분리

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyApiSpec.java
@@ -9,7 +9,6 @@ import org.ject.support.domain.apply.dto.ApplyStatusResponse;
 import org.ject.support.domain.apply.dto.ApplyTemporaryRequest;
 import org.ject.support.domain.apply.dto.SubmitApplicationRequest;
 import org.ject.support.domain.apply.dto.TempApplicationFormResponse;
-import org.ject.support.domain.member.JobFamily;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -37,9 +36,9 @@ public interface ApplyApiSpec {
 
     @Operation(
             summary = "지원서 제출",
-            description = "작성이 완료된 지원서를 제출합니다.")
+            description = "지원자의 특정 공고에 대해 작성이 완료된 지원서를 제출합니다.")
     void submitApplication(@AuthPrincipal Long memberId,
-                           @RequestParam JobFamily jobFamily,
+                           @RequestParam Long recruitId,
                            @RequestBody SubmitApplicationRequest request);
 
     @Operation(

--- a/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/ject/support/domain/apply/controller/ApplyController.java
@@ -9,7 +9,6 @@ import org.ject.support.domain.apply.dto.ApplyTemporaryRequest;
 import org.ject.support.domain.apply.dto.SubmitApplicationRequest;
 import org.ject.support.domain.apply.dto.TempApplicationFormResponse;
 import org.ject.support.domain.apply.service.ApplyUsecase;
-import org.ject.support.domain.member.JobFamily;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -54,9 +53,9 @@ public class ApplyController implements ApplyApiSpec {
     @PostMapping("/submit")
     @PreAuthorize("hasRole('ROLE_APPLY')")
     public void submitApplication(@AuthPrincipal Long memberId,
-                                  @RequestParam JobFamily jobFamily,
+                                  @RequestParam Long recruitId,
                                   @RequestBody SubmitApplicationRequest request) {
-        applyUsecase.submitApplication(memberId, jobFamily, request.answers(), request.portfolios());
+        applyUsecase.submitApplication(memberId, recruitId, request.answers(), request.portfolios());
     }
 
     @Override

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -179,6 +179,7 @@ public class ApplyService implements ApplyUsecase {
 
     @Override
     @PeriodAccessible(permitAllJob = true)
+    @Transactional(readOnly = true)
     public ApplyStatusResponse checkApplyStatus(Long memberId, Long recruitId) {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -17,7 +17,6 @@ import org.ject.support.domain.apply.exception.ApplyErrorCode;
 import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.domain.apply.repository.ApplicationFormRepository;
 import org.ject.support.domain.apply.repository.ApplyRepository;
-import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.exception.MemberErrorCode;
 import org.ject.support.domain.member.exception.MemberException;
@@ -139,27 +138,25 @@ public class ApplyService implements ApplyUsecase {
     }
 
     @Override
-    @PeriodAccessible
+    @PeriodAccessible(permitAllJob = true)
     @Transactional
     public void submitApplication(Long memberId,
-                                  JobFamily jobFamily,
+                                  Long recruitId,
                                   Map<String, String> answers,
                                   List<ApplyPortfolioDto> portfolios) {
         try {
-            // 1. jobFamily를 통해 현재 기수 지원양식 id 조회
-            Recruit recruit = getPeriodRecruit(jobFamily);
+            // 1. 지원 정보 조회 (낙관적 락 - @Version 기반 동시성 제어)
+            Apply apply = applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(
+                            memberId, recruitId, LocalDateTime.now())
+                    .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
 
             // 2. 지원양식과 answers의 key를 비교해 올바른 질문 양식인지 점검
-            validateQuestions(answers, recruit);
-
-            // 3. 지원 정보 조회 (낙관적 락 - @Version 기반 동시성 제어)
-            Apply apply = applyRepository.findByMemberIdInActiveRecruit(memberId, LocalDateTime.now())
-                    .orElseThrow(() -> new ApplyException(NOT_FOUND_APPLY));
+            validateQuestions(answers, apply.getRecruit());
 
             String content = map2JsonSerializer.serializeAsString(answers);
             List<Portfolio> newPortfolios = getNewPortfolios(portfolios);
 
-            // 4. ApplicationForm 준비
+            // 3. ApplicationForm 준비
             ApplicationForm applicationForm;
             if (apply.isTempSaved()) {
                 applicationForm = apply.getApplicationForm();
@@ -169,7 +166,7 @@ public class ApplyService implements ApplyUsecase {
                 applicationFormRepository.save(applicationForm);
             }
 
-            // 5. Apply 엔티티에 제출 위임 (검증 및 상태 변경 포함)
+            // 4. Apply 엔티티에 제출 위임 (검증 및 상태 변경 포함)
             apply.submit(applicationForm);
 
             // 명시적 flush를 통해 낙관적 락 충돌을 메서드 내부에서 감지하고 catch 블록으로 전달합니다.
@@ -236,11 +233,6 @@ public class ApplyService implements ApplyUsecase {
                 .forEach(key -> {
                     throw new QuestionException(QuestionErrorCode.NOT_FOUND_QUESTION);
                 });
-    }
-
-    private Recruit getPeriodRecruit(final JobFamily jobFamily) {
-        return recruitRepository.findActiveRecruitByJobFamily(jobFamily, LocalDateTime.now())
-                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
     }
 
     private Recruit getActiveRecruit(final Long recruitId) {

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyUsecase.java
@@ -4,7 +4,6 @@ import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
 import org.ject.support.domain.apply.dto.ApplyStatusResponse;
 import org.ject.support.domain.apply.dto.TempApplicationFormResponse;
-import org.ject.support.domain.member.JobFamily;
 
 import java.util.List;
 import java.util.Map;
@@ -21,7 +20,7 @@ public interface ApplyUsecase {
     void deleteProfileAndTempApplicationForm(Long memberId, Long recruitId);
 
     void submitApplication(Long memberId,
-                           JobFamily jobFamily,
+                           Long recruitId,
                            Map<String, String> answers,
                            List<ApplyPortfolioDto> portfolios);
 

--- a/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
+++ b/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
@@ -7,6 +7,7 @@ import org.ject.support.common.security.AuthenticatedMemberIdResolver;
 import org.ject.support.common.security.CustomUserDetails;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
 import org.ject.support.domain.apply.dto.ApplyTemporaryRequest;
+import org.ject.support.domain.apply.dto.SubmitApplicationRequest;
 import org.ject.support.domain.apply.dto.TempApplicationFormResponse;
 import org.ject.support.domain.apply.service.ApplyUsecase;
 import org.ject.support.domain.member.CareerDetails;
@@ -117,6 +118,42 @@ class ApplyControllerTest extends UnitTestSupport {
                 .andExpect(jsonPath("$.status").value("SUCCESS"));
 
         verify(applyUsecase).deleteProfileAndTempApplicationForm(memberId, recruitId);
+    }
+
+    @Test
+    void 지원서를_모집_공고_기준으로_제출한다() throws Exception {
+        // given
+        long memberId = 1L;
+        long recruitId = 10L;
+        setAuthentication(memberId);
+        SubmitApplicationRequest request = new SubmitApplicationRequest(Map.of("1", "답변"), List.of());
+
+        // when, then
+        mockMvc.perform(post("/apply/submit")
+                        .param("recruitId", String.valueOf(recruitId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+
+        verify(applyUsecase).submitApplication(
+                eq(memberId), eq(recruitId), eq(request.answers()), eq(request.portfolios()));
+    }
+
+    @Test
+    void 모집_공고_식별자가_없으면_지원서_제출에_실패한다() throws Exception {
+        // given
+        long memberId = 1L;
+        setAuthentication(memberId);
+        SubmitApplicationRequest request = new SubmitApplicationRequest(Map.of("1", "답변"), List.of());
+
+        // when, then
+        mockMvc.perform(post("/apply/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(applyUsecase);
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
+++ b/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
@@ -6,6 +6,7 @@ import org.ject.support.common.response.ResponseWrapper;
 import org.ject.support.common.security.AuthenticatedMemberIdResolver;
 import org.ject.support.common.security.CustomUserDetails;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
+import org.ject.support.domain.apply.dto.ApplyStatusResponse;
 import org.ject.support.domain.apply.dto.ApplyTemporaryRequest;
 import org.ject.support.domain.apply.dto.SubmitApplicationRequest;
 import org.ject.support.domain.apply.dto.TempApplicationFormResponse;
@@ -30,6 +31,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.List;
 import java.util.Map;
 
+import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -151,6 +153,38 @@ class ApplyControllerTest extends UnitTestSupport {
         mockMvc.perform(post("/apply/submit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(applyUsecase);
+    }
+
+    @Test
+    void 지원상태를_모집_공고_기준으로_조회한다() throws Exception {
+        // given
+        long memberId = 1L;
+        long recruitId = 10L;
+        setAuthentication(memberId);
+        given(applyUsecase.checkApplyStatus(memberId, recruitId))
+                .willReturn(new ApplyStatusResponse(SUBMITTED));
+
+        // when, then
+        mockMvc.perform(get("/apply/status")
+                        .param("recruitId", String.valueOf(recruitId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.status").value("SUBMITTED"));
+
+        verify(applyUsecase).checkApplyStatus(memberId, recruitId);
+    }
+
+    @Test
+    void 모집_공고_식별자가_없으면_지원상태_조회에_실패한다() throws Exception {
+        // given
+        long memberId = 1L;
+        setAuthentication(memberId);
+
+        // when, then
+        mockMvc.perform(get("/apply/status"))
                 .andExpect(status().isBadRequest());
 
         verifyNoInteractions(applyUsecase);

--- a/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
+++ b/src/test/java/org/ject/support/domain/apply/service/ApplyServiceTest.java
@@ -104,12 +104,12 @@ class ApplyServiceTest extends UnitTestSupport {
 
         Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
 
-        when(recruitRepository.findActiveRecruitByJobFamily(any(), any())).thenReturn(Optional.of(recruit));
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(
+                eq(applicant.getId()), eq(recruit.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
         // when
-        applyService.submitApplication(1L, BE, answers, List.of());
+        applyService.submitApplication(1L, recruit.getId(), answers, List.of());
 
         // then
         // 1. TEMP_SAVED 상태에서는 update가 발생하므로 save가 호출되지 않아야 함
@@ -135,12 +135,12 @@ class ApplyServiceTest extends UnitTestSupport {
         ApplicationForm applicationForm = getApplicationForm(answers.toString());
         Apply apply = getApply(1L, recruit, applicant, applicationForm, TEMP_SAVED);
 
-        when(recruitRepository.findActiveRecruitByJobFamily(any(), any())).thenReturn(Optional.of(recruit));
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(
+                eq(applicant.getId()), eq(recruit.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
         // expected
-        assertThatThrownBy(() -> applyService.submitApplication(1L, PD, answers, List.of()))
+        assertThatThrownBy(() -> applyService.submitApplication(1L, recruit.getId(), answers, List.of()))
                 .isInstanceOf(ApplyException.class)
                 .extracting("errorCode")
                 .isEqualTo(ApplyErrorCode.PORTFOLIO_REQUIRED);
@@ -162,12 +162,12 @@ class ApplyServiceTest extends UnitTestSupport {
                 new ApplyPortfolioDto("url", "name", "100", "1")
         );
 
-        when(recruitRepository.findActiveRecruitByJobFamily(any(), any())).thenReturn(Optional.of(recruit));
-        when(applyRepository.findByMemberIdInActiveRecruit(eq(applicant.getId()), any())).thenReturn(Optional.of(apply));
+        when(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(
+                eq(applicant.getId()), eq(recruit.getId()), any())).thenReturn(Optional.of(apply));
         when(map2JsonSerializer.serializeAsString(answers)).thenReturn(answers.toString());
 
         // when
-        applyService.submitApplication(1L, PD, answers, portfolios);
+        applyService.submitApplication(1L, recruit.getId(), answers, portfolios);
 
         // then
         assertThat(apply.getStatus()).isEqualTo(SUBMITTED);
@@ -191,10 +191,13 @@ class ApplyServiceTest extends UnitTestSupport {
                 "3", "답변 3",
                 "4", "답변 4");
 
-        when(recruitRepository.findActiveRecruitByJobFamily(any(), any())).thenReturn(Optional.of(recruit));
+        Member applicant = getApplicant(1L, "email@test.com");
+        Apply apply = getApply(1L, recruit, applicant, null, JOINED);
+        when(applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(
+                eq(applicant.getId()), eq(recruit.getId()), any())).thenReturn(Optional.of(apply));
 
         // when, then
-        assertThatThrownBy(() -> applyService.submitApplication(1L, BE, answers, List.of()))
+        assertThatThrownBy(() -> applyService.submitApplication(1L, recruit.getId(), answers, List.of()))
                 .isInstanceOf(QuestionException.class);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #546
close #548
Parent: #427

## 📝 작업 내용

- `/apply/submit` 요청 파라미터를 `jobFamily`에서 `recruitId`로 변경
- 제출 대상 지원서를 `memberId + recruitId` 기준으로 조회하도록 변경
- `/apply/status?recruitId=` controller 계약 테스트 추가
- `recruitId` 누락 시 submit/status가 bad request를 반환하는 테스트 추가
- 지원 상태 조회 서비스에 read-only 트랜잭션 명시

## 🙏 리뷰 요구사항 (선택)

- `@PeriodAccessible(permitAllJob = true)`는 기존 Aspect가 `JobFamily` 인자를 요구하기 때문에 이번 PR에서 유지했습니다. 실제 공고 활성 여부는 repository의 recruit 기간 조건으로 검증하며, #16에서 `recruitId` 기반 Redis 검증으로 정리 예정입니다.