### PR TITLE
[feat] 앱개발자 직군 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/member/JobFamily.java
+++ b/src/main/java/org/ject/support/domain/member/JobFamily.java
@@ -10,6 +10,7 @@ public enum JobFamily {
     PD("프로덕트 디자이너(PD)", true),
     FE("프론트엔드 개발자(FE)", false),
     BE("백엔드 개발자(BE)", false),
+    APP("앱 개발자(APP)", false),
     SUPPORTER("운영 서포터즈", false),
     ;
 

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -106,6 +106,8 @@ class FileControllerTest extends ApplicationPeriodTest {
                 .thenReturn(Boolean.toString(false));
         when(redisTemplate.opsForValue().get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.BE.name())))
                 .thenReturn(Boolean.toString(false));
+        when(redisTemplate.opsForValue().get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.APP.name())))
+                .thenReturn(Boolean.toString(false));
         when(redisTemplate.opsForValue().get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.SUPPORTER.name())))
                 .thenReturn(Boolean.toString(false));
 

--- a/src/test/java/org/ject/support/domain/member/JobFamilyTest.java
+++ b/src/test/java/org/ject/support/domain/member/JobFamilyTest.java
@@ -1,14 +1,56 @@
 package org.ject.support.domain.member;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 class JobFamilyTest {
 
     @Test
+    @DisplayName("프로덕트 매니저 직군을 제공한다")
+    void 프로덕트_매니저_직군을_제공한다() {
+        assertThat(JobFamily.PM.getDescription()).isEqualTo("프로덕트 매니저(PM)");
+        assertThat(JobFamily.PM.isPortfolioRequired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("프로덕트 디자이너 직군을 제공한다")
+    void 프로덕트_디자이너_직군을_제공한다() {
+        assertThat(JobFamily.PD.getDescription()).isEqualTo("프로덕트 디자이너(PD)");
+    }
+
+    @Test
+    @DisplayName("프론트엔드 개발자 직군을 제공한다")
+    void 프론트엔드_개발자_직군을_제공한다() {
+        assertThat(JobFamily.FE.getDescription()).isEqualTo("프론트엔드 개발자(FE)");
+        assertThat(JobFamily.FE.isPortfolioRequired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("백엔드 개발자 직군을 제공한다")
+    void 백엔드_개발자_직군을_제공한다() {
+        assertThat(JobFamily.BE.getDescription()).isEqualTo("백엔드 개발자(BE)");
+        assertThat(JobFamily.BE.isPortfolioRequired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("앱 개발자 직군을 제공한다")
+    void 앱_개발자_직군을_제공한다() {
+        assertThat(JobFamily.APP.getDescription()).isEqualTo("앱 개발자(APP)");
+        assertThat(JobFamily.APP.isPortfolioRequired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("운영 서포터즈 직군을 제공한다")
     void 운영_서포터즈_직군을_제공한다() {
         assertThat(JobFamily.SUPPORTER.getDescription()).isEqualTo("운영 서포터즈");
         assertThat(JobFamily.SUPPORTER.isPortfolioRequired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("프로덕트 디자이너는 포트폴리오가 필수다")
+    void 프로덕트_디자이너는_포트폴리오가_필수다() {
+        assertThat(JobFamily.PD.isPortfolioRequired()).isTrue();
     }
 }

--- a/src/test/java/org/ject/support/testconfig/ApplicationPeriodTest.java
+++ b/src/test/java/org/ject/support/testconfig/ApplicationPeriodTest.java
@@ -33,6 +33,8 @@ public abstract class ApplicationPeriodTest {
                 .thenReturn(Boolean.toString(true));
         when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.BE.name())))
                 .thenReturn(Boolean.toString(true));
+        when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.APP.name())))
+                .thenReturn(Boolean.toString(true));
         when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.SUPPORTER.name())))
                 .thenReturn(Boolean.toString(true));
         when(redisTemplate.getConnectionFactory()).thenReturn(redisConnectionFactory);


### PR DESCRIPTION
## 관련 이슈
Closes #580

## 변경 사항
- 신규 직군 앱 개발자(APP) 추가
- APP 직군은 포트폴리오 필수X로 제공
- JobFamily 테스트 보강
- 모집 기간 테스트 설정에 APP 직군 추가 반영