### PR TITLE
test: 공고별 지원 상태 API 계약 보강

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -182,6 +182,7 @@ public class ApplyService implements ApplyUsecase {
 
     @Override
     @PeriodAccessible(permitAllJob = true)
+    @Transactional(readOnly = true)
     public ApplyStatusResponse checkApplyStatus(Long memberId, Long recruitId) {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER));

--- a/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
+++ b/src/test/java/org/ject/support/domain/apply/controller/ApplyControllerTest.java
@@ -6,6 +6,7 @@ import org.ject.support.common.response.ResponseWrapper;
 import org.ject.support.common.security.AuthenticatedMemberIdResolver;
 import org.ject.support.common.security.CustomUserDetails;
 import org.ject.support.domain.apply.dto.ApplyProfileRequest;
+import org.ject.support.domain.apply.dto.ApplyStatusResponse;
 import org.ject.support.domain.apply.dto.ApplyTemporaryRequest;
 import org.ject.support.domain.apply.dto.TempApplicationFormResponse;
 import org.ject.support.domain.apply.service.ApplyUsecase;
@@ -29,6 +30,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.List;
 import java.util.Map;
 
+import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -117,6 +119,38 @@ class ApplyControllerTest extends UnitTestSupport {
                 .andExpect(jsonPath("$.status").value("SUCCESS"));
 
         verify(applyUsecase).deleteProfileAndTempApplicationForm(memberId, recruitId);
+    }
+
+    @Test
+    void 지원상태를_모집_공고_기준으로_조회한다() throws Exception {
+        // given
+        long memberId = 1L;
+        long recruitId = 10L;
+        setAuthentication(memberId);
+        given(applyUsecase.checkApplyStatus(memberId, recruitId))
+                .willReturn(new ApplyStatusResponse(SUBMITTED));
+
+        // when, then
+        mockMvc.perform(get("/apply/status")
+                        .param("recruitId", String.valueOf(recruitId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.status").value("SUBMITTED"));
+
+        verify(applyUsecase).checkApplyStatus(memberId, recruitId);
+    }
+
+    @Test
+    void 모집_공고_식별자가_없으면_지원상태_조회에_실패한다() throws Exception {
+        // given
+        long memberId = 1L;
+        setAuthentication(memberId);
+
+        // when, then
+        mockMvc.perform(get("/apply/status"))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(applyUsecase);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

close #548
Parent: #427

## 📝 작업 내용

- `/apply/status?recruitId=` 성공 응답 controller 테스트 추가
- `recruitId` 누락 시 bad request 응답 controller 테스트 추가
- 지원 상태 조회 서비스에 read-only 트랜잭션 명시

## 🙏 리뷰 요구사항 (선택)

- 기존 상태 조회 구현은 이미 `memberId + recruitId` 기준으로 동작하고 있어, 이번 PR은 API 계약을 테스트로 고정하는 범위입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 신청 상태 확인 요청 처리가 최적화되었습니다.

* **Tests**
  * 신청 상태 조회 엔드포인트의 테스트 커버리지가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->