### PR TITLE
feat: 어드민 회원 필터 확장

### DIFF
--- a/src/main/java/org/ject/support/admin/apply/service/ApplyPassService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/ApplyPassService.java
@@ -33,6 +33,7 @@ public class ApplyPassService {
             // 지원자 role 승격
             Member member = apply.getMember();
             member.promoteToSemester();
+            member.updateMemberType(apply.getRecruit().getRecruitType().toMemberType());
         });
 
         // 승인한 구성원 수 반환

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberController.java
@@ -11,6 +11,7 @@ import org.ject.support.admin.member.dto.MemberRegisterRequest;
 import org.ject.support.admin.member.dto.MemberResponse;
 import org.ject.support.admin.member.service.AdminMemberService;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.Role;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,13 +36,14 @@ public class AdminMemberController {
 
     @Operation(
             summary = "구성원 목록 조회",
-            description = "구성원 목록을 조회합니다. 역할, 직군, 학기 필터링이 가능합니다.")
+            description = "구성원 목록을 조회합니다. 역할, 직군, 학기, 구성원 타입 필터링이 가능합니다.")
     @GetMapping
     public Page<MemberResponse> findMembers(@RequestParam final Role role,
                                             @RequestParam(required = false) final JobFamily jobFamily,
                                             @RequestParam(required = false) final Long semesterId,
+                                            @RequestParam(required = false) final MemberType memberType,
                                             @PageableDefault(size = 15) final Pageable pageable) {
-        return adminMemberService.findMembers(role, jobFamily, semesterId, pageable);
+        return adminMemberService.findMembers(role, jobFamily, semesterId, memberType, pageable);
     }
 
     @Operation(

--- a/src/main/java/org/ject/support/admin/member/repository/AdminMemberQueryRepository.java
+++ b/src/main/java/org/ject/support/admin/member/repository/AdminMemberQueryRepository.java
@@ -1,6 +1,7 @@
 package org.ject.support.admin.member.repository;
 
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.dto.MemberProjection;
 import org.springframework.data.domain.Page;
@@ -8,5 +9,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface AdminMemberQueryRepository {
 
-    Page<MemberProjection> findMembers(Role role, JobFamily jobFamily, Long semesterId, Pageable pageable);
+    Page<MemberProjection> findMembers(Role role, JobFamily jobFamily, Long semesterId, MemberType memberType,
+                                       Pageable pageable);
 }

--- a/src/main/java/org/ject/support/admin/member/repository/AdminMemberRepositoryImpl.java
+++ b/src/main/java/org/ject/support/admin/member/repository/AdminMemberRepositoryImpl.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.common.data.PageResponse;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.dto.MemberProjection;
 import org.ject.support.domain.member.dto.QMemberProjection;
@@ -28,6 +29,7 @@ public class AdminMemberRepositoryImpl implements AdminMemberQueryRepository {
             final Role role,
             final JobFamily jobFamily,
             final Long semesterId,
+            final MemberType memberType,
             final Pageable pageable
     ) {
         final List<MemberProjection> content = queryFactory
@@ -45,6 +47,7 @@ public class AdminMemberRepositoryImpl implements AdminMemberQueryRepository {
                         member.role.eq(role),
                         eqJobFamily(jobFamily),
                         eqSemesterId(semesterId),
+                        eqMemberType(memberType),
                         member.isDeleted.eq(false))
                 .orderBy(member.createdAt.desc())
                 .offset(pageable.getOffset())
@@ -60,6 +63,7 @@ public class AdminMemberRepositoryImpl implements AdminMemberQueryRepository {
                         member.role.eq(role),
                         eqJobFamily(jobFamily),
                         eqSemesterId(semesterId),
+                        eqMemberType(memberType),
                         member.isDeleted.eq(false))
                 .fetchOne();
 
@@ -76,6 +80,12 @@ public class AdminMemberRepositoryImpl implements AdminMemberQueryRepository {
     private BooleanExpression eqSemesterId(final Long semesterId) {
         return Optional.ofNullable(semesterId)
                 .map(semester.id::eq)
+                .orElse(null);
+    }
+
+    private BooleanExpression eqMemberType(final MemberType memberType) {
+        return Optional.ofNullable(memberType)
+                .map(member.memberType::eq)
                 .orElse(null);
     }
 }

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberService.java
@@ -11,6 +11,7 @@ import org.ject.support.admin.member.dto.MemberResponse;
 import org.ject.support.admin.member.repository.AdminMemberRepository;
 import org.ject.support.common.data.PageResponse;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.dto.MemberProjection;
 import org.ject.support.domain.member.entity.Member;
@@ -42,9 +43,10 @@ public class AdminMemberService {
             final Role role,
             final JobFamily jobFamily,
             final Long semesterId,
+            final MemberType memberType,
             final Pageable pageable
     ) {
-        Page<MemberProjection> projections = adminMemberRepository.findMembers(role, jobFamily, semesterId, pageable);
+        Page<MemberProjection> projections = adminMemberRepository.findMembers(role, jobFamily, semesterId, memberType, pageable);
         List<MemberResponse> content = projections.getContent().stream()
                 .map(MemberResponse::from)
                 .toList();

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -50,6 +50,6 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
     @Query("select count(a) from Apply a where a.status = :status")
     Long countByStatus(@Param("status") ApplyStatus status);
 
-    @Query("SELECT a FROM Apply a JOIN FETCH a.member WHERE a.id IN :ids")
+    @Query("SELECT a FROM Apply a JOIN FETCH a.member JOIN FETCH a.recruit WHERE a.id IN :ids")
     List<Apply> findAllByIdWithMember(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -161,6 +161,10 @@ public class Member extends BaseTimeEntity {
         this.role = Role.SEMESTER;
     }
 
+    public void updateMemberType(MemberType memberType) {
+        this.memberType = memberType;
+    }
+
     public boolean isProfileComplete() {
         return this.name != null && this.phoneNumber != null;
     }

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -31,6 +31,7 @@ import org.ject.support.domain.member.Role;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
 @SQLRestriction("is_deleted = false")
@@ -162,7 +163,7 @@ public class Member extends BaseTimeEntity {
     }
 
     public void updateMemberType(MemberType memberType) {
-        this.memberType = memberType;
+        this.memberType = Objects.requireNonNull(memberType, "memberType must not be null");
     }
 
     public boolean isProfileComplete() {

--- a/src/main/java/org/ject/support/domain/recruit/domain/RecruitType.java
+++ b/src/main/java/org/ject/support/domain/recruit/domain/RecruitType.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.recruit.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.member.MemberType;
 
 @Getter
 @RequiredArgsConstructor
@@ -28,6 +29,14 @@ public enum RecruitType {
             case MAKERS, SUPPORTERS -> recruitTypeDetail == RecruitTypeDetail.NEW
                     || recruitTypeDetail == RecruitTypeDetail.REFILL;
             case REGULAR, REGULAR_WAITLIST, BACKFILL, MANUAL -> true;
+        };
+    }
+
+    public MemberType toMemberType() {
+        return switch (this) {
+            case MAKERS -> MemberType.MAKERS;
+            case SUPPORTERS -> MemberType.SUPPORTERS;
+            case SEMESTER, REGULAR, REGULAR_WAITLIST, BACKFILL, MANUAL -> MemberType.SEMESTER;
         };
     }
 }

--- a/src/test/java/org/ject/support/admin/apply/service/ApplyPassServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/ApplyPassServiceTest.java
@@ -76,6 +76,7 @@ class ApplyPassServiceTest extends UnitTestSupport {
 
         // then
         assertThat(result).isEqualTo(1);
+        assertThat(applicant.getRole()).isEqualTo(Role.SEMESTER);
         assertThat(applicant.getMemberType()).isEqualTo(MemberType.MAKERS);
     }
 
@@ -93,6 +94,7 @@ class ApplyPassServiceTest extends UnitTestSupport {
 
         // then
         assertThat(result).isEqualTo(1);
+        assertThat(applicant.getRole()).isEqualTo(Role.SEMESTER);
         assertThat(applicant.getMemberType()).isEqualTo(MemberType.SUPPORTERS);
     }
 

--- a/src/test/java/org/ject/support/admin/apply/service/ApplyPassServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/ApplyPassServiceTest.java
@@ -8,10 +8,12 @@ import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.domain.apply.repository.ApplyRepository;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.recruit.domain.Question;
 import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.RecruitType;
 import org.ject.support.domain.recruit.domain.Semester;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -55,6 +57,43 @@ class ApplyPassServiceTest extends UnitTestSupport {
         assertThat(applicant1.getRole()).isEqualTo(Role.SEMESTER);
         assertThat(applicant2.getRole()).isEqualTo(Role.SEMESTER);
         assertThat(applicant3.getRole()).isEqualTo(Role.SEMESTER);
+        assertThat(applicant1.getMemberType()).isEqualTo(MemberType.SEMESTER);
+        assertThat(applicant2.getMemberType()).isEqualTo(MemberType.SEMESTER);
+        assertThat(applicant3.getMemberType()).isEqualTo(MemberType.SEMESTER);
+    }
+
+    @Test
+    void 메이커스_지원자_합격_시_구성원_타입을_메이커스로_변경한다() {
+        // given
+        Recruit recruit = getActiveRecruit(1L, JobFamily.FE, RecruitType.MAKERS, List.of());
+        Member applicant = getApplicant(1L, "applicant@test.com");
+        Apply apply = getApply(1L, recruit, applicant, getApplicationForm("content"), ApplyStatus.SUBMITTED);
+
+        when(applyRepository.findAllByIdWithMember(List.of(1L))).thenReturn(List.of(apply));
+
+        // when
+        int result = applyPassService.passApply(List.of(1L));
+
+        // then
+        assertThat(result).isEqualTo(1);
+        assertThat(applicant.getMemberType()).isEqualTo(MemberType.MAKERS);
+    }
+
+    @Test
+    void 운영_서포터즈_지원자_합격_시_구성원_타입을_운영_서포터즈로_변경한다() {
+        // given
+        Recruit recruit = getActiveRecruit(1L, JobFamily.SUPPORTER, RecruitType.SUPPORTERS, List.of());
+        Member applicant = getApplicant(1L, "applicant@test.com");
+        Apply apply = getApply(1L, recruit, applicant, getApplicationForm("content"), ApplyStatus.SUBMITTED);
+
+        when(applyRepository.findAllByIdWithMember(List.of(1L))).thenReturn(List.of(apply));
+
+        // when
+        int result = applyPassService.passApply(List.of(1L));
+
+        // then
+        assertThat(result).isEqualTo(1);
+        assertThat(applicant.getMemberType()).isEqualTo(MemberType.SUPPORTERS);
     }
 
     @Test
@@ -77,12 +116,17 @@ class ApplyPassServiceTest extends UnitTestSupport {
     }
 
     private Recruit getActiveRecruit(Long id, JobFamily jobFamily, List<Question> questions) {
+        return getActiveRecruit(id, jobFamily, RecruitType.SEMESTER, questions);
+    }
+
+    private Recruit getActiveRecruit(Long id, JobFamily jobFamily, RecruitType recruitType, List<Question> questions) {
         return Recruit.builder()
                 .id(id)
                 .semester(Semester.builder().id(1L).name("1기").build())
                 .startDate(LocalDateTime.now().minusDays(1))
                 .endDate(LocalDateTime.now().plusDays(1))
                 .jobFamily(jobFamily)
+                .recruitType(recruitType)
                 .questions(questions)
                 .build();
     }

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberControllerTest.java
@@ -24,6 +24,7 @@ import org.ject.support.admin.member.dto.MemberResponse;
 import org.ject.support.admin.member.service.AdminMemberService;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.exception.MemberErrorCode;
@@ -80,7 +81,7 @@ class AdminMemberControllerTest extends UnitTestSupport {
         );
         var mockPage = new PageImpl<>(memberList, pageable, 1);
 
-        given(memberManagementService.findMembers(any(Role.class), any(), any(), any(Pageable.class)))
+        given(memberManagementService.findMembers(any(Role.class), any(), any(), any(), any(Pageable.class)))
                 .willReturn(mockPage);
 
         // expected
@@ -95,7 +96,8 @@ class AdminMemberControllerTest extends UnitTestSupport {
                 .andExpect(jsonPath("$.content[0].email").value(TEST_EMAIL))
                 .andDo(print());
 
-        verify(memberManagementService).findMembers(eq(Role.SEMESTER), eq(null), eq(null), any(Pageable.class));
+        verify(memberManagementService).findMembers(eq(Role.SEMESTER), eq(null), eq(null), eq(null),
+                any(Pageable.class));
     }
 
     @Test
@@ -114,7 +116,8 @@ class AdminMemberControllerTest extends UnitTestSupport {
         );
         var mockPage = new PageImpl<>(memberList, pageable, 1);
 
-        given(memberManagementService.findMembers(any(Role.class), any(JobFamily.class), any(), any(Pageable.class)))
+        given(memberManagementService.findMembers(any(Role.class), any(JobFamily.class), any(), any(),
+                any(Pageable.class)))
                 .willReturn(mockPage);
 
         // expected
@@ -129,7 +132,8 @@ class AdminMemberControllerTest extends UnitTestSupport {
                 .andExpect(jsonPath("$.content[0].jobFamily").value("BE"))
                 .andDo(print());
 
-        verify(memberManagementService).findMembers(eq(Role.SEMESTER), eq(JobFamily.BE), eq(null), any(Pageable.class));
+        verify(memberManagementService).findMembers(eq(Role.SEMESTER), eq(JobFamily.BE), eq(null), eq(null),
+                any(Pageable.class));
     }
 
     @Test
@@ -149,7 +153,8 @@ class AdminMemberControllerTest extends UnitTestSupport {
         );
         var mockPage = new PageImpl<>(memberList, pageable, 1);
 
-        given(memberManagementService.findMembers(any(Role.class), any(), eq(semesterId), any(Pageable.class)))
+        given(memberManagementService.findMembers(any(Role.class), any(), eq(semesterId), any(),
+                any(Pageable.class)))
                 .willReturn(mockPage);
 
         // expected
@@ -164,7 +169,44 @@ class AdminMemberControllerTest extends UnitTestSupport {
                 .andExpect(jsonPath("$.content[0].semesterName").value("1"))
                 .andDo(print());
 
-        verify(memberManagementService).findMembers(eq(Role.SEMESTER), eq(null), eq(semesterId), any(Pageable.class));
+        verify(memberManagementService).findMembers(eq(Role.SEMESTER), eq(null), eq(semesterId), eq(null),
+                any(Pageable.class));
+    }
+
+    @Test
+    void 회원_목록_조회_성공_구성원_타입_필터_적용() throws Exception {
+        // given
+        var pageable = PageRequest.of(0, 15);
+        var memberList = List.of(
+                MemberResponse.builder()
+                        .id(1L)
+                        .name(TEST_NAME)
+                        .phoneNumber(TEST_PHONE_NUMBER)
+                        .email(TEST_EMAIL)
+                        .jobFamily(JobFamily.FE)
+                        .semesterName("1")
+                        .build()
+        );
+        var mockPage = new PageImpl<>(memberList, pageable, 1);
+
+        given(memberManagementService.findMembers(any(Role.class), any(), any(), any(MemberType.class),
+                any(Pageable.class)))
+                .willReturn(mockPage);
+
+        // expected
+        mockMvc.perform(get("/admin/members")
+                        .param("role", "SEMESTER")
+                        .param("memberType", "MAKERS")
+                        .param("page", "0")
+                        .param("size", "15")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].jobFamily").value("FE"))
+                .andDo(print());
+
+        verify(memberManagementService).findMembers(eq(Role.SEMESTER), eq(null), eq(null), eq(MemberType.MAKERS),
+                any(Pageable.class));
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/member/repository/AdminMemberQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/admin/member/repository/AdminMemberQueryRepositoryTest.java
@@ -1,0 +1,89 @@
+package org.ject.support.admin.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.dto.MemberProjection;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.recruit.domain.Semester;
+import org.ject.support.domain.recruit.repository.SemesterRepository;
+import org.ject.support.testconfig.QueryDslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@Import({QueryDslTestConfig.class, AdminMemberRepositoryImpl.class})
+@DataJpaTest
+class AdminMemberQueryRepositoryTest {
+
+    @Autowired
+    AdminMemberRepository adminMemberRepository;
+
+    @Autowired
+    SemesterRepository semesterRepository;
+
+    Semester semester;
+
+    @BeforeEach
+    void setUp() {
+        semester = semesterRepository.save(Semester.builder()
+                .name("1기")
+                .isRecruiting(false)
+                .build());
+    }
+
+    @Test
+    void 구성원_타입으로_회원_목록을_필터링한다() {
+        // given
+        Member semesterMember = createMember("semester@test.com", MemberType.SEMESTER);
+        Member makersMember = createMember("makers@test.com", MemberType.MAKERS);
+        adminMemberRepository.saveAll(List.of(semesterMember, makersMember));
+
+        // when
+        Page<MemberProjection> result = adminMemberRepository.findMembers(
+                Role.SEMESTER, null, null, MemberType.MAKERS, PageRequest.of(0, 15));
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().getFirst().email()).isEqualTo("makers@test.com");
+    }
+
+    @Test
+    void 구성원_타입이_null이면_기존_조건으로_회원_목록을_조회한다() {
+        // given
+        Member semesterMember = createMember("semester@test.com", MemberType.SEMESTER);
+        Member makersMember = createMember("makers@test.com", MemberType.MAKERS);
+        adminMemberRepository.saveAll(List.of(semesterMember, makersMember));
+
+        // when
+        Page<MemberProjection> result = adminMemberRepository.findMembers(
+                Role.SEMESTER, null, null, null, PageRequest.of(0, 15));
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    private Member createMember(String email, MemberType memberType) {
+        return Member.builder()
+                .email(email)
+                .name("홍길동")
+                .phoneNumber("01012345678")
+                .semesterId(semester.getId())
+                .jobFamily(JobFamily.BE)
+                .role(Role.SEMESTER)
+                .memberType(memberType)
+                .pin("123456")
+                .status(MemberStatus.ACTIVE)
+                .build();
+    }
+}

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
@@ -68,16 +68,16 @@ class AdminMemberServiceTest extends UnitTestSupport {
         );
         var expectedPage = new PageImpl<>(memberList, pageable, 2);
 
-        given(adminMemberRepository.findMembers(role, jobFamily, semesterId, pageable))
+        given(adminMemberRepository.findMembers(role, jobFamily, semesterId, MemberType.SEMESTER, pageable))
                 .willReturn(expectedPage);
 
         // when
-        var result = adminMemberService.findMembers(role, jobFamily, semesterId, pageable);
+        var result = adminMemberService.findMembers(role, jobFamily, semesterId, MemberType.SEMESTER, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(2);
-        verify(adminMemberRepository).findMembers(role, jobFamily, semesterId, pageable);
+        verify(adminMemberRepository).findMembers(role, jobFamily, semesterId, MemberType.SEMESTER, pageable);
     }
 
     @Test
@@ -91,15 +91,15 @@ class AdminMemberServiceTest extends UnitTestSupport {
         );
         var expectedPage = new PageImpl<>(memberList, pageable, 1);
 
-        given(adminMemberRepository.findMembers(role, null, null, pageable))
+        given(adminMemberRepository.findMembers(role, null, null, null, pageable))
                 .willReturn(expectedPage);
 
         // when
-        var result = adminMemberService.findMembers(role, null, null, pageable);
+        var result = adminMemberService.findMembers(role, null, null, null, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
-        verify(adminMemberRepository).findMembers(role, null, null, pageable);
+        verify(adminMemberRepository).findMembers(role, null, null, null, pageable);
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
@@ -1,5 +1,7 @@
 package org.ject.support.domain.apply.repository;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.ApplyStatus;
 import org.ject.support.domain.member.JobFamily;
@@ -42,6 +44,9 @@ class ApplyRepositoryTest {
 
     @Autowired
     RecruitRepository recruitRepository;
+
+    @Autowired
+    EntityManager entityManager;
 
     Semester semester;
     Recruit pmRecruit;
@@ -167,6 +172,24 @@ class ApplyRepositoryTest {
         assertThat(result.getMember()).isEqualTo(feApplicant);
         assertThat(result.getRecruit()).isEqualTo(feRecruit);
         assertThat(result.getStatus()).isEqualTo(TEMP_SAVED);
+    }
+
+    @Test
+    void 지원ID_목록으로_회원과_모집을_함께_조회한다() {
+        // given
+        Member applicant = createMember("email@test.com", Role.APPLY);
+        memberRepository.save(applicant);
+        Apply savedApply = applyRepository.save(getApply(applicant, beRecruit, SUBMITTED));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        Apply result = applyRepository.findAllByIdWithMember(List.of(savedApply.getId())).get(0);
+
+        // then
+        PersistenceUnitUtil persistenceUnitUtil = entityManager.getEntityManagerFactory().getPersistenceUnitUtil();
+        assertThat(persistenceUnitUtil.isLoaded(result.getMember())).isTrue();
+        assertThat(persistenceUnitUtil.isLoaded(result.getRecruit())).isTrue();
     }
 
     private Recruit getRecruit(JobFamily jobFamily) {

--- a/src/test/java/org/ject/support/domain/member/MemberTest.java
+++ b/src/test/java/org/ject/support/domain/member/MemberTest.java
@@ -4,6 +4,7 @@ import org.ject.support.domain.member.entity.Member;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MemberTest {
 
@@ -65,6 +66,21 @@ class MemberTest {
         assertThat(member.getRegion()).isEqualTo(region);
         assertThat(member.getJobFamily()).isNull();
         assertThat(member.getMemberType()).isEqualTo(MemberType.SEMESTER);
+    }
+
+    @Test
+    void 구성원_타입을_null로_변경하면_예외가_발생한다() {
+        // given
+        Member member = Member.builder()
+                .email("john@example.com")
+                .role(Role.SEMESTER)
+                .status(MemberStatus.ACTIVE)
+                .build();
+
+        // when, then
+        assertThatThrownBy(() -> member.updateMemberType(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("memberType must not be null");
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/recruit/domain/RecruitTypeTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/domain/RecruitTypeTest.java
@@ -3,6 +3,9 @@ package org.ject.support.domain.recruit.domain;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.member.MemberType.MAKERS;
+import static org.ject.support.domain.member.MemberType.SEMESTER;
+import static org.ject.support.domain.member.MemberType.SUPPORTERS;
 
 class RecruitTypeTest {
 
@@ -51,5 +54,20 @@ class RecruitTypeTest {
         assertThat(RecruitType.REGULAR_WAITLIST.supports(RecruitTypeDetail.REGULAR)).isTrue();
         assertThat(RecruitType.BACKFILL.supports(RecruitTypeDetail.REFILL)).isTrue();
         assertThat(RecruitType.MANUAL.supports(RecruitTypeDetail.REGULAR)).isTrue();
+    }
+
+    @Test
+    void 모집_유형을_구성원_타입으로_변환한다() {
+        assertThat(RecruitType.SEMESTER.toMemberType()).isEqualTo(SEMESTER);
+        assertThat(RecruitType.MAKERS.toMemberType()).isEqualTo(MAKERS);
+        assertThat(RecruitType.SUPPORTERS.toMemberType()).isEqualTo(SUPPORTERS);
+    }
+
+    @Test
+    void 기존_모집_유형은_정규_기수_구성원_타입으로_변환한다() {
+        assertThat(RecruitType.REGULAR.toMemberType()).isEqualTo(SEMESTER);
+        assertThat(RecruitType.REGULAR_WAITLIST.toMemberType()).isEqualTo(SEMESTER);
+        assertThat(RecruitType.BACKFILL.toMemberType()).isEqualTo(SEMESTER);
+        assertThat(RecruitType.MANUAL.toMemberType()).isEqualTo(SEMESTER);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #552
Parent: #427

## 📝 작업 내용

- `/admin/members` 목록 조회에 `memberType` 선택 필터를 추가했습니다.
- 어드민 회원 조회 서비스와 QueryDSL 조건에 `memberType` 필터를 전달했습니다.
- 컨트롤러/서비스/레포지토리 테스트로 구성원 타입 필터 동작을 검증했습니다.

## 🙏 리뷰 요구사항 (선택)

- 기존 `role` 필터는 유지하고, `memberType`을 선택 필터로 추가한 범위가 적절한지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 멤버 목록에 멤버 유형(MemberType) 필터가 추가되어 역할·포지션·학기와 함께 더 정밀한 검색이 가능합니다.
  * 지원자 합격 처리 시 해당 채용 유형에 따라 멤버의 유형이 자동으로 설정됩니다.

* **테스트**
  * 멤버 유형 필터링 및 지원자 합격에 따른 멤버 유형 변경에 대한 테스트가 추가 및 보강되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/JECT-Official-WebSite-Server/pull/553)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->