### PR TITLE
feat:관리자 계정 목록 조회 구현

### DIFF
--- a/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
+++ b/src/main/java/org/ject/support/admin/account/controller/AdminAccountController.java
@@ -5,19 +5,31 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.account.dto.AdminAccountResponse;
 import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountUpdateRequest;
+import org.ject.support.admin.account.dto.AdminAccountSearchCondition;
 import org.ject.support.admin.account.service.AdminAccountService;
 import org.ject.support.common.security.AuthPrincipal;
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Role;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +38,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminAccountController {
 
     private final AdminAccountService adminAccountService;
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    @Operation(
+            summary = "관리자 계정 목록 조회",
+            description = "관리자 계정 목록을 조회합니다. 계정 유형과 상태를 복수 필터로 선택할 수 있습니다.")
+    public Page<AdminAccountResponse> findAccounts(
+            @RequestParam(required = false) final List<Role> roles,
+            @RequestParam(required = false) final List<MemberStatus> statuses,
+            @PageableDefault(sort = "createdAt", direction = Direction.DESC) final Pageable pageable) {
+        AdminAccountSearchCondition condition = new AdminAccountSearchCondition(roles, statuses);
+        return adminAccountService.findAccounts(condition, pageable);
+    }
 
     @PostMapping
     @PreAuthorize("hasAuthority('ROLE_ADMIN')")

--- a/src/main/java/org/ject/support/admin/account/dto/AdminAccountResponse.java
+++ b/src/main/java/org/ject/support/admin/account/dto/AdminAccountResponse.java
@@ -1,0 +1,23 @@
+package org.ject.support.admin.account.dto;
+
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.dto.MemberAccountProjection;
+
+public record AdminAccountResponse(
+        Long id,
+        String email,
+        String name,
+        Role role,
+        MemberStatus status
+) {
+
+    public static AdminAccountResponse from(final MemberAccountProjection projection) {
+        return new AdminAccountResponse(
+                projection.id(),
+                projection.email(),
+                projection.name(),
+                projection.role(),
+                projection.status());
+    }
+}

--- a/src/main/java/org/ject/support/admin/account/dto/AdminAccountSearchCondition.java
+++ b/src/main/java/org/ject/support/admin/account/dto/AdminAccountSearchCondition.java
@@ -1,0 +1,12 @@
+package org.ject.support.admin.account.dto;
+
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Role;
+
+import java.util.List;
+
+public record AdminAccountSearchCondition(
+        List<Role> roles,
+        List<MemberStatus> statuses
+) {
+}

--- a/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
+++ b/src/main/java/org/ject/support/admin/account/service/AdminAccountService.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
+import org.ject.support.admin.account.dto.AdminAccountResponse;
 import org.ject.support.admin.account.dto.AdminAccountUpdateRequest;
+import org.ject.support.admin.account.dto.AdminAccountSearchCondition;
 import org.ject.support.admin.component.AdminMemberComponent;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
@@ -13,9 +15,13 @@ import org.ject.support.domain.member.Role;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.entity.MemberEditor;
 import org.ject.support.domain.member.repository.MemberRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +31,13 @@ public class AdminAccountService {
     private final MemberRepository memberRepository;
     private final AdminMemberComponent adminMemberComponent;
     private final PasswordEncoder passwordEncoder;
+
+    public Page<AdminAccountResponse> findAccounts(final AdminAccountSearchCondition condition,
+                                                   final Pageable pageable) {
+        validateBackofficeRoles(condition.roles());
+        return memberRepository.findAccounts(condition, pageable)
+                .map(AdminAccountResponse::from);
+    }
 
     @Transactional
     public void createAccount(final AdminAccountCreateRequest request) {
@@ -98,6 +111,16 @@ public class AdminAccountService {
 
     private void validateBackofficeRole(final Role role) {
         if (!role.isBackoffice()) {
+            throw new AdminException(AdminErrorCode.INVALID_ADMIN_ACCOUNT_ROLE);
+        }
+    }
+
+    private void validateBackofficeRoles(final List<Role> roles) {
+        if (roles == null || roles.isEmpty()) {
+            return;
+        }
+
+        if (roles.stream().anyMatch(role -> !role.isBackoffice())) {
             throw new AdminException(AdminErrorCode.INVALID_ADMIN_ACCOUNT_ROLE);
         }
     }

--- a/src/main/java/org/ject/support/domain/member/dto/MemberAccountProjection.java
+++ b/src/main/java/org/ject/support/domain/member/dto/MemberAccountProjection.java
@@ -1,0 +1,13 @@
+package org.ject.support.domain.member.dto;
+
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Role;
+
+public record MemberAccountProjection(
+        Long id,
+        String email,
+        String name,
+        Role role,
+        MemberStatus status
+) {
+}

--- a/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepository.java
@@ -1,11 +1,18 @@
 package org.ject.support.domain.member.repository;
 
-import java.util.List;
+import org.ject.support.admin.account.dto.AdminAccountSearchCondition;
+import org.ject.support.domain.member.dto.MemberAccountProjection;
 import org.ject.support.domain.member.dto.TeamMemberNames;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface MemberQueryRepository {
 
     TeamMemberNames findMemberNamesByTeamId(Long teamId);
 
     List<String> findEmailsByIdsAndNotSubmitted(List<Long> applicantIds);
+
+    Page<MemberAccountProjection> findAccounts(AdminAccountSearchCondition condition, Pageable pageable);
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberQueryRepositoryImpl.java
@@ -10,12 +10,22 @@ import static org.ject.support.domain.member.entity.QMember.member;
 import static org.ject.support.domain.member.entity.QTeamMember.teamMember;
 
 import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQueryFactory;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.account.dto.AdminAccountSearchCondition;
+import org.ject.support.common.data.PageResponse;
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.dto.MemberAccountProjection;
 import org.ject.support.domain.member.dto.QTeamMemberNames;
 import org.ject.support.domain.member.dto.TeamMemberNames;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -64,5 +74,56 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
                         member.isDeleted.eq(false),
                         apply.status.eq(SUBMITTED).not())
                 .fetch();
+    }
+
+    @Override
+    public Page<MemberAccountProjection> findAccounts(final AdminAccountSearchCondition condition,
+                                                      final Pageable pageable) {
+        List<MemberAccountProjection> content = queryFactory
+                .select(Projections.constructor(
+                        MemberAccountProjection.class,
+                        member.id,
+                        member.email,
+                        member.name,
+                        member.role,
+                        member.status))
+                .from(member)
+                .where(
+                        member.isDeleted.eq(false),
+                        member.role.in(Role.backofficeRoles()),
+                        inRoles(condition.roles()),
+                        inStatuses(condition.statuses())
+                )
+                .orderBy(member.createdAt.desc(), member.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(member.count())
+                .from(member)
+                .where(
+                        member.isDeleted.eq(false),
+                        member.role.in(Role.backofficeRoles()),
+                        inRoles(condition.roles()),
+                        inStatuses(condition.statuses())
+                )
+                .fetchOne();
+
+        return PageResponse.from(content, pageable, total != null ? total : 0L);
+    }
+
+    private BooleanExpression inRoles(final List<Role> roles) {
+        return Optional.ofNullable(roles)
+                .filter(values -> !values.isEmpty())
+                .map(member.role::in)
+                .orElse(null);
+    }
+
+    private BooleanExpression inStatuses(final List<MemberStatus> statuses) {
+        return Optional.ofNullable(statuses)
+                .filter(values -> !values.isEmpty())
+                .map(member.status::in)
+                .orElse(null);
     }
 }

--- a/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
+++ b/src/test/java/org/ject/support/admin/account/controller/AdminAccountControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
+import org.ject.support.admin.account.dto.AdminAccountResponse;
 import org.ject.support.admin.account.dto.AdminAccountUpdateRequest;
 import org.ject.support.admin.account.service.AdminAccountService;
 import org.ject.support.base.UnitTestSupport;
@@ -11,12 +12,17 @@ import org.ject.support.common.exception.GlobalErrorCode;
 import org.ject.support.common.exception.GlobalExceptionHandler;
 import org.ject.support.common.security.AuthenticatedMemberIdResolver;
 import org.ject.support.common.security.CustomUserDetails;
+import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Role;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -24,11 +30,16 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -51,13 +62,75 @@ class AdminAccountControllerTest extends UnitTestSupport {
         objectMapper = new ObjectMapper();
         mockMvc = MockMvcBuilders.standaloneSetup(adminAccountController)
                 .setControllerAdvice(new GlobalExceptionHandler())
-                .setCustomArgumentResolvers(new AuthenticatedMemberIdResolver())
+                .setCustomArgumentResolvers(
+                        new AuthenticatedMemberIdResolver(),
+                        new PageableHandlerMethodArgumentResolver())
                 .build();
     }
 
     @AfterEach
     void tearDown() {
         SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 관리자_계정_목록_조회_성공() throws Exception {
+        // given
+        var response = new AdminAccountResponse(1L, "admin@ject.kr", "김젝트", Role.ADMIN, MemberStatus.ACTIVE);
+        var page = new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1);
+
+        given(adminAccountService.findAccounts(any(), any(Pageable.class))).willReturn(page);
+
+        // when, then
+        mockMvc.perform(get("/admin/accounts")
+                        .param("roles", "ADMIN", "SUPPORTER")
+                        .param("statuses", "ACTIVE", "LOCKED")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].email").value("admin@ject.kr"))
+                .andExpect(jsonPath("$.content[0].name").value("김젝트"))
+                .andExpect(jsonPath("$.content[0].role").value("ADMIN"))
+                .andExpect(jsonPath("$.content[0].status").value("ACTIVE"))
+                .andDo(print());
+
+        verify(adminAccountService).findAccounts(
+                argThat(condition ->
+                        condition.roles().equals(List.of(Role.ADMIN, Role.SUPPORTER))
+                                && condition.statuses().equals(List.of(MemberStatus.ACTIVE, MemberStatus.LOCKED))),
+                any(Pageable.class));
+    }
+
+    @Test
+    void 관리자_계정_목록_조회는_필터를_생략할_수_있다() throws Exception {
+        // given
+        var page = new PageImpl<AdminAccountResponse>(List.of(), PageRequest.of(0, 20), 0);
+
+        given(adminAccountService.findAccounts(any(), any(Pageable.class))).willReturn(page);
+
+        // when, then
+        mockMvc.perform(get("/admin/accounts")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        verify(adminAccountService).findAccounts(
+                argThat(condition -> condition.roles() == null && condition.statuses() == null),
+                any(Pageable.class));
+    }
+
+    @Test
+    void 관리자_계정_목록_조회는_ADMIN_권한만_허용한다() throws Exception {
+        // when
+        PreAuthorize preAuthorize = AdminAccountController.class
+                .getMethod("findAccounts", List.class, List.class, Pageable.class)
+                .getAnnotation(PreAuthorize.class);
+
+        // then
+        assertThat(preAuthorize).isNotNull();
+        assertThat(preAuthorize.value()).isEqualTo("hasAuthority('ROLE_ADMIN')");
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
+++ b/src/test/java/org/ject/support/admin/account/service/AdminAccountServiceTest.java
@@ -3,24 +3,32 @@ package org.ject.support.admin.account.service;
 import org.ject.support.admin.account.dto.AdminAccountActiveUpdateRequest;
 import org.ject.support.admin.account.dto.AdminAccountCreateRequest;
 import org.ject.support.admin.account.dto.AdminAccountRoleUpdateRequest;
+import org.ject.support.admin.account.dto.AdminAccountResponse;
 import org.ject.support.admin.account.dto.AdminAccountUpdateRequest;
+import org.ject.support.admin.account.dto.AdminAccountSearchCondition;
 import org.ject.support.admin.component.AdminMemberComponent;
 import org.ject.support.admin.exception.AdminErrorCode;
 import org.ject.support.admin.exception.AdminException;
+import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.MemberStatus;
-import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.dto.MemberAccountProjection;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -44,6 +52,44 @@ class AdminAccountServiceTest extends UnitTestSupport {
     private static final String TEST_EMAIL = "admin@ject.kr";
     private static final String TEST_PASSWORD = "password123";
     private static final String ENCODED_PASSWORD = "encoded-password";
+
+    @Test
+    void 관리자_계정_목록_조회_성공() {
+        // given
+        var pageable = PageRequest.of(0, 20);
+        var condition = new AdminAccountSearchCondition(
+                List.of(Role.ADMIN, Role.SUPPORTER),
+                List.of(MemberStatus.ACTIVE));
+        var projection = new MemberAccountProjection(1L, TEST_EMAIL, "김젝트", Role.ADMIN, MemberStatus.ACTIVE);
+        var page = new PageImpl<>(List.of(projection), pageable, 1);
+
+        given(memberRepository.findAccounts(condition, pageable)).willReturn(page);
+
+        // when
+        var result = adminAccountService.findAccounts(condition, pageable);
+
+        // then
+        assertThat(result.getContent())
+                .containsExactly(new AdminAccountResponse(1L, TEST_EMAIL, "김젝트", Role.ADMIN, MemberStatus.ACTIVE));
+        verify(memberRepository).findAccounts(condition, pageable);
+    }
+
+    @Test
+    void 관리자_계정_목록_조회_실패_관리자_계정_유형이_아닌_role_필터() {
+        // given
+        var pageable = PageRequest.of(0, 20);
+        var condition = new AdminAccountSearchCondition(
+                List.of(Role.ADMIN, Role.SEMESTER),
+                List.of(MemberStatus.ACTIVE));
+
+        // when, then
+        assertThatThrownBy(() -> adminAccountService.findAccounts(condition, pageable))
+                .isInstanceOf(AdminException.class)
+                .extracting(e -> ((AdminException) e).getErrorCode())
+                .isEqualTo(AdminErrorCode.INVALID_ADMIN_ACCOUNT_ROLE);
+
+        verify(memberRepository, never()).findAccounts(any(), eq(pageable));
+    }
 
     @Test
     void 관리자_계정_생성_성공() {

--- a/src/test/java/org/ject/support/domain/member/repository/MemberAccountQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberAccountQueryRepositoryTest.java
@@ -1,0 +1,115 @@
+package org.ject.support.domain.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.ject.support.admin.account.dto.AdminAccountSearchCondition;
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.member.dto.MemberAccountProjection;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.testconfig.QueryDslTestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@Import(QueryDslTestConfig.class)
+@DataJpaTest
+class MemberAccountQueryRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    void 필터가_없으면_삭제되지_않은_백오피스_계정만_조회한다() {
+        // given
+        Member admin = createMember("admin@ject.kr", "관리자", Role.ADMIN, MemberStatus.ACTIVE);
+        Member operations = createMember("operations@ject.kr", "운영자", Role.OPERATIONS, MemberStatus.ACTIVE);
+        Member semester = createMember("semester@ject.kr", "일반회원", Role.SEMESTER, MemberStatus.ACTIVE);
+        Member deleted = createMember("deleted@ject.kr", "삭제회원", Role.SUPPORTER, MemberStatus.ACTIVE);
+        ReflectionTestUtils.setField(deleted, "isDeleted", true);
+        memberRepository.saveAll(List.of(admin, operations, semester, deleted));
+
+        // when
+        Page<MemberAccountProjection> result = memberRepository.findAccounts(
+                new AdminAccountSearchCondition(null, null),
+                PageRequest.of(0, 20));
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent())
+                .extracting(MemberAccountProjection::email)
+                .containsExactlyInAnyOrder("admin@ject.kr", "operations@ject.kr");
+    }
+
+    @Test
+    void 계정_유형과_상태를_복수_필터로_조회한다() {
+        // given
+        memberRepository.saveAll(List.of(
+                createMember("active-admin@ject.kr", "활성관리자", Role.ADMIN, MemberStatus.ACTIVE),
+                createMember("locked-admin@ject.kr", "잠긴관리자", Role.ADMIN, MemberStatus.LOCKED),
+                createMember("active-supporter@ject.kr", "활성서포터", Role.SUPPORTER, MemberStatus.ACTIVE),
+                createMember("locked-operations@ject.kr", "잠긴운영자", Role.OPERATIONS, MemberStatus.LOCKED)
+        ));
+
+        AdminAccountSearchCondition condition = new AdminAccountSearchCondition(
+                List.of(Role.ADMIN, Role.SUPPORTER),
+                List.of(MemberStatus.ACTIVE));
+
+        // when
+        Page<MemberAccountProjection> result = memberRepository.findAccounts(condition, PageRequest.of(0, 20));
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent())
+                .extracting(MemberAccountProjection::email)
+                .containsExactlyInAnyOrder("active-admin@ject.kr", "active-supporter@ject.kr");
+    }
+
+    @Test
+    void 페이지네이션과_기본_정렬을_적용한다() {
+        // given
+        Member first = createMember("first@ject.kr", "첫번째", Role.ADMIN, MemberStatus.ACTIVE);
+        Member second = createMember("second@ject.kr", "두번째", Role.ADMIN, MemberStatus.ACTIVE);
+        Member third = createMember("third@ject.kr", "세번째", Role.ADMIN, MemberStatus.ACTIVE);
+        setCreatedAt(first, LocalDateTime.of(2026, 1, 1, 0, 0));
+        setCreatedAt(second, LocalDateTime.of(2026, 1, 2, 0, 0));
+        setCreatedAt(third, LocalDateTime.of(2026, 1, 3, 0, 0));
+        memberRepository.saveAll(List.of(first, second, third));
+        memberRepository.flush();
+
+        // when
+        Page<MemberAccountProjection> result = memberRepository.findAccounts(
+                new AdminAccountSearchCondition(null, null),
+                PageRequest.of(0, 2));
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getContent())
+                .extracting(MemberAccountProjection::email)
+                .containsExactly("third@ject.kr", "second@ject.kr");
+    }
+
+    private Member createMember(String email, String name, Role role, MemberStatus status) {
+        return Member.builder()
+                .email(email)
+                .name(name)
+                .phoneNumber("01012345678")
+                .memberType(MemberType.SEMESTER)
+                .semesterId(1L)
+                .role(role)
+                .pin("encoded-password")
+                .status(status)
+                .build();
+    }
+
+    private void setCreatedAt(Member member, LocalDateTime createdAt) {
+        ReflectionTestUtils.setField(member, "createdAt", createdAt);
+    }
+}

--- a/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
@@ -89,7 +89,7 @@ class QuestionControllerTest {
         recruitRepository.save(recruit);
 
         member = Member.builder()
-                .email("test32" + uniqueSuffix + "@gmail.com")
+                .email("test_" + uniqueSuffix + "@gmail.com")
                 .semesterId(1L)
                 .jobFamily(JobFamily.BE)
                 .name("김젝트")


### PR DESCRIPTION
## #️⃣연관된 이슈

close #474 

## 📝 작업 내용

### 백오피스 - 관리자 계정 목록 조회 
- 관리자 계정 목록 조회 API 추가
  - `GET /admin/accounts`
  - `Pageable` 기반 페이지네이션 지원
  - 계정 유형 `roles`, 상태 `statuses` 복수 필터 지원
- 관리자 계정 목록 응답 DTO 추가
  - `id`, `email`, `name`, `role`, `status`
- 관리자 계정 목록 조회 로직을 `MemberRepository` 계열로 정리
  - `MemberQueryRepository.findAccounts(...)`
  - `MemberQueryRepositoryImpl` Querydsl 조회 구현
- 기존 `AdminAccountQueryRepository` 제거
- 관련 controller/service/repository 테스트 추가 및 수정


### 백오피스 기능 명세서
<img width="228" height="304" alt="image" src="https://github.com/user-attachments/assets/b73f0962-4706-491e-b3e6-9468717e38dc" />

### Figma 참고
<img width="778" height="476" alt="image" src="https://github.com/user-attachments/assets/46f7fbce-5e35-4901-9cff-6539b6a8132e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자용 계정 목록 조회 기능 추가
  * 계정 역할 및 상태에 따른 필터링 지원
  * 페이징을 통한 대량 계정 조회 지원

* **Tests**
  * 관리자 계정 조회 관련 테스트 코드 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/JECT-Official-WebSite-Server/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->