### PR TITLE
[feat] member 데이터 분리 및 활동 관리 테이블 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,20 @@ out/
 spy.log
 src/main/generated/
 dynamodb-local-metadata.json
+
+### mac OS ###
+.DS_Store
+
+### AI ###
+CLAUDE.md
+AGENTS.md
+GEMINI.md
+CODEX.md
+.cursorrules
+.cursorignore
+.cursor/rules/
+.cursor/rules/*.mdc
+.windsurfrules
+.windsurf/
+.roo/
+.roo-rules/

--- a/src/main/java/org/ject/support/domain/apply/domain/Applicant.java
+++ b/src/main/java/org/ject/support/domain/apply/domain/Applicant.java
@@ -1,0 +1,95 @@
+package org.ject.support.domain.apply.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.ject.support.common.util.StringListConverter;
+import org.ject.support.domain.base.BaseTimeEntity;
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.member.Region;
+import org.ject.support.domain.member.Role;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "applicant")
+@SQLDelete(sql = "UPDATE applicant SET is_deleted = true WHERE id = ?")
+@SQLRestriction("is_deleted = false")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Applicant extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 20)
+    private String name;
+
+    @Column(length = 12)
+    private String phoneNumber;
+
+    @Column(length = 30, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private Long semesterId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(45)")
+    private JobFamily jobFamily;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(10)", nullable = false)
+    private Role role;
+
+    @Column(length = 255)
+    private String pin;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(45)", nullable = false)
+    @Builder.Default
+    private MemberStatus status = MemberStatus.ACTIVE;
+
+    @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30)
+    private CareerDetails careerDetails;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30)
+    private ExperiencePeriod experiencePeriod;
+
+    @Column(name = "domain_name", length = 50)
+    @Convert(converter = StringListConverter.class)
+    @Builder.Default
+    private List<String> interestedDomains = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30)
+    private Region region;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "member_type", columnDefinition = "varchar(45)", nullable = false)
+    @Builder.Default
+    private MemberType memberType = MemberType.SEMESTER;
+}

--- a/src/main/java/org/ject/support/domain/member/ActivityStatus.java
+++ b/src/main/java/org/ject/support/domain/member/ActivityStatus.java
@@ -1,0 +1,15 @@
+package org.ject.support.domain.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ActivityStatus {
+    ACTIVE("활동중"),
+    COMPLETED("완주"),
+    ENDED("활동종료"),
+    DROPOUT("중도하차");
+
+    private final String description;
+}

--- a/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
@@ -1,0 +1,74 @@
+package org.ject.support.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.ject.support.domain.base.BaseTimeEntity;
+import org.ject.support.domain.member.ActivityStatus;
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "member_activity")
+@SQLDelete(sql = "UPDATE member_activity SET is_deleted = true WHERE id = ?")
+@SQLRestriction("is_deleted = false")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberActivity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30)
+    private CareerDetails careerDetails;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "member_type", columnDefinition = "varchar(45)", nullable = false)
+    private MemberType memberType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(45)")
+    private JobFamily jobFamily;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(45)")
+    private ActivityStatus activityStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30)
+    private ExperiencePeriod experiencePeriod;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    @Column(length = 100)
+    private String memo;
+}

--- a/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
@@ -58,8 +58,9 @@ public class MemberActivity extends BaseTimeEntity {
     private JobFamily jobFamily;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "varchar(45)")
-    private ActivityStatus activityStatus;
+    @Column(columnDefinition = "varchar(45)", nullable = false)
+    @Builder.Default
+    private ActivityStatus activityStatus = ActivityStatus.ACTIVE;
 
     @Enumerated(EnumType.STRING)
     @Column(length = 30)

--- a/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
@@ -37,9 +37,8 @@ public class MemberActivity extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
 
     @Column(name = "is_deleted", nullable = false)
     @Builder.Default

--- a/src/main/java/org/ject/support/domain/member/entity/MemberMakers.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberMakers.java
@@ -1,0 +1,56 @@
+package org.ject.support.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.*;
+import org.ject.support.domain.base.BaseTimeEntity;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "member_makers")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberMakers extends BaseTimeEntity {
+
+    @Id
+    private Long id;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id", nullable = false)
+    private MemberActivity memberActivity;
+
+    @Column(length = 20)
+    private String teamName;
+
+    @Column(length = 30)
+    private String mentoringAvailability;
+
+    @Column(length = 30)
+    private String projectSupplementAvailability;
+
+    @Column(length = 30)
+    private String speakerAvailability;
+
+    @Column(length = 30)
+    private String careerLevel;
+
+    @Column(length = 255)
+    private String skills;
+
+    @Column(length = 30)
+    private String company;
+
+    @Column(length = 30)
+    private String expertTopics;
+
+    @Column(length = 20)
+    private String activityCertNumber;
+}

--- a/src/main/java/org/ject/support/domain/member/entity/MemberSemester.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberSemester.java
@@ -1,0 +1,43 @@
+package org.ject.support.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.*;
+import org.ject.support.domain.base.BaseTimeEntity;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "member_semester")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberSemester extends BaseTimeEntity {
+
+    @Id
+    private Long id;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id", nullable = false)
+    private MemberActivity memberActivity;
+
+    @Column(nullable = false)
+    private Long semesterId;
+
+    private Long teamId;
+
+    @Column(length = 20)
+    private String certNumber;
+
+    @Column(length = 255)
+    private String firstReview;
+
+    @Column(length = 255)
+    private String secondReview;
+}

--- a/src/main/java/org/ject/support/domain/member/entity/MemberSupporters.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberSupporters.java
@@ -1,0 +1,32 @@
+package org.ject.support.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.*;
+import org.ject.support.domain.base.BaseTimeEntity;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "member_supporters")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberSupporters extends BaseTimeEntity {
+
+    @Id
+    private Long id;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id", nullable = false)
+    private MemberActivity memberActivity;
+
+    @Column(length = 20)
+    private String activityCertNumber;
+}

--- a/src/main/resources/db/migration/V28__create_applicant_and_copy_member.sql
+++ b/src/main/resources/db/migration/V28__create_applicant_and_copy_member.sql
@@ -1,0 +1,26 @@
+-- 26-05-19 시점의 member 테이블 상태를 그대로 복사
+-- 제약조건은 추후 수정, 추가
+CREATE TABLE applicant
+(
+    id                bigint auto_increment primary key,
+    created_at        datetime(6)                    null,
+    updated_at        datetime(6)                    null,
+    name              varchar(20)                    null,
+    phone_number      varchar(12)                    null,
+    email             varchar(30)                    not null,
+    semester_id       bigint                         not null,
+    job_family        varchar(45)                    null,
+    role              varchar(10)                    not null,
+    pin               varchar(255)                   null,
+    status            varchar(45) default 'ACTIVE'   not null,
+    is_deleted        tinyint(1)  default 0          not null,
+    career_details    varchar(30)                    null,
+    experience_period varchar(30)                    null,
+    domain_name       varchar(50)                    null,
+    region            varchar(30)                    null,
+    member_type       varchar(45) default 'SEMESTER' not null
+);
+
+INSERT INTO applicant (id, created_at, updated_at, name, phone_number, email, semester_id, job_family, role, pin, status, is_deleted, career_details, experience_period, domain_name, region, member_type)
+SELECT                 id, created_at, updated_at, name, phone_number, email, semester_id, job_family, role, pin, status, is_deleted, career_details, experience_period, domain_name, region, member_type
+FROM member;

--- a/src/main/resources/db/migration/V29__create_member_activity_tables.sql
+++ b/src/main/resources/db/migration/V29__create_member_activity_tables.sql
@@ -1,0 +1,67 @@
+-- 멤버 활동 테이블 생성
+CREATE TABLE IF NOT EXISTS member_activity
+(
+    id                BIGINT AUTO_INCREMENT NOT NULL,
+    created_at        datetime(6) NULL,
+    updated_at        datetime(6) NULL,
+    member_id         BIGINT       NOT NULL,
+    is_deleted        TINYINT(1)   NOT NULL DEFAULT 0,
+    career_details    VARCHAR(30)  NULL,
+    member_type       VARCHAR(45)  NOT NULL,
+    job_family        VARCHAR(45)  NULL,
+    activity_status   VARCHAR(45)  NOT NULL DEFAULT 'ACTIVE',
+    experience_period VARCHAR(30)  NULL,
+    start_date        date NULL,
+    end_date          date NULL,
+    memo              VARCHAR(100) NULL,
+    CONSTRAINT `PRIMARY` PRIMARY KEY (id),
+    CONSTRAINT FK_member_activity_member FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE NO ACTION
+) ENGINE = InnoDB;
+
+-- 아래 관리 테이블은 부모인 member_activity.id를 pk로 사용
+-- 기존 semester 테이블과 구별하기 위해 prefix를 테이블명에 추가
+
+-- 일반 구성원 관리 테이블
+CREATE TABLE IF NOT EXISTS member_semester
+(
+    id            BIGINT      NOT NULL,
+    created_at    datetime(6) NULL,
+    updated_at    datetime(6) NULL,
+    semester_id   BIGINT      NOT NULL,
+    team_id       BIGINT NULL,
+    cert_number   VARCHAR(20) NULL,
+    first_review  VARCHAR(255) NULL,
+    second_review VARCHAR(255) NULL,
+    CONSTRAINT `PRIMARY` PRIMARY KEY (id),
+    CONSTRAINT FK_member_semester_member_activity FOREIGN KEY (id) REFERENCES member_activity (id) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+-- 메이커스 관리 테이블
+CREATE TABLE IF NOT EXISTS member_makers
+(
+    id                                  BIGINT      NOT NULL,
+    created_at                          datetime(6) NULL,
+    updated_at                          datetime(6) NULL,
+    team_name                           VARCHAR(20) NULL,
+    mentoring_availability             VARCHAR(30) NULL,
+    project_supplement_availability    VARCHAR(30) NULL,
+    speaker_availability               VARCHAR(30) NULL,
+    career_level                       VARCHAR(30) NULL,
+    skills                             VARCHAR(255) NULL,
+    company                            VARCHAR(30) NULL,
+    expert_topics                      VARCHAR(30) NULL,
+    activity_cert_number               VARCHAR(20) NULL,
+    CONSTRAINT `PRIMARY` PRIMARY KEY (id),
+    CONSTRAINT FK_member_makers_member_activity FOREIGN KEY (id) REFERENCES member_activity (id) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+-- 서포터즈 관리 테이블
+CREATE TABLE IF NOT EXISTS member_supporters
+(
+    id                   BIGINT NOT NULL,
+    created_at           datetime(6) NULL,
+    updated_at           datetime(6) NULL,
+    activity_cert_number VARCHAR(255) NULL,
+    CONSTRAINT `PRIMARY` PRIMARY KEY (id),
+    CONSTRAINT FK_member_supporters_member_activity FOREIGN KEY (id) REFERENCES member_activity (id) ON DELETE CASCADE
+) ENGINE = InnoDB;

--- a/src/main/resources/db/migration/V29__create_member_activity_tables.sql
+++ b/src/main/resources/db/migration/V29__create_member_activity_tables.sql
@@ -61,7 +61,7 @@ CREATE TABLE IF NOT EXISTS member_supporters
     id                   BIGINT NOT NULL,
     created_at           datetime(6) NULL,
     updated_at           datetime(6) NULL,
-    activity_cert_number VARCHAR(255) NULL,
+    activity_cert_number VARCHAR(20) NULL,
     CONSTRAINT `PRIMARY` PRIMARY KEY (id),
     CONSTRAINT FK_member_supporters_member_activity FOREIGN KEY (id) REFERENCES member_activity (id) ON DELETE CASCADE
 ) ENGINE = InnoDB;

--- a/src/main/resources/db/migration/V30__populate_member_activity_from_member.sql
+++ b/src/main/resources/db/migration/V30__populate_member_activity_from_member.sql
@@ -1,0 +1,60 @@
+-- member 테이블에서 1기-4기 일반 회원 데이터를 member_activity와 member_semester로 복사
+-- 1기-3기 구성원: is_deleted=false, role=SEMESTER, status=ACTIVE -> COMPLETED상태로 복사
+-- 4기 구성원: is_deleted=false, role=SEMESTER, status=ACTIVE -> ACTIVE상태로 복사
+-- 4기는 role 승격이 이루어져있지 않아 데이터 이관 불가
+    -- 운영 배포 전까지 4기 구성원의 role 승격 필요
+
+-- 활동 데이터 복사
+INSERT INTO member_activity (
+    created_at,
+    updated_at,
+    member_id,
+    career_details,
+    member_type,
+    job_family,
+    activity_status,
+    experience_period
+)
+SELECT DISTINCT
+    now(),
+    now(),
+    m.id,
+    m.career_details,
+    'SEMESTER',
+    m.job_family,
+    CASE
+        WHEN s.semester_name = '4기' THEN 'ACTIVE'
+        ELSE 'COMPLETED'
+    END,
+    m.experience_period
+FROM member m
+JOIN semester s ON s.id = m.semester_id
+WHERE m.is_deleted = false
+  AND m.role = 'SEMESTER'
+  AND m.status = 'ACTIVE'
+  AND s.semester_name IN ('1기', '2기', '3기', '4기');
+
+-- 일반 구성원의 전용 관리 항목 복사
+INSERT INTO member_semester (
+    created_at,
+    updated_at,
+    id,
+    semester_id,
+    team_id
+)
+SELECT
+    now(),
+    now(),
+    ma.id,
+    m.semester_id,
+    mt.team_id
+FROM member_activity ma
+JOIN member m ON m.id = ma.member_id
+LEFT JOIN (
+    SELECT
+        member_id,
+        MAX(team_id) AS team_id
+    FROM team_member
+    GROUP BY member_id
+) mt ON mt.member_id = ma.member_id
+WHERE ma.member_type = 'SEMESTER';

--- a/src/main/resources/db/migration/V31__soft_delete_members_not_migrated_to_activity.sql
+++ b/src/main/resources/db/migration/V31__soft_delete_members_not_migrated_to_activity.sql
@@ -1,0 +1,6 @@
+-- 활동 관리 데이터로 이관되지 않은 불필요한 member 데이터를 soft delete 처리
+UPDATE member m
+LEFT JOIN member_activity ma ON ma.member_id = m.id
+SET m.is_deleted = true
+WHERE ma.id IS NULL
+  AND m.is_deleted = false


### PR DESCRIPTION
close #556 

## 변경 내용
- 기존 member 데이터를 applicant 테이블로 복사하는 마이그레이션을 추가했습니다.
- member_activity 및 구성원 타입별 관리 테이블(member_semester, member_makers, member_supporters)을 추가했습니다.
- 정규 기수 구성원 데이터를 member_activity/member_semester로 이관하는 마이그레이션을 추가했습니다.
- 이관되지 않은 불필요한 member 데이터를 soft delete 처리하는 마이그레이션을 추가했습니다.
- 신규 테이블에 대응하는 JPA 엔티티를 추가했습니다.

## 코멘트
- 운영 데이터에서 4기는 role이 semester로 승격되지 않아 운영서버 배포 전 승격작업이 필요합니다.
- team_member에는 기록된 member가 role이 apply 상태인 경우가 존재해 일부 데이터 최신화가 필요합니다.
- 이관이 끝난 컬럼 삭제는 코드 수정이 병행되어야 해서 직후 코드 리팩토링 이슈에서 작업할 예정입니다.

## 병합 대상
- base: `dev`
- head: `feat/556-member-separation`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 지원자 관리 기능이 추가되어 지원자 정보를 DB에 저장·관리할 수 있습니다.
  * 회원 활동 기록 시스템이 추가되어 활동(세미스터·메이커스·서포터스)별 정보를 개별 추적합니다.
  * 활동 상태(활동중·완주·활동종료·중도하차) 유형이 도입되었습니다.
* **Chores (데이터 마이그레이션)**
  * 기존 회원 데이터를 신규 활동 구조로 이관하고, 미이관된 레코드는 소프트 삭제 처리했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/JECT-Official-WebSite-Server/pull/569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->