### PR TITLE
feat: 어드민 지원자 필터 확장

### DIFF
--- a/src/main/java/org/ject/support/admin/apply/controller/AdminApplyController.java
+++ b/src/main/java/org/ject/support/admin/apply/controller/AdminApplyController.java
@@ -6,12 +6,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.apply.dto.AdminApplyDetailResponse;
 import org.ject.support.admin.apply.dto.AdminApplyResponse;
+import org.ject.support.admin.apply.dto.AdminApplySearchCondition;
 import org.ject.support.admin.apply.dto.SubmittedApplyBulkDeleteRequest;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.service.AdminApplyService;
 import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.RecruitType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
@@ -36,13 +38,17 @@ public class AdminApplyController {
     @GetMapping
     @Operation(
             summary = "지원서 목록 조회",
-            description = "지원서들의 목록을 조회합니다.")
+            description = "지원서들의 목록을 조회합니다. 모집 공고, 모집 유형, 모집 사유, 기수, 직군, 지원 상태로 필터링할 수 있습니다.")
     public Page<AdminApplyResponse> findApplies(@RequestParam(required = false) final ApplyStatus applyStatus,
                                                 @RequestParam(required = false) final Long semesterId,
                                                 @RequestParam(required = false) final JobFamily jobFamily,
                                                 @RequestParam(required = false) final RecruitType recruitType,
+                                                @RequestParam(required = false) final RecruitTypeDetail recruitTypeDetail,
+                                                @RequestParam(required = false) final Long recruitId,
                                                 @PageableDefault(sort = "createdAt", direction = Direction.DESC) final Pageable pageable) {
-        return adminApplyService.findApplies(applyStatus, semesterId, jobFamily, recruitType, pageable);
+        AdminApplySearchCondition condition = new AdminApplySearchCondition(
+                applyStatus, semesterId, jobFamily, recruitType, recruitTypeDetail, recruitId);
+        return adminApplyService.findApplies(condition, pageable);
     }
 
     @GetMapping("/{applyId}")

--- a/src/main/java/org/ject/support/admin/apply/dto/AdminApplySearchCondition.java
+++ b/src/main/java/org/ject/support/admin/apply/dto/AdminApplySearchCondition.java
@@ -1,0 +1,16 @@
+package org.ject.support.admin.apply.dto;
+
+import org.ject.support.domain.apply.domain.ApplyStatus;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.RecruitType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+
+public record AdminApplySearchCondition(
+        ApplyStatus applyStatus,
+        Long semesterId,
+        JobFamily jobFamily,
+        RecruitType recruitType,
+        RecruitTypeDetail recruitTypeDetail,
+        Long recruitId
+) {
+}

--- a/src/main/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepository.java
+++ b/src/main/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepository.java
@@ -1,19 +1,15 @@
 package org.ject.support.admin.apply.repository;
 
 import java.util.Optional;
+import org.ject.support.admin.apply.dto.AdminApplySearchCondition;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.ApplyStatus;
-import org.ject.support.domain.member.JobFamily;
-import org.ject.support.domain.recruit.domain.RecruitType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface AdminApplyQueryRepository {
-    Page<Apply> findAppliesByStatus(final ApplyStatus status,
-                                    final Long semesterId,
-                                    final JobFamily jobFamily,
-                                    final RecruitType recruitType,
-                                    final Pageable pageable);
+    Page<Apply> findApplies(final AdminApplySearchCondition condition,
+                            final Pageable pageable);
 
     Optional<Apply> findApplyByIdByStatus(final Long applyId, final ApplyStatus status);
 }

--- a/src/main/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryImpl.java
@@ -11,11 +11,13 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.apply.dto.AdminApplySearchCondition;
 import org.ject.support.common.data.PageResponse;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.RecruitType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -27,11 +29,8 @@ public class AdminApplyQueryRepositoryImpl implements AdminApplyQueryRepository 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Apply> findAppliesByStatus(final ApplyStatus status,
-                                           final Long semesterId,
-                                           final JobFamily jobFamily,
-                                           final RecruitType recruitType,
-                                           final Pageable pageable) {
+    public Page<Apply> findApplies(final AdminApplySearchCondition condition,
+                                   final Pageable pageable) {
 
         List<Apply> content = queryFactory
                 .selectFrom(apply)
@@ -42,12 +41,14 @@ public class AdminApplyQueryRepositoryImpl implements AdminApplyQueryRepository 
                 .leftJoin(apply.applicationForm.portfolios, portfolio).fetchJoin()
                 .where(
                         apply.member.isDeleted.eq(false),
-                        eqJobFamily(jobFamily),
-                        eqApplyStatus(status),
-                        eqSemesterId(semesterId),
-                        eqRecruitType(recruitType)
+                        eqJobFamily(condition.jobFamily()),
+                        eqApplyStatus(condition.applyStatus()),
+                        eqSemesterId(condition.semesterId()),
+                        eqRecruitType(condition.recruitType()),
+                        eqRecruitTypeDetail(condition.recruitTypeDetail()),
+                        eqRecruitId(condition.recruitId())
                 )
-                .orderBy(apply.createdAt.desc())
+                .orderBy(apply.createdAt.desc(), apply.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -59,10 +60,12 @@ public class AdminApplyQueryRepositoryImpl implements AdminApplyQueryRepository 
                 .join(apply.recruit, recruit)
                 .where(
                         apply.member.isDeleted.eq(false),
-                        eqJobFamily(jobFamily),
-                        eqApplyStatus(status),
-                        eqSemesterId(semesterId),
-                        eqRecruitType(recruitType)
+                        eqJobFamily(condition.jobFamily()),
+                        eqApplyStatus(condition.applyStatus()),
+                        eqSemesterId(condition.semesterId()),
+                        eqRecruitType(condition.recruitType()),
+                        eqRecruitTypeDetail(condition.recruitTypeDetail()),
+                        eqRecruitId(condition.recruitId())
                 ).fetchOne();
 
         return PageResponse.from(content, pageable, total != null ? total : 0L);
@@ -108,6 +111,18 @@ public class AdminApplyQueryRepositoryImpl implements AdminApplyQueryRepository 
     private BooleanExpression eqRecruitType(final RecruitType recruitType) {
         return Optional.ofNullable(recruitType)
                 .map(apply.recruit.recruitType::eq)
+                .orElse(null);
+    }
+
+    private BooleanExpression eqRecruitTypeDetail(final RecruitTypeDetail recruitTypeDetail) {
+        return Optional.ofNullable(recruitTypeDetail)
+                .map(apply.recruit.recruitTypeDetail::eq)
+                .orElse(null);
+    }
+
+    private BooleanExpression eqRecruitId(final Long recruitId) {
+        return Optional.ofNullable(recruitId)
+                .map(apply.recruit.id::eq)
                 .orElse(null);
     }
 }

--- a/src/main/java/org/ject/support/admin/apply/service/AdminApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/AdminApplyService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.apply.dto.AdminApplyDetailResponse;
 import org.ject.support.admin.apply.dto.AdminApplyResponse;
+import org.ject.support.admin.apply.dto.AdminApplySearchCondition;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.repository.AdminApplyRepository;
 import org.ject.support.common.data.PageResponse;
@@ -16,11 +17,9 @@ import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.exception.ApplyErrorCode;
 import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.domain.apply.repository.ApplyRepository;
-import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.entity.MemberEditor;
 import org.ject.support.domain.recruit.domain.Recruit;
-import org.ject.support.domain.recruit.domain.RecruitType;
 import org.ject.support.domain.recruit.exception.QuestionErrorCode;
 import org.ject.support.domain.recruit.exception.QuestionException;
 import org.springframework.data.domain.Page;
@@ -37,12 +36,9 @@ public class AdminApplyService {
     private final Map2JsonSerializer map2JsonSerializer;
 
     @Transactional(readOnly = true)
-    public Page<AdminApplyResponse> findApplies(final ApplyStatus applyStatus,
-                                                final Long semesterId,
-                                                final JobFamily jobFamily,
-                                                final RecruitType recruitType,
+    public Page<AdminApplyResponse> findApplies(final AdminApplySearchCondition condition,
                                                 final Pageable pageable) {
-        Page<Apply> applyPage = adminApplyRepository.findAppliesByStatus(applyStatus, semesterId, jobFamily, recruitType, pageable);
+        Page<Apply> applyPage = adminApplyRepository.findApplies(condition, pageable);
 
         List<AdminApplyResponse> content = applyPage.getContent().stream()
                 .map(AdminApplyResponse::from)

--- a/src/test/java/org/ject/support/admin/apply/controller/AdminApplyControllerTest.java
+++ b/src/test/java/org/ject/support/admin/apply/controller/AdminApplyControllerTest.java
@@ -1,0 +1,75 @@
+package org.ject.support.admin.apply.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.ject.support.admin.apply.dto.AdminApplyResponse;
+import org.ject.support.admin.apply.dto.AdminApplySearchCondition;
+import org.ject.support.admin.apply.service.AdminApplyService;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.domain.apply.domain.ApplyStatus;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.RecruitType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class AdminApplyControllerTest extends UnitTestSupport {
+
+    @InjectMocks
+    private AdminApplyController adminApplyController;
+
+    @Mock
+    private AdminApplyService adminApplyService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(adminApplyController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .setControllerAdvice(new org.ject.support.common.exception.GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void 지원서_목록_조회시_공고_필터를_전달한다() throws Exception {
+        // given
+        var condition = new AdminApplySearchCondition(
+                ApplyStatus.SUBMITTED, 1L, JobFamily.BE, RecruitType.SEMESTER, RecruitTypeDetail.REFILL, 10L);
+        var pageable = PageRequest.of(0, 15);
+        var page = new PageImpl<AdminApplyResponse>(List.of(), pageable, 0);
+
+        given(adminApplyService.findApplies(eq(condition), any(Pageable.class)))
+                .willReturn(page);
+
+        // when, then
+        mockMvc.perform(get("/admin/applies")
+                        .param("applyStatus", "SUBMITTED")
+                        .param("semesterId", "1")
+                        .param("jobFamily", "BE")
+                        .param("recruitType", "SEMESTER")
+                        .param("recruitTypeDetail", "REFILL")
+                        .param("recruitId", "10")
+                        .param("page", "0")
+                        .param("size", "15")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(adminApplyService).findApplies(eq(condition), any(Pageable.class));
+    }
+}

--- a/src/test/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.ject.support.admin.apply.dto.AdminApplySearchCondition;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.ApplyStatus;
@@ -19,6 +20,8 @@ import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.RecruitType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
@@ -86,7 +89,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyRepository.findAppliesByStatus(status, null, BE, null, pageable);
+        Page<Apply> result = adminApplyRepository.findApplies(condition(status, null, BE, null), pageable);
 
         // then
         assertThat(result.getContent()).hasSize(2);
@@ -113,7 +116,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyRepository.findAppliesByStatus(status, null, null, null, pageable);
+        Page<Apply> result = adminApplyRepository.findApplies(condition(status, null, null, null), pageable);
 
         // then
         assertThat(result.getContent()).hasSize(3);
@@ -135,7 +138,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyRepository.findAppliesByStatus(status, null, BE, null, pageable);
+        Page<Apply> result = adminApplyRepository.findApplies(condition(status, null, BE, null), pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
@@ -158,7 +161,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyRepository.findAppliesByStatus(status, null, BE, null, pageable);
+        Page<Apply> result = adminApplyRepository.findApplies(condition(status, null, BE, null), pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
@@ -179,7 +182,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyRepository.findAppliesByStatus(status, null, BE, null, pageable);
+        Page<Apply> result = adminApplyRepository.findApplies(condition(status, null, BE, null), pageable);
 
         // then
         assertThat(result.getContent()).hasSize(10);
@@ -195,7 +198,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyRepository.findAppliesByStatus(status, null, BE, null, pageable);
+        Page<Apply> result = adminApplyRepository.findApplies(condition(status, null, BE, null), pageable);
 
 
         // then
@@ -224,7 +227,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyRepository.findAppliesByStatus(status, null, BE, null, pageable);
+        Page<Apply> result = adminApplyRepository.findApplies(condition(status, null, BE, null), pageable);
 
         // then
         assertThat(result.getContent()).hasSize(3);
@@ -267,7 +270,7 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyRepository.findAppliesByStatus(status, semester.getId(), BE, null, pageable);
+        Page<Apply> result = adminApplyRepository.findApplies(condition(status, semester.getId(), BE, null), pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
@@ -283,7 +286,7 @@ class AdminApplyQueryRepositoryTest {
                 .startDate(LocalDateTime.now().minusDays(1))
                 .endDate(LocalDateTime.now().plusDays(7))
                 .jobFamily(BE)
-                .recruitType(org.ject.support.domain.recruit.domain.RecruitType.REGULAR)
+                .recruitType(RecruitType.REGULAR)
                 .build());
 
         Recruit backfillRecruit = recruitRepository.save(Recruit.builder()
@@ -291,7 +294,7 @@ class AdminApplyQueryRepositoryTest {
                 .startDate(LocalDateTime.now().minusDays(1))
                 .endDate(LocalDateTime.now().plusDays(7))
                 .jobFamily(BE)
-                .recruitType(org.ject.support.domain.recruit.domain.RecruitType.BACKFILL)
+                .recruitType(RecruitType.BACKFILL)
                 .build());
 
         Member member1 = createMember("regular@test.com", BE);
@@ -306,12 +309,78 @@ class AdminApplyQueryRepositoryTest {
         ApplyStatus status = SUBMITTED;
 
         // when
-        Page<Apply> result = adminApplyRepository.findAppliesByStatus(status, null, null, org.ject.support.domain.recruit.domain.RecruitType.BACKFILL, pageable);
+        Page<Apply> result = adminApplyRepository.findApplies(condition(status, null, null, RecruitType.BACKFILL), pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        assertThat(result.getContent().getFirst().getRecruit().getRecruitType()).isEqualTo(org.ject.support.domain.recruit.domain.RecruitType.BACKFILL);
+        assertThat(result.getContent().getFirst().getRecruit().getRecruitType()).isEqualTo(RecruitType.BACKFILL);
+    }
+
+    @Test
+    void recruitTypeDetail로_제출된_지원서_필터링_조회() {
+        // given
+        Recruit regularRecruit = recruitRepository.save(Recruit.builder()
+                .semester(semester)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(7))
+                .jobFamily(BE)
+                .recruitType(RecruitType.SEMESTER)
+                .recruitTypeDetail(RecruitTypeDetail.REGULAR)
+                .build());
+
+        Recruit refillRecruit = recruitRepository.save(Recruit.builder()
+                .semester(semester)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(7))
+                .jobFamily(BE)
+                .recruitType(RecruitType.SEMESTER)
+                .recruitTypeDetail(RecruitTypeDetail.REFILL)
+                .build());
+
+        Member regularMember = createMember("regular-detail@test.com", BE);
+        Member refillMember = createMember("refill-detail@test.com", BE);
+        memberRepository.saveAll(List.of(regularMember, refillMember));
+
+        Apply regularApply = getApply(regularMember, regularRecruit, SUBMITTED);
+        Apply refillApply = getApply(refillMember, refillRecruit, SUBMITTED);
+        applyRepository.saveAll(List.of(regularApply, refillApply));
+
+        Pageable pageable = PageRequest.of(0, 15);
+        ApplyStatus status = SUBMITTED;
+
+        // when
+        Page<Apply> result = adminApplyRepository.findApplies(
+                condition(status, null, null, null, RecruitTypeDetail.REFILL, null), pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().getFirst().getRecruit().getRecruitTypeDetail()).isEqualTo(RecruitTypeDetail.REFILL);
+    }
+
+    @Test
+    void recruitId로_제출된_지원서_필터링_조회() {
+        // given
+        Member beMember = createMember("be-recruit-id@test.com", BE);
+        Member feMember = createMember("fe-recruit-id@test.com", FE);
+        memberRepository.saveAll(List.of(beMember, feMember));
+
+        Apply beApply = getApply(beMember, beRecruit, SUBMITTED);
+        Apply feApply = getApply(feMember, feRecruit, SUBMITTED);
+        applyRepository.saveAll(List.of(beApply, feApply));
+
+        Pageable pageable = PageRequest.of(0, 15);
+        ApplyStatus status = SUBMITTED;
+
+        // when
+        Page<Apply> result = adminApplyRepository.findApplies(
+                condition(status, null, null, null, null, beRecruit.getId()), pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().getFirst().getRecruit()).isEqualTo(beRecruit);
     }
 
     private Recruit getRecruit(JobFamily jobFamily) {
@@ -348,5 +417,21 @@ class AdminApplyQueryRepositoryTest {
                 .pin("123456")
                 .status(MemberStatus.ACTIVE)
                 .build();
+    }
+
+    private AdminApplySearchCondition condition(ApplyStatus status,
+                                                Long semesterId,
+                                                JobFamily jobFamily,
+                                                RecruitType recruitType) {
+        return condition(status, semesterId, jobFamily, recruitType, null, null);
+    }
+
+    private AdminApplySearchCondition condition(ApplyStatus status,
+                                                Long semesterId,
+                                                JobFamily jobFamily,
+                                                RecruitType recruitType,
+                                                RecruitTypeDetail recruitTypeDetail,
+                                                Long recruitId) {
+        return new AdminApplySearchCondition(status, semesterId, jobFamily, recruitType, recruitTypeDetail, recruitId);
     }
 }

--- a/src/test/java/org/ject/support/admin/apply/service/AdminApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/AdminApplyServiceTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.ject.support.admin.apply.dto.AdminApplyDetailResponse;
 import org.ject.support.admin.apply.dto.AdminApplyResponse;
+import org.ject.support.admin.apply.dto.AdminApplySearchCondition;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.repository.AdminApplyRepository;
 import org.ject.support.base.UnitTestSupport;
@@ -26,6 +27,8 @@ import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.recruit.domain.Question;
 import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.RecruitType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.exception.QuestionErrorCode;
 import org.ject.support.domain.recruit.exception.QuestionException;
@@ -145,17 +148,18 @@ class AdminApplyServiceTest extends UnitTestSupport {
 
         var applies = List.of(submittedApply);
         var page = new PageImpl<>(applies, pageable, 1L);
+        var condition = condition(ApplyStatus.SUBMITTED, semesterId, jobFamily, null);
 
-        given(adminApplyRepository.findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable))
+        given(adminApplyRepository.findApplies(condition, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = adminApplyService.findApplies(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
+        Page<AdminApplyResponse> result = adminApplyService.findApplies(condition, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(adminApplyRepository).findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
+        verify(adminApplyRepository).findApplies(condition, pageable);
     }
 
     @Test
@@ -165,17 +169,18 @@ class AdminApplyServiceTest extends UnitTestSupport {
         Long semesterId = null;
         var applies = List.of(submittedApply);
         var page = new PageImpl<>(applies, pageable, 1L);
+        var condition = condition(ApplyStatus.SUBMITTED, semesterId, null, null);
 
-        given(adminApplyRepository.findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, null, null, pageable))
+        given(adminApplyRepository.findApplies(condition, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = adminApplyService.findApplies(ApplyStatus.SUBMITTED, semesterId, null, null, pageable);
+        Page<AdminApplyResponse> result = adminApplyService.findApplies(condition, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(adminApplyRepository).findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, null, null, pageable);
+        verify(adminApplyRepository).findApplies(condition, pageable);
     }
 
     @Test
@@ -185,17 +190,18 @@ class AdminApplyServiceTest extends UnitTestSupport {
         var jobFamily = JobFamily.BE;
         Long semesterId = null;
         var page = new PageImpl<Apply>(List.of(), pageable, 0L);
+        var condition = condition(ApplyStatus.SUBMITTED, semesterId, jobFamily, null);
 
-        given(adminApplyRepository.findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable))
+        given(adminApplyRepository.findApplies(condition, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = adminApplyService.findApplies(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
+        Page<AdminApplyResponse> result = adminApplyService.findApplies(condition, pageable);
 
         // then
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
-        verify(adminApplyRepository).findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
+        verify(adminApplyRepository).findApplies(condition, pageable);
     }
 
     @Test
@@ -216,19 +222,20 @@ class AdminApplyServiceTest extends UnitTestSupport {
 
         var applies = List.of(submittedApply, apply2);
         var page = new PageImpl<>(applies, pageable, 25L);
+        var condition = condition(ApplyStatus.SUBMITTED, semesterId, jobFamily, null);
 
-        given(adminApplyRepository.findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable))
+        given(adminApplyRepository.findApplies(condition, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = adminApplyService.findApplies(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
+        Page<AdminApplyResponse> result = adminApplyService.findApplies(condition, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(25L);
         assertThat(result.getNumber()).isEqualTo(1);
         assertThat(result.getSize()).isEqualTo(10);
-        verify(adminApplyRepository).findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
+        verify(adminApplyRepository).findApplies(condition, pageable);
     }
 
     @Test
@@ -240,17 +247,39 @@ class AdminApplyServiceTest extends UnitTestSupport {
 
         var applies = List.of(submittedApply);
         var page = new PageImpl<>(applies, pageable, 1L);
+        var condition = condition(ApplyStatus.SUBMITTED, semesterId, jobFamily, null);
 
-        given(adminApplyRepository.findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable))
+        given(adminApplyRepository.findApplies(condition, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = adminApplyService.findApplies(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
+        Page<AdminApplyResponse> result = adminApplyService.findApplies(condition, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(adminApplyRepository).findAppliesByStatus(ApplyStatus.SUBMITTED, semesterId, jobFamily, null, pageable);
+        verify(adminApplyRepository).findApplies(condition, pageable);
+    }
+
+    @Test
+    void 지원서_목록_조회시_공고_필터_조건을_전달한다() {
+        // given
+        var pageable = PageRequest.of(0, 15);
+        var recruitId = 1L;
+        var condition = condition(
+                ApplyStatus.SUBMITTED, null, null, RecruitType.SEMESTER, RecruitTypeDetail.REFILL, recruitId);
+        var applies = List.of(submittedApply);
+        var page = new PageImpl<>(applies, pageable, 1L);
+
+        given(adminApplyRepository.findApplies(condition, pageable))
+                .willReturn(page);
+
+        // when
+        Page<AdminApplyResponse> result = adminApplyService.findApplies(condition, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        verify(adminApplyRepository).findApplies(condition, pageable);
     }
 
     @Test
@@ -538,15 +567,16 @@ class AdminApplyServiceTest extends UnitTestSupport {
         var pageable = PageRequest.of(0, 10);
         Long semesterId = null;
         var page = new PageImpl<Apply>(List.of(), pageable, 0);
+        var condition = condition(ApplyStatus.TEMP_SAVED, semesterId, null, null);
 
-        given(adminApplyRepository.findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable))
+        given(adminApplyRepository.findApplies(condition, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = adminApplyService.findApplies(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
+        Page<AdminApplyResponse> result = adminApplyService.findApplies(condition, pageable);
 
         // then
-        verify(adminApplyRepository).findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
+        verify(adminApplyRepository).findApplies(condition, pageable);
         assertThat(result.getTotalElements()).isZero();
         assertThat(result.getContent()).isEmpty();
     }
@@ -562,7 +592,7 @@ class AdminApplyServiceTest extends UnitTestSupport {
         var semester = Semester.builder().name("1").build();
         var recruit = Recruit.builder()
                 .semester(semester)
-                .recruitType(org.ject.support.domain.recruit.domain.RecruitType.REGULAR)
+                .recruitType(RecruitType.REGULAR)
                 .build();
 
         var a1 = Apply.builder()
@@ -583,15 +613,16 @@ class AdminApplyServiceTest extends UnitTestSupport {
 
         var applies = List.of(a1, a2);
         var page = new PageImpl<>(applies, pageable, applies.size());
+        var condition = condition(ApplyStatus.TEMP_SAVED, semesterId, null, null);
 
-        given(adminApplyRepository.findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable))
+        given(adminApplyRepository.findApplies(condition, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = adminApplyService.findApplies(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
+        Page<AdminApplyResponse> result = adminApplyService.findApplies(condition, pageable);
 
         // then
-        verify(adminApplyRepository).findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
+        verify(adminApplyRepository).findApplies(condition, pageable);
         assertThat(result.getTotalElements()).isEqualTo(2);
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getContent().get(0).applyId()).isEqualTo(1L);
@@ -608,7 +639,7 @@ class AdminApplyServiceTest extends UnitTestSupport {
         var semester = Semester.builder().name("1").build();
         var recruit = Recruit.builder()
                 .semester(semester)
-                .recruitType(org.ject.support.domain.recruit.domain.RecruitType.REGULAR)
+                .recruitType(RecruitType.REGULAR)
                 .build();
 
         var apply = Apply.builder()
@@ -621,17 +652,35 @@ class AdminApplyServiceTest extends UnitTestSupport {
 
         var applies = List.of(apply);
         var page = new PageImpl<>(applies, pageable, applies.size());
+        var condition = condition(ApplyStatus.TEMP_SAVED, semesterId, null, null);
 
-        given(adminApplyRepository.findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable))
+        given(adminApplyRepository.findApplies(condition, pageable))
                 .willReturn(page);
 
         // when
-        Page<AdminApplyResponse> result = adminApplyService.findApplies(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
+        Page<AdminApplyResponse> result = adminApplyService.findApplies(condition, pageable);
 
         // then
-        verify(adminApplyRepository).findAppliesByStatus(ApplyStatus.TEMP_SAVED, semesterId, null, null, pageable);
+        verify(adminApplyRepository).findApplies(condition, pageable);
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().getFirst().applyId()).isEqualTo(1L);
+    }
+
+    private AdminApplySearchCondition condition(ApplyStatus applyStatus,
+                                                Long semesterId,
+                                                JobFamily jobFamily,
+                                                RecruitType recruitType) {
+        return condition(applyStatus, semesterId, jobFamily, recruitType, null, null);
+    }
+
+    private AdminApplySearchCondition condition(ApplyStatus applyStatus,
+                                                Long semesterId,
+                                                JobFamily jobFamily,
+                                                RecruitType recruitType,
+                                                RecruitTypeDetail recruitTypeDetail,
+                                                Long recruitId) {
+        return new AdminApplySearchCondition(
+                applyStatus, semesterId, jobFamily, recruitType, recruitTypeDetail, recruitId);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #550
Parent: #427

## 📝 작업 내용

- 어드민 지원자 목록 조회에 `recruitId` 필터를 추가했습니다.
- 어드민 지원자 목록 조회에 `recruitTypeDetail` 필터를 추가했습니다.
- 지원자 검색 조건을 `AdminApplySearchCondition`으로 묶어 서비스/레포지토리 계약을 정리했습니다.
- 동일한 `createdAt`에서도 페이징 순서가 흔들리지 않도록 `id desc` 보조 정렬을 추가했습니다.

## 🙏 리뷰 요구사항 (선택)

- `recruitId`와 다른 필터가 함께 들어올 때 AND 조건으로 동작하도록 둔 판단을 확인해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 관리자 지원서 목록 조회 시 필터링 로직을 개선하여 모집 유형 상세정보 및 모집 ID 필터링 기능을 추가했습니다.
  * 필터 조건을 통합하여 API 엔드포인트의 유연성과 유지보수성을 향상시켰습니다.

* **Tests**
  * 업데이트된 필터링 로직을 검증하는 테스트를 추가 및 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->