### PR TITLE
[feat] 일반 구성원 추가 기능 구현

### DIFF
--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberSemesterApiSpec.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberSemesterApiSpec.java
@@ -1,0 +1,17 @@
+package org.ject.support.admin.member.controller;
+
+import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "AdminMemberSemester", description = "일반 구성원 API")
+public interface AdminMemberSemesterApiSpec {
+	@Operation(
+		summary = "일반 구성원 추가",
+		description = "일반 구성원을 추가합니다."
+	)
+	void createAdminMemberSemester(@RequestBody @Valid CreateMemberSemesterRequest request);
+}

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberSemesterController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberSemesterController.java
@@ -1,0 +1,24 @@
+package org.ject.support.admin.member.controller;
+
+import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.admin.member.service.AdminMemberUseCase;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/admin/members/semester")
+@RequiredArgsConstructor
+public class AdminMemberSemesterController implements AdminMemberSemesterApiSpec {
+
+	private final AdminMemberUseCase adminMemberUsecase;
+
+	//일반 구성원 추가
+	@Override
+	@PostMapping
+	public void createAdminMemberSemester(CreateMemberSemesterRequest request) {
+		adminMemberUsecase.createMemberSemester(request);
+	}
+}

--- a/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberSemesterRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberSemesterRequest.java
@@ -1,0 +1,57 @@
+package org.ject.support.admin.member.dto.request;
+
+import java.util.List;
+
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Region;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CreateMemberSemesterRequest(
+
+	/*
+	필수 항목: 이름, 전화번호, 이메일, 직군(포지션), 지원자 신분, 모집단위, 기수id
+	선택 항목: 비고, 관심도메인, 거주지역, 직무 관련 경험
+	 */
+	@NotBlank(message = "이름을 입력해주세요")
+	@Pattern(regexp = "^[^\\s]+$", message = "이름은 공백없이 입력해주세요")
+	String name,
+
+	@NotBlank(message = "이메일을 입력해주세요.")
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	@Size(max = 30, message = "이메일은 30자 이하로 입력해주세요.")
+	String email,
+
+	@NotBlank(message = "전화번호를 입력해주세요")
+	String phoneNumber,
+
+	@NotNull(message = "포지션을 선택해주세요")
+	JobFamily jobFamily,
+
+	@NotNull(message = "모집 단위를 선택해주세요")
+	RecruitTypeDetail recruitTypeDetail,
+
+	@NotNull(message = "지원자 신분을 선택해주세요")
+	CareerDetails careerDetails,
+
+	@NotNull(message = "기수를 선택해주세요")
+	Long semesterId,
+
+	ExperiencePeriod experiencePeriod,
+
+	String memo,
+
+	@Size(min = 1, max = 3, message = "관심 도메인은 최소 1개부터 최대 3개까지 선택 가능합니다.")
+	List<String> interestedDomains,
+
+	Region region
+
+) {
+}

--- a/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberSemesterRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberSemesterRequest.java
@@ -18,7 +18,7 @@ public record CreateMemberSemesterRequest(
 
 	/*
 	필수 항목: 이름, 전화번호, 이메일, 직군(포지션), 지원자 신분, 모집단위, 기수id
-	선택 항목: 비고, 관심도메인, 거주지역, 직무 관련 경험
+	선택 항목: 팀id, 비고, 관심도메인, 거주지역, 직무 관련 경험
 	 */
 	@NotBlank(message = "이름을 입력해주세요")
 	@Pattern(regexp = "^[^\\s]+$", message = "이름은 공백없이 입력해주세요")
@@ -43,6 +43,8 @@ public record CreateMemberSemesterRequest(
 
 	@NotNull(message = "기수를 선택해주세요")
 	Long semesterId,
+
+	Long teamId,
 
 	ExperiencePeriod experiencePeriod,
 

--- a/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberSemesterRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberSemesterRequest.java
@@ -21,6 +21,7 @@ public record CreateMemberSemesterRequest(
 	선택 항목: 팀id, 비고, 관심도메인, 거주지역, 직무 관련 경험
 	 */
 	@NotBlank(message = "이름을 입력해주세요")
+	@Size(max = 20, message = "이름은 20자 이하로 입력해주세요.")
 	@Pattern(regexp = "^[^\\s]+$", message = "이름은 공백없이 입력해주세요")
 	String name,
 
@@ -30,6 +31,7 @@ public record CreateMemberSemesterRequest(
 	String email,
 
 	@NotBlank(message = "전화번호를 입력해주세요")
+	@Pattern(regexp = "^010\\d{8}$", message = "010으로 시작하는 11자리 숫자를 입력해주세요.")
 	String phoneNumber,
 
 	@NotNull(message = "포지션을 선택해주세요")
@@ -48,6 +50,7 @@ public record CreateMemberSemesterRequest(
 
 	ExperiencePeriod experiencePeriod,
 
+	@Size(max = 100, message = "비고는 100자 이하로 입력해주세요.")
 	String memo,
 
 	@Size(min = 1, max = 3, message = "관심 도메인은 최소 1개부터 최대 3개까지 선택 가능합니다.")

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
@@ -30,7 +30,8 @@ public class AdminMemberActivityService {
 			request.careerDetails(),
 			request.experiencePeriod(),
 			request.memo(),
-			request.semesterId()
+			request.semesterId(),
+			request.teamId()
 		);
 
 		memberActivityRepository.save(memberActivity);

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
@@ -1,0 +1,45 @@
+package org.ject.support.admin.member.service;
+
+import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.member.entity.MemberActivity;
+import org.ject.support.domain.member.exception.MemberException;
+import org.ject.support.domain.member.repository.MemberActivityRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import static org.ject.support.domain.member.exception.MemberErrorCode.ALREADY_EXIST_MEMBER_SEMESTER_ACTIVITY;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberActivityService {
+
+	private final MemberActivityRepository memberActivityRepository;
+
+
+	public void createMemberSemesterActivity(CreateMemberSemesterRequest request, Long memberId) {
+		// 추가하려는 대상이 같은 기수에 이미 등록되어있는지 중복 검증
+		validateDuplicateSemesterActivity(memberId, request.semesterId());
+
+		// MemberActivity생성, 내부에서 MemberSemester 생성
+		MemberActivity memberActivity = MemberActivity.createSemesterActivity(
+			memberId,
+			request.jobFamily(),
+			request.recruitTypeDetail(),
+			request.careerDetails(),
+			request.experiencePeriod(),
+			request.memo(),
+			request.semesterId()
+		);
+
+		memberActivityRepository.save(memberActivity);
+	}
+
+	// 동일 기수 일반 구성원 활동 중복 검증
+	private void validateDuplicateSemesterActivity(Long memberId, Long semesterId) {
+		if (memberActivityRepository.existsSemesterActivity(memberId, MemberType.SEMESTER, semesterId)) {
+			throw new MemberException(ALREADY_EXIST_MEMBER_SEMESTER_ACTIVITY);
+		}
+	}
+}

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberService.java
@@ -13,11 +13,39 @@ public class AdminMemberService {
 
 	private final MemberRepository memberRepository;
 
+	/*
+	(2026.06.23)
+	1. email로 삭제 포함 구성원 신상 전부 조회
+	2. 삭제된 구성원 존재시: isDeleted를 복구하고 새로 입력받은 값으로 덮어쓰기
+	3. 활성 구성원 존재시: 기존 값 재사용
+	4. 미 존재시: 새로 생성
+	 */
+
 	// email 기준 구성원 조회 또는 신상정보 생성
 	public Long findOrCreateMember(CreateMemberSemesterRequest request) {
-		return memberRepository.findByEmail(request.email())
-			.map(Member::getId)
+		return memberRepository.findByEmailIncludingDeleted(request.email())
+			.map(member -> useExistingMember(member, request))
 			.orElseGet(() -> createMember(request));
+	}
+
+	// 기존 구성원 상태에 따라 재사용 또는 복구
+	private Long useExistingMember(Member member, CreateMemberSemesterRequest request) {
+		if (member.getIsDeleted()) {
+			return restoreMember(member, request);
+		}
+
+		return member.getId();
+	}
+
+	// 삭제된 구성원 신상정보 갱신 후 복구
+	private Long restoreMember(Member member, CreateMemberSemesterRequest request) {
+		member.restore(
+			request.name(),
+			request.phoneNumber(),
+			request.interestedDomains(),
+			request.region()
+		);
+		return member.getId();
 	}
 
 	// 구성원 신상정보 생성

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberService.java
@@ -1,0 +1,32 @@
+package org.ject.support.admin.member.service;
+
+import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberService {
+
+	private final MemberRepository memberRepository;
+
+	// email 기준 구성원 조회 또는 신상정보 생성
+	public Long findOrCreateMember(CreateMemberSemesterRequest request) {
+		return memberRepository.findByEmail(request.email())
+			.map(Member::getId)
+			.orElseGet(() -> createMember(request));
+	}
+
+	// 구성원 신상정보 생성
+	private Long createMember(CreateMemberSemesterRequest request) {
+		Member member = Member.create(request.name(), request.email(), request.phoneNumber(),
+			request.interestedDomains(), request.region());
+
+		Member savedMember = memberRepository.save(member);
+		return savedMember.getId();
+	}
+
+}

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberService.java
@@ -22,8 +22,13 @@ public class AdminMemberService {
 
 	// 구성원 신상정보 생성
 	private Long createMember(CreateMemberSemesterRequest request) {
-		Member member = Member.create(request.name(), request.email(), request.phoneNumber(),
-			request.interestedDomains(), request.region());
+		Member member = Member.create(
+			request.name(),
+			request.email(),
+			request.phoneNumber(),
+			request.interestedDomains(),
+			request.region()
+		);
 
 		Member savedMember = memberRepository.save(member);
 		return savedMember.getId();

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberTeamService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberTeamService.java
@@ -1,0 +1,20 @@
+package org.ject.support.admin.member.service;
+
+import java.util.List;
+
+import org.ject.support.domain.member.repository.TeamRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberTeamService {
+
+	private final TeamRepository teamRepository;
+
+	// 기수에 속한 팀 ID 목록 조회
+	public List<Long> getTeamIdsBySemesterId(Long semesterId) {
+		return teamRepository.findIdsBySemesterId(semesterId);
+	}
+}

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberUseCase.java
@@ -1,0 +1,32 @@
+package org.ject.support.admin.member.service;
+
+import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.domain.recruit.service.SemesterInquiryUsecase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberUseCase {
+
+	private final AdminMemberService adminMemberService;
+	private final AdminMemberActivityService adminMemberActivityService;
+	private final SemesterInquiryUsecase semesterInquiryUsecase;
+
+	//일반 구성원 생성
+	@Transactional
+	public void createMemberSemester(CreateMemberSemesterRequest request) {
+		//기수 검증, 유효하지 않은 기수는 조회 시점에 semester쪽에서 예외 처리
+		semesterInquiryUsecase.getSemester(request.semesterId());
+
+		// email 기준 기존 Member 조회 또는 신규 생성
+		Long memberId = adminMemberService.findOrCreateMember(request);
+
+		//memberId 기준으로 MemberActivity + MemberSemester 생성 후 저장
+		adminMemberActivityService.createMemberSemesterActivity(request, memberId);
+
+	}
+
+}

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberUseCase.java
@@ -1,6 +1,9 @@
 package org.ject.support.admin.member.service;
 
+import static org.ject.support.domain.member.exception.MemberErrorCode.NOT_FOUND_TEAM_OF_SEMESTER;
+
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.recruit.service.SemesterInquiryUsecase;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,20 +16,31 @@ public class AdminMemberUseCase {
 
 	private final AdminMemberService adminMemberService;
 	private final AdminMemberActivityService adminMemberActivityService;
+	private final AdminMemberTeamService adminMemberTeamService;
 	private final SemesterInquiryUsecase semesterInquiryUsecase;
 
-	//일반 구성원 생성
+	// 일반 구성원 생성 흐름 처리
 	@Transactional
 	public void createMemberSemester(CreateMemberSemesterRequest request) {
-		//기수 검증, 유효하지 않은 기수는 조회 시점에 semester쪽에서 예외 처리
+		// 기수 유효성 검증
 		semesterInquiryUsecase.getSemester(request.semesterId());
+		validateTeam(request.semesterId(), request.teamId());
 
 		// email 기준 기존 Member 조회 또는 신규 생성
 		Long memberId = adminMemberService.findOrCreateMember(request);
 
-		//memberId 기준으로 MemberActivity + MemberSemester 생성 후 저장
+		// memberId 기준 MemberActivity와 MemberSemester 생성 및 저장
 		adminMemberActivityService.createMemberSemesterActivity(request, memberId);
-
 	}
 
+	// 선택한 팀의 기수 소속 검증
+	private void validateTeam(Long semesterId, Long teamId) {
+		if (teamId == null) {
+			return;
+		}
+
+		if (!adminMemberTeamService.getTeamIdsBySemesterId(semesterId).contains(teamId)) {
+			throw new MemberException(NOT_FOUND_TEAM_OF_SEMESTER);
+		}
+	}
 }

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -77,4 +77,18 @@ public class Member extends BaseTimeEntity {
             .interestedDomains(interestedDomains)
             .build();
     }
+
+    // 삭제된 구성원 정보가 있는 경우 복구한 뒤 새로 입력한 값으로 덮어쓰기
+    public void restore(
+        String name,
+        String phoneNumber,
+        List<String> interestedDomains,
+        Region region
+    ) {
+        this.isDeleted = false;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.interestedDomains = interestedDomains;
+        this.region = region;
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -28,7 +28,7 @@ import java.util.List;
 @SQLRestriction("is_deleted = false")
 @Entity
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
@@ -61,4 +61,20 @@ public class Member extends BaseTimeEntity {
     @Builder.Default
     private Boolean isDeleted = false;
 
+
+    public static Member create(
+        String name,
+        String email,
+        String phoneNumber,
+        List<String> interestedDomains,
+        Region region
+    ){
+        return Member.builder()
+            .name(name)
+            .email(email)
+            .phoneNumber(phoneNumber)
+            .region(region)
+            .interestedDomains(interestedDomains)
+            .build();
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
@@ -90,7 +90,8 @@ public class MemberActivity extends BaseTimeEntity {
         CareerDetails careerDetails,
         ExperiencePeriod experiencePeriod,
         String memo,
-        Long semesterId
+        Long semesterId,
+        Long teamId
     ){
         MemberActivity memberActivity = MemberActivity.builder()
             .memberId(memberId)
@@ -103,7 +104,7 @@ public class MemberActivity extends BaseTimeEntity {
             .build();
         //애그리거트 루트인 MemberActivity쪽에서 식별 관계인 엔티티 생성 책임
         //MemberSemester는 MemberActivity없이 단독으로 사용되지 않음
-        memberActivity.memberSemester = MemberSemester.create(memberActivity, semesterId);
+        memberActivity.memberSemester = MemberSemester.create(memberActivity, semesterId, teamId);
         return memberActivity;
     }
 

--- a/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
@@ -1,12 +1,15 @@
 package org.ject.support.domain.member.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 
@@ -23,7 +26,7 @@ import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 
 @Entity
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @Table(name = "member_activity")
 @SQLDelete(sql = "UPDATE member_activity SET is_deleted = true WHERE id = ?")
 @SQLRestriction("is_deleted = false")
@@ -73,4 +76,37 @@ public class MemberActivity extends BaseTimeEntity {
     @Column(name = "recruit_type_detail", length = 45, nullable = false)
     @Enumerated(EnumType.STRING)
     private RecruitTypeDetail recruitTypeDetail;
+
+    @OneToOne(mappedBy = "memberActivity", fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
+    private MemberSemester memberSemester;
+
+    // 일반 구성원 활동과 관리 항목 생성
+    public static MemberActivity createSemesterActivity(
+        Long memberId,
+        JobFamily jobFamily,
+        RecruitTypeDetail recruitTypeDetail,
+        CareerDetails careerDetails,
+        ExperiencePeriod experiencePeriod,
+        String memo,
+        Long semesterId
+    ){
+        MemberActivity memberActivity = MemberActivity.builder()
+            .memberId(memberId)
+            .memberType(MemberType.SEMESTER)
+            .jobFamily(jobFamily)
+            .recruitTypeDetail(recruitTypeDetail)
+            .careerDetails(careerDetails)
+            .experiencePeriod(experiencePeriod)
+            .memo(memo)
+            .build();
+
+        //애그리거트 루트인 MemberActivity쪽에서 식별 관계인 엔티티 생성 책임
+        //MemberSemester는 MemberActivity없이 단독으로 사용되지 않음
+        memberActivity.memberSemester = MemberSemester.create(memberActivity, semesterId);
+        return memberActivity;
+    }
+
+    //Todo: 메이커스 구성원 활동과 관리 항목 생성
+
+    //Todo: 운영 서포터즈 구성원 활동과 관리 항목 생성
 }

--- a/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
@@ -22,6 +22,8 @@ import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.member.exception.MemberErrorCode;
+import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 
 @Entity
@@ -99,7 +101,6 @@ public class MemberActivity extends BaseTimeEntity {
             .experiencePeriod(experiencePeriod)
             .memo(memo)
             .build();
-
         //애그리거트 루트인 MemberActivity쪽에서 식별 관계인 엔티티 생성 책임
         //MemberSemester는 MemberActivity없이 단독으로 사용되지 않음
         memberActivity.memberSemester = MemberSemester.create(memberActivity, semesterId);

--- a/src/main/java/org/ject/support/domain/member/entity/MemberSemester.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberSemester.java
@@ -13,7 +13,7 @@ import org.ject.support.domain.base.BaseTimeEntity;
 
 @Entity
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @Table(name = "member_semester")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -40,4 +40,15 @@ public class MemberSemester extends BaseTimeEntity {
 
     @Column(length = 255)
     private String secondReview;
+
+    static MemberSemester create(
+        MemberActivity memberActivity,
+        Long semesterId
+    ){
+        return MemberSemester.builder()
+            .memberActivity(memberActivity)
+            .semesterId(semesterId)
+            .build();
+    }
+
 }

--- a/src/main/java/org/ject/support/domain/member/entity/MemberSemester.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberSemester.java
@@ -41,7 +41,7 @@ public class MemberSemester extends BaseTimeEntity {
     @Column(length = 255)
     private String secondReview;
 
-    static MemberSemester create(
+    public static MemberSemester create(
         MemberActivity memberActivity,
         Long semesterId
     ){

--- a/src/main/java/org/ject/support/domain/member/entity/MemberSemester.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberSemester.java
@@ -43,11 +43,13 @@ public class MemberSemester extends BaseTimeEntity {
 
     public static MemberSemester create(
         MemberActivity memberActivity,
-        Long semesterId
+        Long semesterId,
+        Long teamId
     ){
         return MemberSemester.builder()
             .memberActivity(memberActivity)
             .semesterId(semesterId)
+            .teamId(teamId)
             .build();
     }
 

--- a/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
@@ -16,7 +16,8 @@ public enum MemberErrorCode implements ErrorCode {
     ALREADY_EXIST_MEMBER(CONFLICT, "MEMBER-2", "이미 가입되어 있는 구성원입니다."),
     NOT_FOUND_SEMESTER_OF_MEMBER(NOT_FOUND, "MEMBER-3", "구성원의 기수를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(CONFLICT, "MEMBER-4", "이미 사용 중인 이메일입니다."),
-    EXCEEDED_INTERESTED_DOMAINS_MAX_SIZE(PAYLOAD_TOO_LARGE, "MEMBER-5", "관심 도메인 목록의 최대 크기를 초과했습니다.")
+    EXCEEDED_INTERESTED_DOMAINS_MAX_SIZE(PAYLOAD_TOO_LARGE, "MEMBER-5", "관심 도메인 목록의 최대 크기를 초과했습니다."),
+    ALREADY_EXIST_MEMBER_SEMESTER_ACTIVITY(CONFLICT, "MEMBER-6", "해당 기수에 이미 등록된 일반 구성원 활동입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
@@ -17,7 +17,8 @@ public enum MemberErrorCode implements ErrorCode {
     NOT_FOUND_SEMESTER_OF_MEMBER(NOT_FOUND, "MEMBER-3", "구성원의 기수를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(CONFLICT, "MEMBER-4", "이미 사용 중인 이메일입니다."),
     EXCEEDED_INTERESTED_DOMAINS_MAX_SIZE(PAYLOAD_TOO_LARGE, "MEMBER-5", "관심 도메인 목록의 최대 크기를 초과했습니다."),
-    ALREADY_EXIST_MEMBER_SEMESTER_ACTIVITY(CONFLICT, "MEMBER-6", "해당 기수에 이미 등록된 일반 구성원 활동입니다.")
+    ALREADY_EXIST_MEMBER_SEMESTER_ACTIVITY(CONFLICT, "MEMBER-6", "해당 기수에 이미 등록된 일반 구성원 활동입니다."),
+    NOT_FOUND_TEAM_OF_SEMESTER(NOT_FOUND, "MEMBER-7", "해당 기수의 팀을 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityRepository.java
@@ -1,0 +1,26 @@
+package org.ject.support.domain.member.repository;
+
+import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.member.entity.MemberActivity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberActivityRepository extends JpaRepository<MemberActivity, Long> {
+
+	@Query("""
+		select count(ma) > 0
+		from MemberActivity ma
+		join ma.memberSemester ms
+		where ma.memberId = :memberId
+		  and ma.memberType = :memberType
+		  and ms.semesterId = :semesterId
+		""")
+	boolean existsSemesterActivity(
+		@Param("memberId") Long memberId,
+		@Param("memberType") MemberType memberType,
+		@Param("semesterId") Long semesterId
+	);
+}

--- a/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+	Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberRepository.java
@@ -2,10 +2,16 @@ package org.ject.support.domain.member.repository;
 
 import org.ject.support.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Optional<Member> findByEmail(String email);
+
+	// 삭제된 이력을 포함하여 조회
+	@Query(value = "SELECT * FROM member WHERE email = :email", nativeQuery = true)
+	Optional<Member> findByEmailIncludingDeleted(@Param("email") String email);
 }

--- a/src/main/java/org/ject/support/domain/member/repository/TeamRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/TeamRepository.java
@@ -1,7 +1,14 @@
 package org.ject.support.domain.member.repository;
 
+import java.util.List;
+
 import org.ject.support.domain.member.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
+
+	@Query("select t.id from Team t where t.semesterId = :semesterId")
+	List<Long> findIdsBySemesterId(@Param("semesterId") Long semesterId);
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/SemesterInquiryService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/SemesterInquiryService.java
@@ -1,8 +1,12 @@
 package org.ject.support.domain.recruit.service;
 
 import lombok.RequiredArgsConstructor;
+
+import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.dto.SemesterResponse;
 import org.ject.support.domain.recruit.dto.SemesterResponses;
+import org.ject.support.domain.recruit.exception.SemesterErrorCode;
+import org.ject.support.domain.recruit.exception.SemesterException;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -22,5 +26,13 @@ public class SemesterInquiryService implements SemesterInquiryUsecase {
                 .stream()
                 .map(SemesterResponse::from)
                 .toList());
+    }
+
+    @Override
+    public SemesterResponse getSemester(Long id) {
+        Semester semester = semesterRepository.findById(id).orElseThrow(
+            () -> new SemesterException(SemesterErrorCode.NOT_FOUND_SEMESTER)
+        );
+        return SemesterResponse.from(semester);
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/SemesterInquiryUsecase.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/SemesterInquiryUsecase.java
@@ -1,5 +1,6 @@
 package org.ject.support.domain.recruit.service;
 
+import org.ject.support.domain.recruit.dto.SemesterResponse;
 import org.ject.support.domain.recruit.dto.SemesterResponses;
 
 public interface SemesterInquiryUsecase {
@@ -9,4 +10,6 @@ public interface SemesterInquiryUsecase {
      * @return 기수 목록
      */
     SemesterResponses getAllSemesters();
+
+    SemesterResponse getSemester(Long id);
 }

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
@@ -64,6 +64,22 @@ class AdminMemberSemesterControllerTest {
     }
 
     @Test
+    @DisplayName("팀을 선택하지 않은 요청도 일반 구성원을 추가한다")
+    void 팀을_선택하지_않은_요청도_일반_구성원을_추가한다() throws Exception {
+        // given
+        CreateMemberSemesterRequest request = createMemberSemesterRequest("jectkim@ject.kr", null);
+
+        // when
+        mockMvc.perform(post("/admin/members/semester")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk());
+
+        // then
+        verify(adminMemberUseCase).createMemberSemester(any(CreateMemberSemesterRequest.class));
+    }
+
+    @Test
     @DisplayName("필수값이 없으면 일반 구성원을 추가하지 않는다")
     void 필수값이_없으면_일반_구성원을_추가하지_않는다() throws Exception {
         // given
@@ -75,6 +91,7 @@ class AdminMemberSemesterControllerTest {
             RecruitTypeDetail.REGULAR,
             CareerDetails.EMPLOYEE,
             1L,
+            null,
             ExperiencePeriod.ONE_TO_TWO,
             "memo",
             List.of("HEALTHCARE"),
@@ -108,6 +125,10 @@ class AdminMemberSemesterControllerTest {
     }
 
     private CreateMemberSemesterRequest createMemberSemesterRequest(String email) {
+		return createMemberSemesterRequest(email, 2L);
+	}
+
+    private CreateMemberSemesterRequest createMemberSemesterRequest(String email, Long teamId) {
         return new CreateMemberSemesterRequest(
             "김젝트",
             email,
@@ -116,6 +137,7 @@ class AdminMemberSemesterControllerTest {
             RecruitTypeDetail.REGULAR,
             CareerDetails.EMPLOYEE,
             1L,
+            teamId,
             ExperiencePeriod.ONE_TO_TWO,
             "memo",
             List.of("HEALTHCARE", "FINTECH", "AI"),

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
@@ -1,0 +1,125 @@
+package org.ject.support.admin.member.controller;
+
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.admin.member.service.AdminMemberUseCase;
+import org.ject.support.common.exception.GlobalExceptionHandler;
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Region;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class AdminMemberSemesterControllerTest {
+
+    @Mock
+    private AdminMemberUseCase adminMemberUseCase;
+
+    @InjectMocks
+    private AdminMemberSemesterController adminMemberSemesterController;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper().findAndRegisterModules();
+        mockMvc = MockMvcBuilders.standaloneSetup(adminMemberSemesterController)
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+    }
+
+    @Test
+    @DisplayName("유효한 요청이면 일반 구성원을 추가한다")
+    void 유효한_요청이면_일반_구성원을_추가한다() throws Exception {
+        // given
+        CreateMemberSemesterRequest request = createMemberSemesterRequest("jectkim@ject.kr");
+
+        // when
+        mockMvc.perform(post("/admin/members/semester")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk());
+
+        // then
+        verify(adminMemberUseCase).createMemberSemester(any(CreateMemberSemesterRequest.class));
+    }
+
+    @Test
+    @DisplayName("필수값이 없으면 일반 구성원을 추가하지 않는다")
+    void 필수값이_없으면_일반_구성원을_추가하지_않는다() throws Exception {
+        // given
+        CreateMemberSemesterRequest request = new CreateMemberSemesterRequest(
+            null,
+            "jectkim@ject.kr",
+            "01012345678",
+            JobFamily.BE,
+            RecruitTypeDetail.REGULAR,
+            CareerDetails.EMPLOYEE,
+            1L,
+            ExperiencePeriod.ONE_TO_TWO,
+            "memo",
+            List.of("HEALTHCARE"),
+            Region.SEOUL
+        );
+
+        // when
+        mockMvc.perform(post("/admin/members/semester")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+
+        // then
+        verify(adminMemberUseCase, never()).createMemberSemester(any(CreateMemberSemesterRequest.class));
+    }
+
+    @Test
+    @DisplayName("이메일 형식이 올바르지 않으면 일반 구성원을 추가하지 않는다")
+    void 이메일_형식이_올바르지_않으면_일반_구성원을_추가하지_않는다() throws Exception {
+        // given
+        CreateMemberSemesterRequest request = createMemberSemesterRequest("invalid-email");
+
+        // when
+        mockMvc.perform(post("/admin/members/semester")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+
+        // then
+        verify(adminMemberUseCase, never()).createMemberSemester(any(CreateMemberSemesterRequest.class));
+    }
+
+    private CreateMemberSemesterRequest createMemberSemesterRequest(String email) {
+        return new CreateMemberSemesterRequest(
+            "김젝트",
+            email,
+            "01012345678",
+            JobFamily.BE,
+            RecruitTypeDetail.REGULAR,
+            CareerDetails.EMPLOYEE,
+            1L,
+            ExperiencePeriod.ONE_TO_TWO,
+            "memo",
+            List.of("HEALTHCARE", "FINTECH", "AI"),
+            Region.SEOUL
+        );
+    }
+}

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -1,0 +1,108 @@
+package org.ject.support.admin.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+
+import java.util.List;
+import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.member.Region;
+import org.ject.support.domain.member.entity.MemberActivity;
+import org.ject.support.domain.member.exception.MemberErrorCode;
+import org.ject.support.domain.member.exception.MemberException;
+import org.ject.support.domain.member.repository.MemberActivityRepository;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminMemberActivityServiceTest {
+
+    @Mock
+    private MemberActivityRepository memberActivityRepository;
+
+    @InjectMocks
+    private AdminMemberActivityService adminMemberActivityService;
+
+    @Test
+    @DisplayName("동일 기수 활동이 없으면 일반 구성원 활동을 저장한다")
+    void 동일_기수_활동이_없으면_일반_구성원_활동을_저장한다() {
+        // given
+        CreateMemberSemesterRequest request = createMemberSemesterRequest();
+        Long memberId = 1L;
+        given(memberActivityRepository.existsSemesterActivity(
+            memberId,
+            MemberType.SEMESTER,
+            request.semesterId()
+        )).willReturn(false);
+
+        // when
+        adminMemberActivityService.createMemberSemesterActivity(request, memberId);
+
+        // then
+        ArgumentCaptor<MemberActivity> captor = ArgumentCaptor.forClass(MemberActivity.class);
+        verify(memberActivityRepository).save(captor.capture());
+
+        MemberActivity memberActivity = captor.getValue();
+        assertThat(memberActivity.getMemberId()).isEqualTo(memberId);
+        assertThat(memberActivity.getJobFamily()).isEqualTo(request.jobFamily());
+        assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(request.recruitTypeDetail());
+        assertThat(memberActivity.getCareerDetails()).isEqualTo(request.careerDetails());
+        assertThat(memberActivity.getExperiencePeriod()).isEqualTo(request.experiencePeriod());
+        assertThat(memberActivity.getMemo()).isEqualTo(request.memo());
+        assertThat(memberActivity.getMemberSemester().getSemesterId()).isEqualTo(request.semesterId());
+    }
+
+    @Test
+    @DisplayName("동일 기수 활동이 있으면 예외가 발생한다")
+    void 동일_기수_활동이_있으면_예외가_발생한다() {
+        // given
+        CreateMemberSemesterRequest request = createMemberSemesterRequest();
+        Long memberId = 1L;
+        given(memberActivityRepository.existsSemesterActivity(
+            memberId,
+            MemberType.SEMESTER,
+            request.semesterId()
+        )).willReturn(true);
+
+        // when
+        Throwable throwable = catchThrowable(() ->
+            adminMemberActivityService.createMemberSemesterActivity(request, memberId)
+        );
+
+        // then
+        assertThat(throwable)
+            .isInstanceOf(MemberException.class)
+            .extracting("errorCode")
+            .isEqualTo(MemberErrorCode.ALREADY_EXIST_MEMBER_SEMESTER_ACTIVITY);
+        verify(memberActivityRepository, never()).save(any(MemberActivity.class));
+    }
+
+    private CreateMemberSemesterRequest createMemberSemesterRequest() {
+        return new CreateMemberSemesterRequest(
+            "김젝트",
+            "jectkim@ject.kr",
+            "01012345678",
+            JobFamily.BE,
+            RecruitTypeDetail.REGULAR,
+            CareerDetails.EMPLOYEE,
+            1L,
+            ExperiencePeriod.ONE_TO_TWO,
+            "memo",
+            List.of("HEALTHCARE", "FINTECH", "AI"),
+            Region.SEOUL
+        );
+    }
+}

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -63,6 +63,7 @@ class AdminMemberActivityServiceTest {
         assertThat(memberActivity.getExperiencePeriod()).isEqualTo(request.experiencePeriod());
         assertThat(memberActivity.getMemo()).isEqualTo(request.memo());
         assertThat(memberActivity.getMemberSemester().getSemesterId()).isEqualTo(request.semesterId());
+        assertThat(memberActivity.getMemberSemester().getTeamId()).isEqualTo(request.teamId());
     }
 
     @Test
@@ -99,6 +100,7 @@ class AdminMemberActivityServiceTest {
             RecruitTypeDetail.REGULAR,
             CareerDetails.EMPLOYEE,
             1L,
+            2L,
             ExperiencePeriod.ONE_TO_TWO,
             "memo",
             List.of("HEALTHCARE", "FINTECH", "AI"),

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
@@ -1,0 +1,98 @@
+package org.ject.support.admin.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Region;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminMemberServiceTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@InjectMocks
+	private AdminMemberService adminMemberService;
+
+	private CreateMemberSemesterRequest createMemberSemesterRequest() {
+		return new CreateMemberSemesterRequest(
+			"김젝트",
+			"jectkim@ject.kr",
+			"01012345678",
+			JobFamily.BE,
+			RecruitTypeDetail.REGULAR,
+			CareerDetails.EMPLOYEE,
+			1L,
+			ExperiencePeriod.ONE_TO_TWO,
+			"memo",
+			List.of("HEALTHCARE", "FINTECH", "AI"),
+			Region.SEOUL
+		);
+	}
+
+	@Test
+	@DisplayName("입력한 이메일로 기존 구성원이 존재하지 않으면 새로 저장한다")
+	void 입력한_이메일로_기존_구성원이_존재하지_않으면_새로_저장한다() {
+	    // given
+	    CreateMemberSemesterRequest request = createMemberSemesterRequest();
+		Member savedMember = mock(Member.class);
+		given(savedMember.getId()).willReturn(1L);
+
+		given(memberRepository.findByEmail(request.email())).willReturn(Optional.empty());
+		given(memberRepository.save(any(Member.class))).willReturn(savedMember);
+
+	    // when
+	    Long memberId = adminMemberService.findOrCreateMember(request);
+
+	    // then
+		assertThat(memberId).isEqualTo(1L);
+		verify(memberRepository).findByEmail(request.email());
+
+		// 실제 save 시점에 전달된 인자 확인
+		ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+		verify(memberRepository).save(memberCaptor.capture());
+
+		Member member = memberCaptor.getValue();
+		assertThat(member.getEmail()).isEqualTo(request.email());
+		assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
+		assertThat(member.getName()).isEqualTo(request.name());
+		assertThat(member.getRegion()).isEqualTo(request.region());
+		assertThat(member.getInterestedDomains()).containsExactlyElementsOf(request.interestedDomains());
+	}
+
+	@Test
+	@DisplayName("입력한 이메일로 기존 구성원이 존재하면 새로 저장하지 않는다")
+	void 입력한_이메일로_기존_구성원이_존재하면_새로_저장하지_않는다() {
+	    // given
+	    CreateMemberSemesterRequest request = createMemberSemesterRequest();
+		Member existMember = mock(Member.class);
+		given(existMember.getId()).willReturn(3L);
+
+		given(memberRepository.findByEmail(request.email())).willReturn(Optional.of(existMember));
+
+	    // when
+	    Long memberId = adminMemberService.findOrCreateMember(request);
+
+	    // then
+		assertThat(memberId).isEqualTo(existMember.getId());
+		verify(memberRepository).findByEmail(request.email());
+		verify(memberRepository, never()).save(any(Member.class));
+	}
+}

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class AdminMemberServiceTest {
@@ -56,7 +57,7 @@ class AdminMemberServiceTest {
 		Member savedMember = mock(Member.class);
 		given(savedMember.getId()).willReturn(1L);
 
-		given(memberRepository.findByEmail(request.email())).willReturn(Optional.empty());
+		given(memberRepository.findByEmailIncludingDeleted(request.email())).willReturn(Optional.empty());
 		given(memberRepository.save(any(Member.class))).willReturn(savedMember);
 
 	    // when
@@ -64,7 +65,7 @@ class AdminMemberServiceTest {
 
 	    // then
 		assertThat(memberId).isEqualTo(1L);
-		verify(memberRepository).findByEmail(request.email());
+		verify(memberRepository).findByEmailIncludingDeleted(request.email());
 
 		// 실제 save 시점에 전달된 인자 확인
 		ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
@@ -85,15 +86,49 @@ class AdminMemberServiceTest {
 	    CreateMemberSemesterRequest request = createMemberSemesterRequest();
 		Member existMember = mock(Member.class);
 		given(existMember.getId()).willReturn(3L);
+		given(existMember.getIsDeleted()).willReturn(false);
 
-		given(memberRepository.findByEmail(request.email())).willReturn(Optional.of(existMember));
+		given(memberRepository.findByEmailIncludingDeleted(request.email())).willReturn(Optional.of(existMember));
 
 	    // when
 	    Long memberId = adminMemberService.findOrCreateMember(request);
 
 	    // then
 		assertThat(memberId).isEqualTo(existMember.getId());
-		verify(memberRepository).findByEmail(request.email());
+		verify(memberRepository).findByEmailIncludingDeleted(request.email());
+		verify(memberRepository, never()).save(any(Member.class));
+	}
+
+	@Test
+	@DisplayName("입력한 이메일로 삭제된 구성원이 존재하면 복구하고 값을 덮어쓴다")
+	void 입력한_이메일로_삭제된_구성원이_존재하면_복구하고_값을_덮어쓴다() {
+	    // given
+	    CreateMemberSemesterRequest request = createMemberSemesterRequest();
+		Member deletedMember = Member.create(
+			"삭제된 구성원",
+			request.email(),
+			"01087654321",
+			List.of("COMMERCE"),
+			Region.BUSAN
+		);
+
+		//Todo: 삭제 API 구현 시 도메인 로직을 사용하도록 수정
+		ReflectionTestUtils.setField(deletedMember, "id", 7L);
+		ReflectionTestUtils.setField(deletedMember, "isDeleted", true);
+
+		given(memberRepository.findByEmailIncludingDeleted(request.email())).willReturn(Optional.of(deletedMember));
+
+	    // when
+	    Long memberId = adminMemberService.findOrCreateMember(request);
+
+	    // then
+		assertThat(memberId).isEqualTo(7L);
+		assertThat(deletedMember.getIsDeleted()).isFalse();
+		assertThat(deletedMember.getName()).isEqualTo(request.name());
+		assertThat(deletedMember.getPhoneNumber()).isEqualTo(request.phoneNumber());
+		assertThat(deletedMember.getInterestedDomains()).containsExactlyElementsOf(request.interestedDomains());
+		assertThat(deletedMember.getRegion()).isEqualTo(request.region());
+		verify(memberRepository).findByEmailIncludingDeleted(request.email());
 		verify(memberRepository, never()).save(any(Member.class));
 	}
 }

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
@@ -40,6 +40,7 @@ class AdminMemberServiceTest {
 			RecruitTypeDetail.REGULAR,
 			CareerDetails.EMPLOYEE,
 			1L,
+			null,
 			ExperiencePeriod.ONE_TO_TWO,
 			"memo",
 			List.of("HEALTHCARE", "FINTECH", "AI"),

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberTeamServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberTeamServiceTest.java
@@ -1,0 +1,41 @@
+package org.ject.support.admin.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+
+import java.util.List;
+
+import org.ject.support.domain.member.repository.TeamRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminMemberTeamServiceTest {
+
+	@Mock
+	private TeamRepository teamRepository;
+
+	@InjectMocks
+	private AdminMemberTeamService adminMemberTeamService;
+
+	@Test
+	@DisplayName("기수에 속한 팀 ID 목록을 조회한다")
+	void 기수에_속한_팀_ID_목록을_조회한다() {
+		// given
+		Long semesterId = 1L;
+		List<Long> teamIds = List.of(1L, 2L);
+		given(teamRepository.findIdsBySemesterId(semesterId)).willReturn(teamIds);
+
+		// when
+		List<Long> result = adminMemberTeamService.getTeamIdsBySemesterId(semesterId);
+
+		// then
+		assertThat(result).containsExactlyElementsOf(teamIds);
+		verify(teamRepository).findIdsBySemesterId(semesterId);
+	}
+}

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberUseCaseTest.java
@@ -1,0 +1,90 @@
+package org.ject.support.admin.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.Region;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+import org.ject.support.domain.recruit.exception.SemesterErrorCode;
+import org.ject.support.domain.recruit.exception.SemesterException;
+import org.ject.support.domain.recruit.service.SemesterInquiryUsecase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminMemberUseCaseTest {
+
+	@Mock
+	private AdminMemberService adminMemberService;
+
+	@Mock
+	private AdminMemberActivityService adminMemberActivityService;
+
+	@Mock
+	private SemesterInquiryUsecase semesterInquiryUsecase;
+
+	@InjectMocks
+	private AdminMemberUseCase adminMemberUseCase;
+
+	private CreateMemberSemesterRequest createMemberSemesterRequest() {
+		return new CreateMemberSemesterRequest(
+			"김젝트",
+			"jectkim@ject.kr",
+			"01012345678",
+			JobFamily.BE,
+			RecruitTypeDetail.REGULAR,
+			CareerDetails.EMPLOYEE,
+			1L,
+			ExperiencePeriod.ONE_TO_TWO,
+			"memo",
+			List.of("HEALTHCARE", "FINTECH", "AI"),
+			Region.SEOUL
+		);
+	}
+	@Test
+	@DisplayName("일반 구성원을 생성한다")
+	void 일반_구성원을_생성한다() {
+	    // given
+		CreateMemberSemesterRequest request = createMemberSemesterRequest();
+		Long memberId = 1L;
+
+		given(adminMemberService.findOrCreateMember(request)).willReturn(memberId);
+
+	    // when
+		adminMemberUseCase.createMemberSemester(request);
+
+	    // then
+		verify(semesterInquiryUsecase).getSemester(request.semesterId());
+		verify(adminMemberService).findOrCreateMember(request);
+		verify(adminMemberActivityService).createMemberSemesterActivity(request, memberId);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 기수로 구성원 생성을 시도하면 예외가 발생한다")
+	void 존재하지_않는_기수로_구성원_생성을_시도하면_예외가_발생한다() {
+	    // given
+	    CreateMemberSemesterRequest request = createMemberSemesterRequest();
+		SemesterException exception = new SemesterException(SemesterErrorCode.NOT_FOUND_SEMESTER);
+	    given(semesterInquiryUsecase.getSemester(request.semesterId())).willThrow(exception);
+
+	    // when
+		Throwable throwable = catchThrowable(() -> adminMemberUseCase.createMemberSemester(request));
+
+		// then
+		assertThat(throwable).isSameAs(exception);
+		verifyNoInteractions(adminMemberService);
+		verifyNoInteractions(adminMemberActivityService);
+
+	}
+
+}

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberUseCaseTest.java
@@ -10,6 +10,8 @@ import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.Region;
+import org.ject.support.domain.member.exception.MemberErrorCode;
+import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 import org.ject.support.domain.recruit.exception.SemesterErrorCode;
 import org.ject.support.domain.recruit.exception.SemesterException;
@@ -31,12 +33,19 @@ class AdminMemberUseCaseTest {
 	private AdminMemberActivityService adminMemberActivityService;
 
 	@Mock
+	private AdminMemberTeamService adminMemberTeamService;
+
+	@Mock
 	private SemesterInquiryUsecase semesterInquiryUsecase;
 
 	@InjectMocks
 	private AdminMemberUseCase adminMemberUseCase;
 
 	private CreateMemberSemesterRequest createMemberSemesterRequest() {
+		return createMemberSemesterRequest(null);
+	}
+
+	private CreateMemberSemesterRequest createMemberSemesterRequest(Long teamId) {
 		return new CreateMemberSemesterRequest(
 			"김젝트",
 			"jectkim@ject.kr",
@@ -45,6 +54,7 @@ class AdminMemberUseCaseTest {
 			RecruitTypeDetail.REGULAR,
 			CareerDetails.EMPLOYEE,
 			1L,
+			teamId,
 			ExperiencePeriod.ONE_TO_TWO,
 			"memo",
 			List.of("HEALTHCARE", "FINTECH", "AI"),
@@ -65,8 +75,49 @@ class AdminMemberUseCaseTest {
 
 	    // then
 		verify(semesterInquiryUsecase).getSemester(request.semesterId());
+		verifyNoInteractions(adminMemberTeamService);
 		verify(adminMemberService).findOrCreateMember(request);
 		verify(adminMemberActivityService).createMemberSemesterActivity(request, memberId);
+	}
+
+	@Test
+	@DisplayName("기수와 팀 검증을 통과하면 일반 구성원을 생성한다")
+	void 기수와_팀_검증을_통과하면_일반_구성원을_생성한다() {
+		// given
+		CreateMemberSemesterRequest request = createMemberSemesterRequest(2L);
+		Long memberId = 1L;
+		given(adminMemberTeamService.getTeamIdsBySemesterId(request.semesterId()))
+			.willReturn(List.of(request.teamId()));
+		given(adminMemberService.findOrCreateMember(request)).willReturn(memberId);
+
+		// when
+		adminMemberUseCase.createMemberSemester(request);
+
+		// then
+		verify(semesterInquiryUsecase).getSemester(request.semesterId());
+		verify(adminMemberTeamService).getTeamIdsBySemesterId(request.semesterId());
+		verify(adminMemberService).findOrCreateMember(request);
+		verify(adminMemberActivityService).createMemberSemesterActivity(request, memberId);
+	}
+
+	@Test
+	@DisplayName("해당 기수에 속하지 않은 팀을 선택하면 예외가 발생한다")
+	void 해당_기수에_속하지_않은_팀을_선택하면_예외가_발생한다() {
+		// given
+		CreateMemberSemesterRequest request = createMemberSemesterRequest(4L);
+		given(adminMemberTeamService.getTeamIdsBySemesterId(request.semesterId()))
+			.willReturn(List.of(1L, 2L, 3L));
+
+		// when
+		Throwable throwable = catchThrowable(() -> adminMemberUseCase.createMemberSemester(request));
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.NOT_FOUND_TEAM_OF_SEMESTER);
+		verifyNoInteractions(adminMemberService);
+		verifyNoInteractions(adminMemberActivityService);
 	}
 
 	@Test
@@ -82,6 +133,7 @@ class AdminMemberUseCaseTest {
 
 		// then
 		assertThat(throwable).isSameAs(exception);
+		verifyNoInteractions(adminMemberTeamService);
 		verifyNoInteractions(adminMemberService);
 		verifyNoInteractions(adminMemberActivityService);
 

--- a/src/test/java/org/ject/support/common/data/redis/resilience/CacheFallbackIntegrationTest.java
+++ b/src/test/java/org/ject/support/common/data/redis/resilience/CacheFallbackIntegrationTest.java
@@ -2,6 +2,7 @@ package org.ject.support.common.data.redis.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ject.support.domain.member.fixture.MemberFixture.member;
 import static org.ject.support.domain.recruit.domain.Question.InputType.TEXT;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
@@ -77,13 +78,11 @@ class CacheFallbackIntegrationTest {
 
         recruitRepository.save(recruit);
 
-        Member member = Member.create(
-                "김젝트",
-                "test" + uniqueSuffix + "@gmail.com",
-                "01012345678",
-                List.of(),
-                null
-        );
+        Member member = member()
+                .email("test" + uniqueSuffix + "@gmail.com")
+                .interestedDomains(List.of())
+                .region(null)
+                .build();
         memberRepository.save(member);
     }
 

--- a/src/test/java/org/ject/support/common/data/redis/resilience/CacheFallbackIntegrationTest.java
+++ b/src/test/java/org/ject/support/common/data/redis/resilience/CacheFallbackIntegrationTest.java
@@ -77,11 +77,13 @@ class CacheFallbackIntegrationTest {
 
         recruitRepository.save(recruit);
 
-        Member member = Member.builder()
-                .email("test" + uniqueSuffix + "@gmail.com")
-                .name("김젝트")
-                .phoneNumber("01012345678")
-                .build();
+        Member member = Member.create(
+                "김젝트",
+                "test" + uniqueSuffix + "@gmail.com",
+                "01012345678",
+                List.of(),
+                null
+        );
         memberRepository.save(member);
     }
 

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.ject.support.domain.file.exception.FileErrorCode.INVALID_EXTENSION;
+import static org.ject.support.domain.member.fixture.MemberFixture.member;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -53,13 +54,12 @@ class FileControllerTest extends ApplicationPeriodTest {
 
     @BeforeEach
     void setUp() {
-        member = Member.create(
-                "홍길동",
-                "test32@gmail.com",
-                "01012345678",
-                List.of(),
-                null
-        );
+        member = member()
+                .name("홍길동")
+                .email("test32@gmail.com")
+                .interestedDomains(List.of())
+                .region(null)
+                .build();
         memberRepository.save(member);
     }
 

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.ject.support.domain.file.exception.FileErrorCode.INVALID_EXTENSION;
@@ -52,11 +53,13 @@ class FileControllerTest extends ApplicationPeriodTest {
 
     @BeforeEach
     void setUp() {
-        member = Member.builder()
-                .email("test32@gmail.com")
-                .name("홍길동")
-                .phoneNumber("01012345678")
-                .build();
+        member = Member.create(
+                "홍길동",
+                "test32@gmail.com",
+                "01012345678",
+                List.of(),
+                null
+        );
         memberRepository.save(member);
     }
 

--- a/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
+++ b/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
@@ -58,6 +58,19 @@ class MemberActivityTest {
 		// then
 		assertThat(memberSemester).isNotNull();
 		assertThat(memberSemester.getSemesterId()).isEqualTo(2L);
+		assertThat(memberSemester.getTeamId()).isEqualTo(3L);
 		assertThat(memberSemester.getMemberActivity()).isSameAs(memberActivity);
+	}
+
+	@Test
+	@DisplayName("팀을 선택하지 않으면 팀 정보 없이 일반 구성원 활동을 생성한다")
+	void 팀을_선택하지_않으면_팀_정보_없이_일반_구성원_활동을_생성한다() {
+		// given
+
+		// when
+		MemberActivity memberActivity = semesterActivity().teamId(null).build();
+
+		// then
+		assertThat(memberActivity.getMemberSemester().getTeamId()).isNull();
 	}
 }

--- a/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
+++ b/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
@@ -1,0 +1,63 @@
+package org.ject.support.domain.member.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.ject.support.domain.member.ActivityStatus;
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberActivityTest {
+
+	private MemberActivity createSemesterActivity(){
+		return MemberActivity.createSemesterActivity(
+			1L,
+			JobFamily.BE,
+			RecruitTypeDetail.REGULAR,
+			CareerDetails.EMPLOYEE,
+			ExperiencePeriod.ONE_TO_TWO,
+			"테스트 메모",
+			2L
+		);
+	}
+
+	@Test
+	@DisplayName("일반 구성원 활동을 생성한다.")
+	void 일반_구성원_활동을_생성한다() {
+
+		MemberActivity memberActivity = createSemesterActivity();
+
+		assertThat(memberActivity.getMemberId()).isEqualTo(1L);
+		assertThat(memberActivity.getMemberType()).isEqualTo(MemberType.SEMESTER);
+		assertThat(memberActivity.getJobFamily()).isEqualTo(JobFamily.BE);
+		assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(RecruitTypeDetail.REGULAR);
+		assertThat(memberActivity.getCareerDetails()).isEqualTo(CareerDetails.EMPLOYEE);
+		assertThat(memberActivity.getExperiencePeriod()).isEqualTo(ExperiencePeriod.ONE_TO_TWO);
+		assertThat(memberActivity.getMemo()).isEqualTo("테스트 메모");
+
+	}
+
+	@Test
+	@DisplayName("일반_구성원_활동은_ACTIVE_상태로_생성된다")
+	void 일반_구성원_활동은_ACTIVE_상태로_생성된다() {
+		MemberActivity memberActivity = createSemesterActivity();
+
+		assertThat(memberActivity.getActivityStatus()).isEqualTo(ActivityStatus.ACTIVE);
+		assertThat(memberActivity.getIsDeleted()).isFalse();
+	}
+
+	@Test
+	@DisplayName("일반_구성원_활동을_생성하면_관리_항목이_함께_생성된다")
+	void 일반_구성원_활동을_생성하면_관리_항목이_함께_생성된다() {
+		MemberActivity memberActivity = createSemesterActivity();
+		MemberSemester memberSemester = memberActivity.getMemberSemester();
+
+		assertThat(memberSemester).isNotNull();
+		assertThat(memberSemester.getSemesterId()).isEqualTo(2L);
+		assertThat(memberSemester.getMemberActivity()).isSameAs(memberActivity);
+	}
+}

--- a/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
+++ b/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.member.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.member.fixture.SemesterActivityFixture.semesterActivity;
 
 import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.CareerDetails;
@@ -13,24 +14,15 @@ import org.junit.jupiter.api.Test;
 
 class MemberActivityTest {
 
-	private MemberActivity createSemesterActivity(){
-		return MemberActivity.createSemesterActivity(
-			1L,
-			JobFamily.BE,
-			RecruitTypeDetail.REGULAR,
-			CareerDetails.EMPLOYEE,
-			ExperiencePeriod.ONE_TO_TWO,
-			"테스트 메모",
-			2L
-		);
-	}
-
 	@Test
-	@DisplayName("일반 구성원 활동을 생성한다.")
+	@DisplayName("일반 구성원 활동을 생성한다")
 	void 일반_구성원_활동을_생성한다() {
+		// given
 
-		MemberActivity memberActivity = createSemesterActivity();
+		// when
+		MemberActivity memberActivity = semesterActivity().build();
 
+		// then
 		assertThat(memberActivity.getMemberId()).isEqualTo(1L);
 		assertThat(memberActivity.getMemberType()).isEqualTo(MemberType.SEMESTER);
 		assertThat(memberActivity.getJobFamily()).isEqualTo(JobFamily.BE);
@@ -42,20 +34,28 @@ class MemberActivityTest {
 	}
 
 	@Test
-	@DisplayName("일반_구성원_활동은_ACTIVE_상태로_생성된다")
+	@DisplayName("일반 구성원 활동은 ACTIVE 상태로 생성된다")
 	void 일반_구성원_활동은_ACTIVE_상태로_생성된다() {
-		MemberActivity memberActivity = createSemesterActivity();
+		// given
 
+		// when
+		MemberActivity memberActivity = semesterActivity().build();
+
+		// then
 		assertThat(memberActivity.getActivityStatus()).isEqualTo(ActivityStatus.ACTIVE);
 		assertThat(memberActivity.getIsDeleted()).isFalse();
 	}
 
 	@Test
-	@DisplayName("일반_구성원_활동을_생성하면_관리_항목이_함께_생성된다")
+	@DisplayName("일반 구성원 활동을 생성하면 관리 항목이 함께 생성된다")
 	void 일반_구성원_활동을_생성하면_관리_항목이_함께_생성된다() {
-		MemberActivity memberActivity = createSemesterActivity();
+		// given
+
+		// when
+		MemberActivity memberActivity = semesterActivity().build();
 		MemberSemester memberSemester = memberActivity.getMemberSemester();
 
+		// then
 		assertThat(memberSemester).isNotNull();
 		assertThat(memberSemester.getSemesterId()).isEqualTo(2L);
 		assertThat(memberSemester.getMemberActivity()).isSameAs(memberActivity);

--- a/src/test/java/org/ject/support/domain/member/entity/MemberTest.java
+++ b/src/test/java/org/ject/support/domain/member/entity/MemberTest.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.member.entity;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.member.fixture.MemberFixture.member;
 
 import java.util.List;
 
@@ -11,22 +12,24 @@ import org.junit.jupiter.api.Test;
 class MemberTest {
 
 	@Test
-	@DisplayName("")
+	@DisplayName("구성원을 생성한다")
 	void 구성원을_생성한다() {
-	    Member member = Member.create(
-			"김젝트",
-			"admin@ject.kr",
-			"01012345678",
-			List.of("HEALTHCARE","FINTECH", "AI"),
-			Region.SEOUL
-		);
+		// given
+		List<String> interestedDomains = List.of("HEALTHCARE", "FINTECH", "AI");
 
-		assertEquals("김젝트", member.getName());
-		assertEquals("admin@ject.kr", member.getEmail());
-		assertEquals("01012345678", member.getPhoneNumber());
-		assertEquals(List.of("HEALTHCARE","FINTECH", "AI"), member.getInterestedDomains());
-		assertEquals(Region.SEOUL, member.getRegion());
+		// when
+	    Member member = member()
+			.email("admin@ject.kr")
+			.interestedDomains(interestedDomains)
+			.build();
 
+		// then
+		assertThat(member.getName()).isEqualTo("김젝트");
+		assertThat(member.getEmail()).isEqualTo("admin@ject.kr");
+		assertThat(member.getPhoneNumber()).isEqualTo("01012345678");
+		assertThat(member.getInterestedDomains()).containsExactlyElementsOf(interestedDomains);
+		assertThat(member.getRegion()).isEqualTo(Region.SEOUL);
+		assertThat(member.getIsDeleted()).isFalse();
 	}
 
 }

--- a/src/test/java/org/ject/support/domain/member/entity/MemberTest.java
+++ b/src/test/java/org/ject/support/domain/member/entity/MemberTest.java
@@ -1,0 +1,32 @@
+package org.ject.support.domain.member.entity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.ject.support.domain.member.Region;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+	@Test
+	@DisplayName("")
+	void 구성원을_생성한다() {
+	    Member member = Member.create(
+			"김젝트",
+			"admin@ject.kr",
+			"01012345678",
+			List.of("HEALTHCARE","FINTECH", "AI"),
+			Region.SEOUL
+		);
+
+		assertEquals("김젝트", member.getName());
+		assertEquals("admin@ject.kr", member.getEmail());
+		assertEquals("01012345678", member.getPhoneNumber());
+		assertEquals(List.of("HEALTHCARE","FINTECH", "AI"), member.getInterestedDomains());
+		assertEquals(Region.SEOUL, member.getRegion());
+
+	}
+
+}

--- a/src/test/java/org/ject/support/domain/member/fixture/MemberFixture.java
+++ b/src/test/java/org/ject/support/domain/member/fixture/MemberFixture.java
@@ -1,0 +1,50 @@
+package org.ject.support.domain.member.fixture;
+
+import java.util.List;
+import org.ject.support.domain.member.Region;
+import org.ject.support.domain.member.entity.Member;
+
+public final class MemberFixture {
+
+    private String name = "김젝트";
+    private String email = "member@test.com";
+    private String phoneNumber = "01012345678";
+    private List<String> interestedDomains = List.of("커머스");
+    private Region region = Region.SEOUL;
+
+    private MemberFixture() {
+    }
+
+    public static MemberFixture member() {
+        return new MemberFixture();
+    }
+
+    public MemberFixture name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public MemberFixture email(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public MemberFixture phoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+        return this;
+    }
+
+    public MemberFixture interestedDomains(List<String> interestedDomains) {
+        this.interestedDomains = interestedDomains;
+        return this;
+    }
+
+    public MemberFixture region(Region region) {
+        this.region = region;
+        return this;
+    }
+
+    public Member build() {
+        return Member.create(name, email, phoneNumber, interestedDomains, region);
+    }
+}

--- a/src/test/java/org/ject/support/domain/member/fixture/SemesterActivityFixture.java
+++ b/src/test/java/org/ject/support/domain/member/fixture/SemesterActivityFixture.java
@@ -1,0 +1,72 @@
+package org.ject.support.domain.member.fixture;
+
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.entity.MemberActivity;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+
+public final class SemesterActivityFixture {
+
+    private Long memberId = 1L;
+    private JobFamily jobFamily = JobFamily.BE;
+    private RecruitTypeDetail recruitTypeDetail = RecruitTypeDetail.REGULAR;
+    private CareerDetails careerDetails = CareerDetails.EMPLOYEE;
+    private ExperiencePeriod experiencePeriod = ExperiencePeriod.ONE_TO_TWO;
+    private String memo = "테스트 메모";
+    private Long semesterId = 2L;
+
+    private SemesterActivityFixture() {
+    }
+
+    public static SemesterActivityFixture semesterActivity() {
+        return new SemesterActivityFixture();
+    }
+
+    public SemesterActivityFixture memberId(Long memberId) {
+        this.memberId = memberId;
+        return this;
+    }
+
+    public SemesterActivityFixture jobFamily(JobFamily jobFamily) {
+        this.jobFamily = jobFamily;
+        return this;
+    }
+
+    public SemesterActivityFixture recruitTypeDetail(RecruitTypeDetail recruitTypeDetail) {
+        this.recruitTypeDetail = recruitTypeDetail;
+        return this;
+    }
+
+    public SemesterActivityFixture careerDetails(CareerDetails careerDetails) {
+        this.careerDetails = careerDetails;
+        return this;
+    }
+
+    public SemesterActivityFixture experiencePeriod(ExperiencePeriod experiencePeriod) {
+        this.experiencePeriod = experiencePeriod;
+        return this;
+    }
+
+    public SemesterActivityFixture memo(String memo) {
+        this.memo = memo;
+        return this;
+    }
+
+    public SemesterActivityFixture semesterId(Long semesterId) {
+        this.semesterId = semesterId;
+        return this;
+    }
+
+    public MemberActivity build() {
+        return MemberActivity.createSemesterActivity(
+            memberId,
+            jobFamily,
+            recruitTypeDetail,
+            careerDetails,
+            experiencePeriod,
+            memo,
+            semesterId
+        );
+    }
+}

--- a/src/test/java/org/ject/support/domain/member/fixture/SemesterActivityFixture.java
+++ b/src/test/java/org/ject/support/domain/member/fixture/SemesterActivityFixture.java
@@ -15,6 +15,7 @@ public final class SemesterActivityFixture {
     private ExperiencePeriod experiencePeriod = ExperiencePeriod.ONE_TO_TWO;
     private String memo = "테스트 메모";
     private Long semesterId = 2L;
+    private Long teamId = 3L;
 
     private SemesterActivityFixture() {
     }
@@ -58,6 +59,11 @@ public final class SemesterActivityFixture {
         return this;
     }
 
+    public SemesterActivityFixture teamId(Long teamId) {
+        this.teamId = teamId;
+        return this;
+    }
+
     public MemberActivity build() {
         return MemberActivity.createSemesterActivity(
             memberId,
@@ -66,7 +72,8 @@ public final class SemesterActivityFixture {
             careerDetails,
             experiencePeriod,
             memo,
-            semesterId
+            semesterId,
+            teamId
         );
     }
 }

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -1,0 +1,137 @@
+package org.ject.support.domain.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.member.fixture.MemberFixture.member;
+import static org.ject.support.domain.member.fixture.SemesterActivityFixture.semesterActivity;
+
+import jakarta.persistence.EntityManager;
+import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.entity.MemberActivity;
+import org.ject.support.domain.member.entity.MemberSemester;
+import org.ject.support.testconfig.QueryDslTestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@Import(QueryDslTestConfig.class)
+@DataJpaTest
+class MemberActivityRepositoryTest {
+
+    private static final Long SEMESTER_ID = 5L;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    MemberActivityRepository memberActivityRepository;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Test
+    void 일반_구성원_활동을_저장하면_하위_테이블에_기수_정보를_함께_저장한다() {
+        // given
+        Member member = memberRepository.save(member().email("member@test.com").build());
+        MemberActivity activity = semesterActivity()
+            .memberId(member.getId())
+            .semesterId(SEMESTER_ID)
+            .build();
+
+        // when
+        MemberActivity savedActivity = memberActivityRepository.saveAndFlush(activity);
+        entityManager.clear();
+
+        MemberActivity result = memberActivityRepository.findById(savedActivity.getId())
+            .orElseThrow();
+        MemberSemester memberSemester = result.getMemberSemester();
+
+        // then
+        assertThat(memberSemester).isNotNull();
+        assertThat(memberSemester.getId()).isEqualTo(result.getId());
+        assertThat(memberSemester.getSemesterId()).isEqualTo(SEMESTER_ID);
+        assertThat(memberSemester.getMemberActivity()).isSameAs(result);
+    }
+
+    @Test
+    void 같은_구성원의_동일_기수_활동이_존재하면_true를_반환한다() {
+        // given
+        Member member = memberRepository.save(member().email("member@test.com").build());
+        memberActivityRepository.saveAndFlush(semesterActivity()
+            .memberId(member.getId())
+            .semesterId(SEMESTER_ID)
+            .build());
+
+        // when
+        boolean result = memberActivityRepository.existsSemesterActivity(
+            member.getId(),
+            MemberType.SEMESTER,
+            SEMESTER_ID
+        );
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 다른_기수의_활동만_존재하면_false를_반환한다() {
+        // given
+        Member member = memberRepository.save(member().email("member@test.com").build());
+        memberActivityRepository.saveAndFlush(semesterActivity()
+            .memberId(member.getId())
+            .semesterId(SEMESTER_ID)
+            .build());
+
+        // when
+        boolean result = memberActivityRepository.existsSemesterActivity(
+            member.getId(),
+            MemberType.SEMESTER,
+            6L
+        );
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void 다른_구성원의_활동만_존재하면_false를_반환한다() {
+        // given
+        Member member = memberRepository.save(member().email("member@test.com").build());
+        Member otherMember = memberRepository.save(member().email("other-member@test.com").build());
+        memberActivityRepository.saveAndFlush(semesterActivity()
+            .memberId(member.getId())
+            .semesterId(SEMESTER_ID)
+            .build());
+
+        // when
+        boolean result = memberActivityRepository.existsSemesterActivity(
+            otherMember.getId(),
+            MemberType.SEMESTER,
+            SEMESTER_ID
+        );
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void 다른_구성원_유형으로_조회하면_false를_반환한다() {
+        // given
+        Member member = memberRepository.save(member().email("member@test.com").build());
+        memberActivityRepository.saveAndFlush(semesterActivity()
+            .memberId(member.getId())
+            .semesterId(SEMESTER_ID)
+            .build());
+
+        // when
+        boolean result = memberActivityRepository.existsSemesterActivity(
+            member.getId(),
+            MemberType.MAKERS,
+            SEMESTER_ID
+        );
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -51,6 +51,7 @@ class MemberActivityRepositoryTest {
         assertThat(memberSemester).isNotNull();
         assertThat(memberSemester.getId()).isEqualTo(result.getId());
         assertThat(memberSemester.getSemesterId()).isEqualTo(SEMESTER_ID);
+        assertThat(memberSemester.getTeamId()).isEqualTo(3L);
         assertThat(memberSemester.getMemberActivity()).isSameAs(result);
     }
 

--- a/src/test/java/org/ject/support/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberRepositoryTest.java
@@ -9,6 +9,7 @@ import org.ject.support.testconfig.QueryDslTestConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
 @Import(QueryDslTestConfig.class)
@@ -17,6 +18,9 @@ class MemberRepositoryTest {
 
     @Autowired
     MemberRepository memberRepository;
+
+    @Autowired
+    TestEntityManager entityManager;
 
     @Test
     void 이메일로_구성원을_조회한다() {
@@ -42,5 +46,25 @@ class MemberRepositoryTest {
 
         // then
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void 삭제된_구성원을_포함해_이메일로_조회한다() {
+        // given
+        String email = "deleted@test.com";
+        Member savedMember = memberRepository.save(member().email(email).build());
+        memberRepository.delete(savedMember);
+        memberRepository.flush();
+        entityManager.clear();
+
+        // when
+        Optional<Member> activeResult = memberRepository.findByEmail(email);
+        Optional<Member> includingDeletedResult = memberRepository.findByEmailIncludingDeleted(email);
+
+        // then
+        assertThat(activeResult).isEmpty();
+        assertThat(includingDeletedResult).isPresent();
+        assertThat(includingDeletedResult.get().getEmail()).isEqualTo(email);
+        assertThat(includingDeletedResult.get().getIsDeleted()).isTrue();
     }
 }

--- a/src/test/java/org/ject/support/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,46 @@
+package org.ject.support.domain.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.member.fixture.MemberFixture.member;
+
+import java.util.Optional;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.testconfig.QueryDslTestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@Import(QueryDslTestConfig.class)
+@DataJpaTest
+class MemberRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    void 이메일로_구성원을_조회한다() {
+        // given
+        String email = "member@test.com";
+        memberRepository.save(member().email(email).build());
+
+        // when
+        Optional<Member> result = memberRepository.findByEmail(email);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getEmail()).isEqualTo(email);
+    }
+
+    @Test
+    void 존재하지_않는_이메일로_조회하면_빈_결과를_반환한다() {
+        // given
+        String email = "not-found@test.com";
+
+        // when
+        Optional<Member> result = memberRepository.findByEmail(email);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/org/ject/support/domain/member/repository/TeamRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/TeamRepositoryTest.java
@@ -1,0 +1,34 @@
+package org.ject.support.domain.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.ject.support.domain.member.entity.Team;
+import org.ject.support.testconfig.QueryDslTestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@Import(QueryDslTestConfig.class)
+@DataJpaTest
+class TeamRepositoryTest {
+
+	@Autowired
+	private TeamRepository teamRepository;
+
+	@Test
+	void 기수_ID로_팀_ID_목록을_조회한다() {
+		// given
+		Team firstTeam = teamRepository.save(Team.builder().name("1팀").semesterId(1L).build());
+		Team secondTeam = teamRepository.save(Team.builder().name("2팀").semesterId(1L).build());
+		teamRepository.save(Team.builder().name("다른 기수 팀").semesterId(2L).build());
+
+		// when
+		List<Long> result = teamRepository.findIdsBySemesterId(1L);
+
+		// then
+		assertThat(result).containsExactlyInAnyOrder(firstTeam.getId(), secondTeam.getId());
+	}
+}

--- a/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.ject.support.domain.member.fixture.MemberFixture.member;
 import static org.ject.support.domain.recruit.domain.Question.InputType.TEXT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -86,13 +87,11 @@ class QuestionControllerTest {
 
         recruitRepository.save(recruit);
 
-        member = Member.create(
-                "김젝트",
-                "test_" + uniqueSuffix + "@gmail.com",
-                "01012345678",
-                List.of(),
-                null
-        );
+        member = member()
+                .email("test_" + uniqueSuffix + "@gmail.com")
+                .interestedDomains(List.of())
+                .region(null)
+                .build();
         memberRepository.save(member);
     }
 

--- a/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/controller/QuestionControllerTest.java
@@ -86,11 +86,13 @@ class QuestionControllerTest {
 
         recruitRepository.save(recruit);
 
-        member = Member.builder()
-                .email("test_" + uniqueSuffix + "@gmail.com")
-                .name("김젝트")
-                .phoneNumber("01012345678")
-                .build();
+        member = Member.create(
+                "김젝트",
+                "test_" + uniqueSuffix + "@gmail.com",
+                "01012345678",
+                List.of(),
+                null
+        );
         memberRepository.save(member);
     }
 

--- a/src/test/java/org/ject/support/domain/recruit/service/SemesterInquiryServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/SemesterInquiryServiceTest.java
@@ -1,0 +1,64 @@
+package org.ject.support.domain.recruit.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+import org.ject.support.domain.recruit.domain.Semester;
+import org.ject.support.domain.recruit.dto.SemesterResponse;
+import org.ject.support.domain.recruit.exception.SemesterErrorCode;
+import org.ject.support.domain.recruit.exception.SemesterException;
+import org.ject.support.domain.recruit.repository.SemesterRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SemesterInquiryServiceTest {
+
+    @Mock
+    private SemesterRepository semesterRepository;
+
+    @InjectMocks
+    private SemesterInquiryService semesterInquiryService;
+
+    @Test
+    @DisplayName("기수 ID로 기수를 조회한다")
+    void 기수_ID로_기수를_조회한다() {
+        // given
+        Long semesterId = 1L;
+        Semester semester = Semester.builder()
+            .id(semesterId)
+            .name("5기")
+            .build();
+        given(semesterRepository.findById(semesterId)).willReturn(Optional.of(semester));
+
+        // when
+        SemesterResponse response = semesterInquiryService.getSemester(semesterId);
+
+        // then
+        assertThat(response.id()).isEqualTo(semesterId);
+        assertThat(response.name()).isEqualTo(semester.getName());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 기수 ID로 조회하면 예외가 발생한다")
+    void 존재하지_않는_기수_ID로_조회하면_예외가_발생한다() {
+        // given
+        Long semesterId = 1L;
+        given(semesterRepository.findById(semesterId)).willReturn(Optional.empty());
+
+        // when
+        Throwable throwable = catchThrowable(() -> semesterInquiryService.getSemester(semesterId));
+
+        // then
+        assertThat(throwable)
+            .isInstanceOf(SemesterException.class)
+            .extracting("errorCode")
+            .isEqualTo(SemesterErrorCode.NOT_FOUND_SEMESTER);
+    }
+}


### PR DESCRIPTION
## 연관 이슈
Closes #518 

## 작업 내용

- 일반 구성원 추가 API 구현
- 이메일 기준 기존 Member 조회 및 신규 생성
- MemberActivity와 MemberSemester 일괄 생성
- 동일 기수 활동 중복 등록 검증
- 기수 및 teamId 유효성 검증
- 관련 테스트 추가

## 호출 구조

```text
Controller → UseCase(전체 로직 조립) → 도메인별 Service → Repository
```

```text
AdminMemberSemesterController → AdminMemberUseCase → SemesterInquiryUsecase → SemesterRepository
AdminMemberSemesterController → AdminMemberUseCase → AdminMemberTeamService → TeamRepository
AdminMemberSemesterController → AdminMemberUseCase → AdminMemberService → MemberRepository
AdminMemberSemesterController → AdminMemberUseCase → AdminMemberActivityService → MemberActivityRepository
```

UseCase는 구성원 추가 흐름을 조립하고, 실제 조회,생성,저장 책임은 도메인별 Service에 분리했습니다.

MemberActivity는 일반 구성원 활동의 Aggregate Root로서 MemberSemester를 생성하며, 두 엔티티는 식별 관계와 Cascade를 통해 함께 저장됩니다.

```text
MemberActivity.createSemesterActivity() → MemberSemester.create() → MemberActivityRepository.save()
```

## API

### 일반 구성원 추가

`POST /admin/members/semester`

- 'teamId'가 입력된 경우 해당 기수에 속한 팀인지 검증
- 이메일에 해당하는 Member가 없으면 신상정보 생성
- 기존 Member가 있으면 신상정보를 재사용하고 활동만 추가
- 동일 기수 활동이 존재하면 중복 등록 예외 반환


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**New Features**
- 관리자용 회원 등록 API 엔드포인트 추가: 기수별로 회원을 일괄 등록할 수 있습니다. 이름, 이메일, 전화번호, 직군, 모집 유형, 경력, 관심 도메인, 거주 지역 등의 정보를 입력받으며, 필수 항목 검증과 이메일 형식 검증이 자동으로 적용됩니다.

**Tests**
- 회원 등록 로직 및 저장소 관련 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->