### PR TITLE
feat: 모집 기간 검증 공고 기준 확장

### DIFF
--- a/src/main/java/org/ject/support/common/util/PeriodAccessible.java
+++ b/src/main/java/org/ject/support/common/util/PeriodAccessible.java
@@ -10,4 +10,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface PeriodAccessible {
     boolean permitAllJob() default false;
+
+    int recruitIdParameterIndex() default -1;
 }

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -47,6 +47,8 @@ import static org.ject.support.domain.apply.exception.ApplyErrorCode.NOT_FOUND_A
 @Service
 @RequiredArgsConstructor
 public class ApplyService implements ApplyUsecase {
+    private static final int RECRUIT_ID_PARAMETER_INDEX = 1;
+
     private final RecruitRepository recruitRepository;
     private final ApplyRepository applyRepository;
     private final ApplicationFormRepository applicationFormRepository;
@@ -55,7 +57,7 @@ public class ApplyService implements ApplyUsecase {
     private final String2MapSerializer string2MapSerializer;
 
     @Override
-    @PeriodAccessible(permitAllJob = true)
+    @PeriodAccessible(recruitIdParameterIndex = RECRUIT_ID_PARAMETER_INDEX)
     @Transactional(readOnly = true)
     public TempApplicationFormResponse findTempApplicationForm(final Long memberId, final Long recruitId) {
         Apply apply = applyRepository.findByMemberIdAndRecruitIdInActiveRecruit(memberId, recruitId, LocalDateTime.now())
@@ -76,7 +78,7 @@ public class ApplyService implements ApplyUsecase {
     }
 
     @Override
-    @PeriodAccessible(permitAllJob = true)
+    @PeriodAccessible(recruitIdParameterIndex = RECRUIT_ID_PARAMETER_INDEX)
     @Transactional
     public void saveApplicationTemporarily(Long memberId,
                                            Long recruitId,
@@ -116,7 +118,7 @@ public class ApplyService implements ApplyUsecase {
     }
 
     @Override
-    @PeriodAccessible(permitAllJob = true)
+    @PeriodAccessible(recruitIdParameterIndex = RECRUIT_ID_PARAMETER_INDEX)
     @Transactional
     public void deleteProfileAndTempApplicationForm(Long memberId, Long recruitId) {
         // 지원 정보 조회
@@ -138,7 +140,7 @@ public class ApplyService implements ApplyUsecase {
     }
 
     @Override
-    @PeriodAccessible(permitAllJob = true)
+    @PeriodAccessible(recruitIdParameterIndex = RECRUIT_ID_PARAMETER_INDEX)
     @Transactional
     public void submitApplication(Long memberId,
                                   Long recruitId,
@@ -178,7 +180,7 @@ public class ApplyService implements ApplyUsecase {
     }
 
     @Override
-    @PeriodAccessible(permitAllJob = true)
+    @PeriodAccessible(recruitIdParameterIndex = RECRUIT_ID_PARAMETER_INDEX)
     @Transactional(readOnly = true)
     public ApplyStatusResponse checkApplyStatus(Long memberId, Long recruitId) {
         memberRepository.findById(memberId)
@@ -190,7 +192,7 @@ public class ApplyService implements ApplyUsecase {
     }
 
     @Override
-    @PeriodAccessible(permitAllJob = true)
+    @PeriodAccessible(recruitIdParameterIndex = RECRUIT_ID_PARAMETER_INDEX)
     @Transactional
     public void saveProfile(Long memberId, Long recruitId, ApplyProfileRequest request) {
         var member = memberRepository.findById(memberId)

--- a/src/main/java/org/ject/support/domain/recruit/controller/DevRecruitController.java
+++ b/src/main/java/org/ject/support/domain/recruit/controller/DevRecruitController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.dto.RecruitUpdateRequest;
 import org.ject.support.domain.recruit.dto.RecruitUpdatedEvent;
@@ -40,10 +41,12 @@ public class DevRecruitController {
 
         Recruit recruit = recruitRepository.findById(recruitId)
                 .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
+        JobFamily previousJobFamily = recruit.getJobFamily();
         recruit.update(request.jobFamily(), request.startDate(), request.endDate());
 
         eventPublisher.publishEvent(new RecruitUpdatedEvent(
                 recruit.getId(),
+                previousJobFamily,
                 recruit.getJobFamily(),
                 recruit.getStartDate(),
                 recruit.getEndDate()));

--- a/src/main/java/org/ject/support/domain/recruit/dto/RecruitUpdatedEvent.java
+++ b/src/main/java/org/ject/support/domain/recruit/dto/RecruitUpdatedEvent.java
@@ -4,5 +4,9 @@ import org.ject.support.domain.member.JobFamily;
 
 import java.time.LocalDateTime;
 
-public record RecruitUpdatedEvent(Long recruitId, JobFamily jobFamily, LocalDateTime startDate, LocalDateTime endDate) {
+public record RecruitUpdatedEvent(Long recruitId,
+                                  JobFamily previousJobFamily,
+                                  JobFamily currentJobFamily,
+                                  LocalDateTime startDate,
+                                  LocalDateTime endDate) {
 }

--- a/src/main/java/org/ject/support/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/RecruitRepository.java
@@ -27,4 +27,9 @@ public interface RecruitRepository extends JpaRepository<Recruit, Long>, Recruit
     @Query("SELECT r FROM Recruit r WHERE r.id = :recruitId AND r.startDate <= :now AND r.endDate >= :now")
     Recruit findActiveRecruitById(@Param("recruitId") Long recruitId,
                                   @Param("now") LocalDateTime now);
+
+    @Query("SELECT MAX(r.endDate) FROM Recruit r "
+            + "WHERE r.jobFamily = :jobFamily AND r.startDate <= :now AND r.endDate >= :now")
+    LocalDateTime findLatestActiveRecruitEndDateByJobFamily(@Param("jobFamily") JobFamily jobFamily,
+                                                            @Param("now") LocalDateTime now);
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/AccessPeriodInitializer.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/AccessPeriodInitializer.java
@@ -1,15 +1,11 @@
 package org.ject.support.domain.recruit.service;
 
 import lombok.RequiredArgsConstructor;
-import org.ject.support.domain.member.JobFamily;
-import org.ject.support.domain.recruit.dto.Constants;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 
 /**
@@ -18,26 +14,12 @@ import java.time.LocalDateTime;
 @Component
 @RequiredArgsConstructor
 public class AccessPeriodInitializer implements ApplicationRunner {
-    private final RedisTemplate<String, String> redisTemplate;
     private final RecruitRepository recruitRepository;
+    private final RecruitFlagService recruitFlagService;
 
     @Override
     public void run(final ApplicationArguments args) {
-        for (JobFamily jobFamily : JobFamily.values()) {
-            setRecruitFlag(jobFamily);
-        }
-    }
-
-    private void setRecruitFlag(JobFamily jobFamily) {
-        if (Boolean.FALSE.equals(redisTemplate.hasKey(getKey(jobFamily)))) {
-            recruitRepository.findActiveRecruitByJobFamily(jobFamily, LocalDateTime.now())
-                    .ifPresent(recruit -> redisTemplate.opsForValue().set(
-                            getKey(jobFamily), Boolean.toString(true),
-                            Duration.between(recruit.getStartDate(), recruit.getEndDate())));
-        }
-    }
-
-    private String getKey(JobFamily jobFamily) {
-        return String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, jobFamily);
+        recruitRepository.findActiveRecruits(LocalDateTime.now())
+                .forEach(recruitFlagService::setRecruitFlag);
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/AccessPeriodVerifier.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/AccessPeriodVerifier.java
@@ -43,24 +43,24 @@ public class AccessPeriodVerifier {
         }
 
         try {
+            if (target.recruitIdParameterIndex() >= 0) {
+                Long recruitId = extractRecruitId(joinPoint, target.recruitIdParameterIndex());
+                validateRecruiting(isRecruiting(getKeyName(recruitId)));
+                return proceed(joinPoint, circuitBreaker);
+            }
+
             // 모든 직군에 대한 요청인 경우, 하나의 어떤 RECRUIT_FLAG만 있어도 허용
             if (target.permitAllJob()) {
                 boolean isAnyRecruiting = Arrays.stream(JobFamily.values())
-                        .anyMatch(jobFamily -> Boolean.parseBoolean(redisTemplate.opsForValue()
-                                .get(getKeyName(jobFamily.name()))));
+                        .anyMatch(jobFamily -> isRecruiting(getKeyName(jobFamily.name())));
                 validateRecruiting(isAnyRecruiting);
             } else {
                 // 특정 직군을 파라미터로 받은 경우, 해당 직군에 대한 모집 여부로 판단
                 JobFamily jobFamily = extractJobFamily(joinPoint);
-                boolean isRecruiting = Boolean.parseBoolean(redisTemplate.opsForValue()
-                        .get(getKeyName(jobFamily.name())));
-                validateRecruiting(isRecruiting);
+                validateRecruiting(isRecruiting(getKeyName(jobFamily.name())));
             }
 
-            Object result = joinPoint.proceed();
-            // 성공 기록
-            circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
-            return result;
+            return proceed(joinPoint, circuitBreaker);
         } catch (Throwable throwable) {
             // 레디스 관련 인프라 장애(연결, 타임아웃 등) 시 폴백 처리
             if (RedisCacheExceptionClassifier.isRedisRelated(throwable)) {
@@ -76,8 +76,23 @@ public class AccessPeriodVerifier {
         }
     }
 
+    private Object proceed(ProceedingJoinPoint joinPoint, CircuitBreaker circuitBreaker) throws Throwable {
+        Object result = joinPoint.proceed();
+        // 성공 기록
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        return result;
+    }
+
     private String getKeyName(String jobFamilyName) {
         return String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, jobFamilyName);
+    }
+
+    private String getKeyName(Long recruitId) {
+        return String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, recruitId);
+    }
+
+    private boolean isRecruiting(String keyName) {
+        return Boolean.parseBoolean(redisTemplate.opsForValue().get(keyName));
     }
 
     private void validateRecruiting(boolean isRecruiting) {
@@ -92,5 +107,13 @@ public class AccessPeriodVerifier {
                 .map(JobFamily.class::cast)
                 .findFirst()
                 .orElseThrow(() -> new GlobalException(GlobalErrorCode.MISS_REQUIRED_JOB_FAMILY_PARAMETER));
+    }
+
+    private Long extractRecruitId(ProceedingJoinPoint joinPoint, int recruitIdParameterIndex) {
+        Object[] args = joinPoint.getArgs();
+        if (recruitIdParameterIndex >= args.length || !(args[recruitIdParameterIndex] instanceof Long recruitId)) {
+            throw new GlobalException(GlobalErrorCode.MISS_REQUIRED_REQUEST_PARAMETER);
+        }
+        return recruitId;
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitCanceledEventHandler.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitCanceledEventHandler.java
@@ -7,8 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import static org.ject.support.domain.recruit.dto.Constants.RECRUIT_FLAG_PREFIX;
-
 @Service
 @RequiredArgsConstructor
 public class RecruitCanceledEventHandler {
@@ -21,7 +19,7 @@ public class RecruitCanceledEventHandler {
     @CacheEvict(value = "activeRecruit", key = "#event.jobFamily().name()")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleRecruitCanceled(RecruitCanceledEvent event) {
-        recruitFlagService.deleteRecruitFlag(String.format("%s%s", RECRUIT_FLAG_PREFIX, event.jobFamily()));
+        recruitFlagService.deleteRecruitFlag(event.recruitId(), event.jobFamily());
         recruitScheduleService.cancelJobs(event.recruitId());
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitFlagService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitFlagService.java
@@ -3,12 +3,12 @@ package org.ject.support.domain.recruit.service;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.List;
 
 import static org.ject.support.domain.recruit.dto.Constants.RECRUIT_FLAG_PREFIX;
 
@@ -17,6 +17,7 @@ import static org.ject.support.domain.recruit.dto.Constants.RECRUIT_FLAG_PREFIX;
 public class RecruitFlagService {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private final RecruitRepository recruitRepository;
 
     public void setRecruitFlag(Recruit recruit) {
         Duration timeToLive = Duration.between(LocalDateTime.now(), recruit.getEndDate());
@@ -27,11 +28,31 @@ public class RecruitFlagService {
         if (recruit.getId() != null) {
             redisTemplate.opsForValue().set(getRecruitFlagKey(recruit.getId()), Boolean.TRUE.toString(), timeToLive);
         }
-        redisTemplate.opsForValue().set(getRecruitFlagKey(recruit.getJobFamily()), Boolean.TRUE.toString(), timeToLive);
+        refreshJobFamilyFlag(recruit.getJobFamily());
     }
 
     public void deleteRecruitFlag(Long recruitId, JobFamily jobFamily) {
-        redisTemplate.delete(List.of(getRecruitFlagKey(recruitId), getRecruitFlagKey(jobFamily)));
+        if (recruitId != null) {
+            redisTemplate.delete(getRecruitFlagKey(recruitId));
+        }
+        refreshJobFamilyFlag(jobFamily);
+    }
+
+    private void refreshJobFamilyFlag(JobFamily jobFamily) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime latestEndDate = recruitRepository.findLatestActiveRecruitEndDateByJobFamily(jobFamily, now);
+        if (latestEndDate == null) {
+            redisTemplate.delete(getRecruitFlagKey(jobFamily));
+            return;
+        }
+
+        Duration timeToLive = Duration.between(now, latestEndDate);
+        if (timeToLive.isZero() || timeToLive.isNegative()) {
+            redisTemplate.delete(getRecruitFlagKey(jobFamily));
+            return;
+        }
+
+        redisTemplate.opsForValue().set(getRecruitFlagKey(jobFamily), Boolean.TRUE.toString(), timeToLive);
     }
 
     private String getRecruitFlagKey(Long recruitId) {

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitFlagService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitFlagService.java
@@ -38,7 +38,7 @@ public class RecruitFlagService {
         refreshJobFamilyFlag(jobFamily);
     }
 
-    private void refreshJobFamilyFlag(JobFamily jobFamily) {
+    void refreshJobFamilyFlag(JobFamily jobFamily) {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime latestEndDate = recruitRepository.findLatestActiveRecruitEndDateByJobFamily(jobFamily, now);
         if (latestEndDate == null) {

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitFlagService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitFlagService.java
@@ -1,12 +1,14 @@
 package org.ject.support.domain.recruit.service;
 
 import lombok.RequiredArgsConstructor;
+import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.ject.support.domain.recruit.dto.Constants.RECRUIT_FLAG_PREFIX;
 
@@ -17,14 +19,26 @@ public class RecruitFlagService {
     private final RedisTemplate<String, String> redisTemplate;
 
     public void setRecruitFlag(Recruit recruit) {
-        redisTemplate.opsForValue().set(
-                String.format("%s%s", RECRUIT_FLAG_PREFIX, recruit.getJobFamily().name()),
-                Boolean.TRUE.toString(),
-                Duration.between(LocalDateTime.now(), recruit.getEndDate())
-        );
+        Duration timeToLive = Duration.between(LocalDateTime.now(), recruit.getEndDate());
+        if (timeToLive.isZero() || timeToLive.isNegative()) {
+            return;
+        }
+
+        if (recruit.getId() != null) {
+            redisTemplate.opsForValue().set(getRecruitFlagKey(recruit.getId()), Boolean.TRUE.toString(), timeToLive);
+        }
+        redisTemplate.opsForValue().set(getRecruitFlagKey(recruit.getJobFamily()), Boolean.TRUE.toString(), timeToLive);
     }
 
-    public void deleteRecruitFlag(String recruitFlag) {
-        redisTemplate.delete(recruitFlag);
+    public void deleteRecruitFlag(Long recruitId, JobFamily jobFamily) {
+        redisTemplate.delete(List.of(getRecruitFlagKey(recruitId), getRecruitFlagKey(jobFamily)));
+    }
+
+    private String getRecruitFlagKey(Long recruitId) {
+        return String.format("%s%s", RECRUIT_FLAG_PREFIX, recruitId);
+    }
+
+    private String getRecruitFlagKey(JobFamily jobFamily) {
+        return String.format("%s%s", RECRUIT_FLAG_PREFIX, jobFamily.name());
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitService.java
@@ -63,9 +63,11 @@ public class RecruitService implements RecruitUsecase {
         if (recruit.isClosed()) {
             throw new RecruitException(RecruitErrorCode.UPDATE_NOT_ALLOW_FOR_CLOSED);
         }
+        JobFamily previousJobFamily = recruit.getJobFamily();
         recruit.update(request.jobFamily(), request.startDate(), request.endDate());
         eventPublisher.publishEvent(new RecruitUpdatedEvent(
                 recruit.getId(),
+                previousJobFamily,
                 recruit.getJobFamily(),
                 recruit.getStartDate(),
                 recruit.getEndDate()));

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitUpdatedEventHandler.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitUpdatedEventHandler.java
@@ -36,6 +36,7 @@ public class RecruitUpdatedEventHandler {
             recruitFlagService.setRecruitFlag(recruit);
         } else {
             // 등록된 모집의 시작일이 미래 시점이라면 스케줄 등록
+            recruitFlagService.deleteRecruitFlag(recruit.getId(), recruit.getJobFamily());
             recruitScheduleService.scheduleRecruitOpen(recruit);
         }
 

--- a/src/main/java/org/ject/support/domain/recruit/service/RecruitUpdatedEventHandler.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/RecruitUpdatedEventHandler.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.recruit.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.dto.RecruitUpdatedEvent;
 import org.ject.support.domain.recruit.exception.RecruitErrorCode;
@@ -21,7 +22,10 @@ public class RecruitUpdatedEventHandler {
     /**
      * 모집 수정 시 호출됨
      */
-    @CacheEvict(value = "activeRecruit", key = "#event.jobFamily().name()")
+    @Caching(evict = {
+            @CacheEvict(value = "activeRecruit", key = "#event.previousJobFamily().name()"),
+            @CacheEvict(value = "activeRecruit", key = "#event.currentJobFamily().name()")
+    })
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleRecruitUpdated(RecruitUpdatedEvent event) {
         // 기존 스케줄 작업 제거
@@ -30,6 +34,10 @@ public class RecruitUpdatedEventHandler {
         // 수정된 모집 정보 조회
         Recruit recruit = recruitRepository.findById(event.recruitId())
                 .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
+
+        if (event.previousJobFamily() != event.currentJobFamily()) {
+            recruitFlagService.refreshJobFamilyFlag(event.previousJobFamily());
+        }
 
         if (recruit.isRecruitingPeriod()) {
             // 등록된 모집이 활성화되어 있다면 즉시 flag 캐싱

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -110,6 +110,8 @@ class FileControllerTest extends ApplicationPeriodTest {
                 .thenReturn(Boolean.toString(false));
         when(redisTemplate.opsForValue().get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.BE.name())))
                 .thenReturn(Boolean.toString(false));
+        when(redisTemplate.opsForValue().get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.SUPPORTER.name())))
+                .thenReturn(Boolean.toString(false));
 
         // then
         mockMvc.perform(post("/upload/portfolios")

--- a/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodInitializerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodInitializerTest.java
@@ -1,97 +1,48 @@
 package org.ject.support.domain.recruit.service;
 
+import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.domain.Semester;
-import org.ject.support.domain.recruit.dto.Constants;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
-import org.ject.support.domain.recruit.repository.SemesterRepository;
-import org.ject.support.testconfig.IntegrationTest;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Transactional;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.ject.support.domain.member.JobFamily.BE;
-import static org.ject.support.domain.member.JobFamily.FE;
-import static org.ject.support.domain.member.JobFamily.PD;
-import static org.ject.support.domain.member.JobFamily.PM;
-import static org.ject.support.domain.member.JobFamily.SUPPORTER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@IntegrationTest
-@Transactional
-@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
-class AccessPeriodInitializerTest {
+class AccessPeriodInitializerTest extends UnitTestSupport {
 
-    @Autowired
+    @InjectMocks
     AccessPeriodInitializer accessPeriodInitializer;
 
-    @Autowired
+    @Mock
     RecruitRepository recruitRepository;
 
-    @Autowired
-    SemesterRepository semesterRepository;
-
-    @Autowired
-    RedisTemplate<String, String> redisTemplate;
+    @Mock
+    RecruitFlagService recruitFlagService;
 
     @Test
-    @DisplayName("애플리케이션 구동 시 RECRUIT_FLAG 세팅")
-    void set_recruit_flag_by_run_application() {
+    void 애플리케이션_구동_시_활성_모집의_recruit_flag를_세팅한다() {
         // given
-        redisTemplate.delete(List.of("RECRUIT_FLAG:PM", "RECRUIT_FLAG:PD", "RECRUIT_FLAG:FE",
-                "RECRUIT_FLAG:BE", "RECRUIT_FLAG:SUPPORTER"));
-
-        Semester savedSemester = semesterRepository.save(Semester.builder()
-                .name("1기")
-                .isRecruiting(true)
-                .build());
-
-        recruitRepository.saveAll(List.of(
-                Recruit.builder()
-                        .semester(savedSemester)
-                        .startDate(LocalDateTime.now().minusDays(1))
-                        .endDate(LocalDateTime.now().plusDays(1))
-                        .jobFamily(PM)
-                        .build(),
-                Recruit.builder()
-                        .semester(savedSemester)
-                        .startDate(LocalDateTime.now().minusDays(1))
-                        .endDate(LocalDateTime.now().plusDays(1))
-                        .jobFamily(PD)
-                        .build(),
-                Recruit.builder()
-                        .semester(savedSemester)
-                        .startDate(LocalDateTime.now().plusDays(3))
-                        .endDate(LocalDateTime.now().plusDays(5))
-                        .jobFamily(FE)
-                        .build(),
-                Recruit.builder()
-                        .semester(savedSemester)
-                        .startDate(LocalDateTime.now().minusDays(1))
-                        .endDate(LocalDateTime.now().plusDays(1))
-                        .jobFamily(SUPPORTER)
-                        .build()
-        ));
+        Recruit recruit = Recruit.builder()
+                .id(1L)
+                .semester(Semester.builder().id(1L).name("1기").isRecruiting(true).build())
+                .jobFamily(JobFamily.BE)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+        when(recruitRepository.findActiveRecruits(any(LocalDateTime.class))).thenReturn(List.of(recruit));
 
         // when
         accessPeriodInitializer.run(null);
 
         // then
-        assertThat(Boolean.parseBoolean(getRecruitFlag(PM))).isTrue();
-        assertThat(Boolean.parseBoolean(getRecruitFlag(PD))).isTrue();
-        assertThat(Boolean.parseBoolean(getRecruitFlag(FE))).isFalse();
-        assertThat(Boolean.parseBoolean(getRecruitFlag(BE))).isFalse();
-        assertThat(Boolean.parseBoolean(getRecruitFlag(SUPPORTER))).isTrue();
-    }
-
-    private String getRecruitFlag(JobFamily jobFamily) {
-        return redisTemplate.opsForValue().get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, jobFamily));
+        verify(recruitFlagService).setRecruitFlag(recruit);
     }
 }

--- a/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodVerifierTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/AccessPeriodVerifierTest.java
@@ -48,6 +48,45 @@ class AccessPeriodVerifierTest extends UnitTestSupport {
         lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         lenient().when(circuitBreakerProvider.get(anyString())).thenReturn(circuitBreaker);
         lenient().when(circuitBreaker.tryAcquirePermission()).thenReturn(true);
+        lenient().when(target.recruitIdParameterIndex()).thenReturn(-1);
+    }
+
+    @Test
+    void 모집_공고_식별자_플래그가_모집중이면_통과() throws Throwable {
+        // given
+        when(target.recruitIdParameterIndex()).thenReturn(1);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 10L});
+        when(valueOperations.get("RECRUIT_FLAG:10")).thenReturn("true");
+        when(joinPoint.proceed()).thenReturn("OK");
+
+        // when
+        Object result = accessPeriodVerifier.checkRecruitmentPeriod(joinPoint, target);
+
+        // then
+        assertThat(result).isEqualTo("OK");
+    }
+
+    @Test
+    void 모집_공고_식별자_플래그가_모집중이_아니면_실패() {
+        // given
+        when(target.recruitIdParameterIndex()).thenReturn(1);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 10L});
+        when(valueOperations.get("RECRUIT_FLAG:10")).thenReturn("false");
+
+        // when, then
+        assertThatThrownBy(() -> accessPeriodVerifier.checkRecruitmentPeriod(joinPoint, target))
+                .isInstanceOf(GlobalException.class);
+    }
+
+    @Test
+    void 모집_공고_식별자_인덱스의_파라미터가_Long이_아니면_실패() {
+        // given
+        when(target.recruitIdParameterIndex()).thenReturn(1);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, "10"});
+
+        // when, then
+        assertThatThrownBy(() -> accessPeriodVerifier.checkRecruitmentPeriod(joinPoint, target))
+                .isInstanceOf(GlobalException.class);
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitFlagServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitFlagServiceTest.java
@@ -1,34 +1,47 @@
 package org.ject.support.domain.recruit.service;
 
+import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.domain.Semester;
-import org.ject.support.testconfig.IntegrationTest;
-import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.redis.core.ValueOperations;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
-@IntegrationTest
-@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
-class RecruitFlagServiceTest {
+class RecruitFlagServiceTest extends UnitTestSupport {
 
-    @Autowired
+    @InjectMocks
     RecruitFlagService recruitFlagService;
 
-    @Autowired
+    @Mock
     RedisTemplate<String, String> redisTemplate;
 
+    @Mock
+    ValueOperations<String, String> valueOperations;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
     @Test
-    @DisplayName("recruit flag 세팅")
-    void set_recruit_flag() {
+    void 모집_공고와_직군_기준_recruit_flag를_함께_세팅한다() {
         // given
         Recruit recruit = Recruit.builder()
+                .id(1L)
                 .semester(Semester.builder().id(1L).name("1기").isRecruiting(true).build())
                 .jobFamily(JobFamily.BE)
                 .startDate(LocalDateTime.now().minusDays(1))
@@ -39,16 +52,34 @@ class RecruitFlagServiceTest {
         recruitFlagService.setRecruitFlag(recruit);
 
         // then
-        assertThat(redisTemplate.opsForValue().get("RECRUIT_FLAG:BE")).isEqualTo("true");
+        verify(valueOperations).set(eq("RECRUIT_FLAG:1"), eq("true"), any(Duration.class));
+        verify(valueOperations).set(eq("RECRUIT_FLAG:BE"), eq("true"), any(Duration.class));
     }
 
     @Test
-    @DisplayName("recruit flag 제거")
-    void delete_recruit_flag() {
+    void 종료된_모집은_recruit_flag를_세팅하지_않는다() {
+        // given
+        Recruit recruit = Recruit.builder()
+                .id(1L)
+                .semester(Semester.builder().id(1L).name("1기").isRecruiting(true).build())
+                .jobFamily(JobFamily.BE)
+                .startDate(LocalDateTime.now().minusDays(2))
+                .endDate(LocalDateTime.now().minusDays(1))
+                .build();
+
         // when
-        recruitFlagService.deleteRecruitFlag("RECRUIT_FLAG:BE");
+        recruitFlagService.setRecruitFlag(recruit);
 
         // then
-        assertThat(redisTemplate.opsForValue().get("RECRUIT_FLAG:BE")).isEqualTo(null);
+        verify(valueOperations, never()).set(any(), any(), any(Duration.class));
+    }
+
+    @Test
+    void 모집_공고와_직군_기준_recruit_flag를_함께_제거한다() {
+        // when
+        recruitFlagService.deleteRecruitFlag(1L, JobFamily.BE);
+
+        // then
+        verify(redisTemplate).delete(List.of("RECRUIT_FLAG:1", "RECRUIT_FLAG:BE"));
     }
 }

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitFlagServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitFlagServiceTest.java
@@ -4,6 +4,7 @@ import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.domain.Semester;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -13,13 +14,12 @@ import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.List;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class RecruitFlagServiceTest extends UnitTestSupport {
 
@@ -28,6 +28,9 @@ class RecruitFlagServiceTest extends UnitTestSupport {
 
     @Mock
     RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    RecruitRepository recruitRepository;
 
     @Mock
     ValueOperations<String, String> valueOperations;
@@ -47,6 +50,8 @@ class RecruitFlagServiceTest extends UnitTestSupport {
                 .startDate(LocalDateTime.now().minusDays(1))
                 .endDate(LocalDateTime.now().plusDays(1))
                 .build();
+        when(recruitRepository.findLatestActiveRecruitEndDateByJobFamily(eq(JobFamily.BE), any(LocalDateTime.class)))
+                .thenReturn(recruit.getEndDate());
 
         // when
         recruitFlagService.setRecruitFlag(recruit);
@@ -76,10 +81,29 @@ class RecruitFlagServiceTest extends UnitTestSupport {
 
     @Test
     void 모집_공고와_직군_기준_recruit_flag를_함께_제거한다() {
+        // given
+        when(recruitRepository.findLatestActiveRecruitEndDateByJobFamily(eq(JobFamily.BE), any(LocalDateTime.class)))
+                .thenReturn(null);
+
         // when
         recruitFlagService.deleteRecruitFlag(1L, JobFamily.BE);
 
         // then
-        verify(redisTemplate).delete(List.of("RECRUIT_FLAG:1", "RECRUIT_FLAG:BE"));
+        verify(redisTemplate).delete("RECRUIT_FLAG:1");
+        verify(redisTemplate).delete("RECRUIT_FLAG:BE");
+    }
+
+    @Test
+    void 같은_직군의_다른_활성_공고가_남아있으면_직군_recruit_flag를_유지한다() {
+        // given
+        when(recruitRepository.findLatestActiveRecruitEndDateByJobFamily(eq(JobFamily.BE), any(LocalDateTime.class)))
+                .thenReturn(LocalDateTime.now().plusDays(2));
+
+        // when
+        recruitFlagService.deleteRecruitFlag(1L, JobFamily.BE);
+
+        // then
+        verify(redisTemplate).delete("RECRUIT_FLAG:1");
+        verify(valueOperations).set(eq("RECRUIT_FLAG:BE"), eq("true"), any(Duration.class));
     }
 }

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitServiceTest.java
@@ -9,6 +9,7 @@ import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.dto.ActiveRecruitmentResponses;
 import org.ject.support.domain.recruit.dto.RecruitRegisterRequest;
 import org.ject.support.domain.recruit.dto.RecruitUpdateRequest;
+import org.ject.support.domain.recruit.dto.RecruitUpdatedEvent;
 import org.ject.support.domain.recruit.exception.RecruitException;
 import org.ject.support.domain.recruit.repository.RecruitRepository;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
@@ -163,6 +164,11 @@ class RecruitServiceTest extends UnitTestSupport {
         // then
         assertThat(recruit.getJobFamily()).isEqualTo(FE);
         assertThat(recruit.getEndDate()).isEqualTo(newEndDate);
+
+        ArgumentCaptor<RecruitUpdatedEvent> eventCaptor = ArgumentCaptor.forClass(RecruitUpdatedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().previousJobFamily()).isEqualTo(BE);
+        assertThat(eventCaptor.getValue().currentJobFamily()).isEqualTo(FE);
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitUpdatedEventHandlerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitUpdatedEventHandlerTest.java
@@ -52,6 +52,7 @@ class RecruitUpdatedEventHandlerTest extends UnitTestSupport {
         recruitUpdatedEventHandler.handleRecruitUpdated(new RecruitUpdatedEvent(
                 1L,
                 JobFamily.BE,
+                JobFamily.BE,
                 futureRecruit.getStartDate(),
                 futureRecruit.getEndDate()));
 
@@ -59,5 +60,30 @@ class RecruitUpdatedEventHandlerTest extends UnitTestSupport {
         verify(recruitFlagService).deleteRecruitFlag(1L, JobFamily.BE);
         verify(recruitScheduleService).scheduleRecruitOpen(futureRecruit);
         verify(recruitFlagService, never()).setRecruitFlag(futureRecruit);
+    }
+
+    @Test
+    void 직군이_변경되면_이전_직군_recruit_flag도_재계산한다() {
+        // given
+        Recruit activeRecruit = Recruit.builder()
+                .id(1L)
+                .semester(Semester.builder().id(1L).name("1기").isRecruiting(true).build())
+                .jobFamily(JobFamily.FE)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+        when(recruitRepository.findById(1L)).thenReturn(Optional.of(activeRecruit));
+
+        // when
+        recruitUpdatedEventHandler.handleRecruitUpdated(new RecruitUpdatedEvent(
+                1L,
+                JobFamily.BE,
+                JobFamily.FE,
+                activeRecruit.getStartDate(),
+                activeRecruit.getEndDate()));
+
+        // then
+        verify(recruitFlagService).refreshJobFamilyFlag(JobFamily.BE);
+        verify(recruitFlagService).setRecruitFlag(activeRecruit);
     }
 }

--- a/src/test/java/org/ject/support/domain/recruit/service/RecruitUpdatedEventHandlerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/RecruitUpdatedEventHandlerTest.java
@@ -1,0 +1,63 @@
+package org.ject.support.domain.recruit.service;
+
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.Semester;
+import org.ject.support.domain.recruit.dto.RecruitUpdatedEvent;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RecruitUpdatedEventHandlerTest extends UnitTestSupport {
+
+    @InjectMocks
+    RecruitUpdatedEventHandler recruitUpdatedEventHandler;
+
+    @Mock
+    RecruitRepository recruitRepository;
+
+    @Mock
+    RecruitFlagService recruitFlagService;
+
+    @Mock
+    RecruitScheduleService recruitScheduleService;
+
+    Recruit futureRecruit;
+
+    @BeforeEach
+    void setUp() {
+        futureRecruit = Recruit.builder()
+                .id(1L)
+                .semester(Semester.builder().id(1L).name("1기").isRecruiting(true).build())
+                .jobFamily(JobFamily.BE)
+                .startDate(LocalDateTime.now().plusDays(1))
+                .endDate(LocalDateTime.now().plusDays(2))
+                .build();
+        when(recruitRepository.findById(1L)).thenReturn(Optional.of(futureRecruit));
+    }
+
+    @Test
+    void 시작일이_미래로_변경되면_기존_recruit_flag를_제거하고_오픈_스케줄을_등록한다() {
+        // when
+        recruitUpdatedEventHandler.handleRecruitUpdated(new RecruitUpdatedEvent(
+                1L,
+                JobFamily.BE,
+                futureRecruit.getStartDate(),
+                futureRecruit.getEndDate()));
+
+        // then
+        verify(recruitFlagService).deleteRecruitFlag(1L, JobFamily.BE);
+        verify(recruitScheduleService).scheduleRecruitOpen(futureRecruit);
+        verify(recruitFlagService, never()).setRecruitFlag(futureRecruit);
+    }
+}

--- a/src/test/java/org/ject/support/testconfig/ApplicationPeriodTest.java
+++ b/src/test/java/org/ject/support/testconfig/ApplicationPeriodTest.java
@@ -1,6 +1,5 @@
 package org.ject.support.testconfig;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import org.ject.support.domain.member.JobFamily;
@@ -26,7 +25,6 @@ public abstract class ApplicationPeriodTest {
     @BeforeEach
     void setUp() {
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        when(valueOperations.get(anyString())).thenReturn(Boolean.toString(true));
         when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.PM.name())))
                 .thenReturn(Boolean.toString(true));
         when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.PD.name())))

--- a/src/test/java/org/ject/support/testconfig/ApplicationPeriodTest.java
+++ b/src/test/java/org/ject/support/testconfig/ApplicationPeriodTest.java
@@ -1,5 +1,6 @@
 package org.ject.support.testconfig;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import org.ject.support.domain.member.JobFamily;
@@ -25,6 +26,7 @@ public abstract class ApplicationPeriodTest {
     @BeforeEach
     void setUp() {
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(anyString())).thenReturn(Boolean.toString(true));
         when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.PM.name())))
                 .thenReturn(Boolean.toString(true));
         when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.PD.name())))
@@ -33,7 +35,8 @@ public abstract class ApplicationPeriodTest {
                 .thenReturn(Boolean.toString(true));
         when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.BE.name())))
                 .thenReturn(Boolean.toString(true));
+        when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.SUPPORTER.name())))
+                .thenReturn(Boolean.toString(true));
         when(redisTemplate.getConnectionFactory()).thenReturn(redisConnectionFactory);
     }
 }
-


### PR DESCRIPTION
## #️⃣연관된 이슈

close #554
Parent: #427

## 📝 작업 내용

- `@PeriodAccessible`에서 `recruitId` 파라미터 인덱스를 지정할 수 있게 확장했습니다.
- `/apply` 지원 플로우의 기간 검증을 `RECRUIT_FLAG:{recruitId}` 기준으로 변경했습니다.
- 모집 flag 저장/삭제 시 공고 식별자 기준 key와 기존 직군 기준 key를 함께 관리하도록 변경했습니다.
- 애플리케이션 구동 시 활성 모집 공고 전체를 기준으로 flag를 초기화하도록 변경했습니다.
- 기간 검증, flag 저장/삭제, 초기화 테스트를 보강했습니다.

## 🙏 리뷰 요구사항 (선택)

- `ApplyService`의 `RECRUIT_ID_PARAMETER_INDEX`가 현재 메서드 시그니처와 맞는지 확인 부탁드립니다.
- 기존 직군 기준 flag는 공고 식별자가 없는 경로의 호환용으로 유지했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 개선**
  * 모집 공고별 접근 검사에 모집 식별자(recruitId) 기반 검증 추가

* **내부 개선**
  * 모집 접근 플래그 관리 개선: 공고·직군 기준 동시 반영, TTL 기반 갱신·삭제 로직 보강
  * 초기화·검증 흐름 단순화 및 장애 회복 로직 강화
  * 모집 수정 시 이전/현재 직군을 고려한 캐시 무효화 및 플래그 갱신 보강

* **테스트**
  * Redis 연동 통합 테스트를 Mockito 단위 테스트로 전환하고 관련 신규/확장 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/JECT-Official-WebSite-Server/pull/555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->