### PR TITLE
[feat] 운영서포터즈 직군 세분화

### DIFF
--- a/src/main/java/org/ject/support/domain/member/JobFamily.java
+++ b/src/main/java/org/ject/support/domain/member/JobFamily.java
@@ -12,6 +12,10 @@ public enum JobFamily {
     BE("백엔드 개발자(BE)", false),
     APP("앱 개발자(APP)", false),
     SUPPORTER("운영 서포터즈", false),
+    OPS("운영팀(OPS)", false),
+    INFRA("인프라팀(INFRA)", false),
+    BX("BX팀(BX)", false),
+    ER("대외협력팀(ER)", false),
     ;
 
     private final String description;

--- a/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/ject/support/domain/file/controller/FileControllerTest.java
@@ -110,6 +110,14 @@ class FileControllerTest extends ApplicationPeriodTest {
                 .thenReturn(Boolean.toString(false));
         when(redisTemplate.opsForValue().get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.SUPPORTER.name())))
                 .thenReturn(Boolean.toString(false));
+        when(redisTemplate.opsForValue().get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.OPS.name())))
+                .thenReturn(Boolean.toString(false));
+        when(redisTemplate.opsForValue().get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.INFRA.name())))
+                .thenReturn(Boolean.toString(false));
+        when(redisTemplate.opsForValue().get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.BX.name())))
+                .thenReturn(Boolean.toString(false));
+        when(redisTemplate.opsForValue().get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.ER.name())))
+                .thenReturn(Boolean.toString(false));
 
         // then
         mockMvc.perform(post("/upload/portfolios")

--- a/src/test/java/org/ject/support/domain/member/JobFamilyTest.java
+++ b/src/test/java/org/ject/support/domain/member/JobFamilyTest.java
@@ -49,6 +49,34 @@ class JobFamilyTest {
     }
 
     @Test
+    @DisplayName("운영팀 직군을 제공한다")
+    void 운영팀_직군을_제공한다() {
+        assertThat(JobFamily.OPS.getDescription()).isEqualTo("운영팀(OPS)");
+        assertThat(JobFamily.OPS.isPortfolioRequired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("인프라팀 직군을 제공한다")
+    void 인프라팀_직군을_제공한다() {
+        assertThat(JobFamily.INFRA.getDescription()).isEqualTo("인프라팀(INFRA)");
+        assertThat(JobFamily.INFRA.isPortfolioRequired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("BX팀 직군을 제공한다")
+    void BX팀_직군을_제공한다() {
+        assertThat(JobFamily.BX.getDescription()).isEqualTo("BX팀(BX)");
+        assertThat(JobFamily.BX.isPortfolioRequired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("대외협력팀 직군을 제공한다")
+    void 대외협력팀_직군을_제공한다() {
+        assertThat(JobFamily.ER.getDescription()).isEqualTo("대외협력팀(ER)");
+        assertThat(JobFamily.ER.isPortfolioRequired()).isFalse();
+    }
+
+    @Test
     @DisplayName("프로덕트 디자이너는 포트폴리오가 필수다")
     void 프로덕트_디자이너는_포트폴리오가_필수다() {
         assertThat(JobFamily.PD.isPortfolioRequired()).isTrue();

--- a/src/test/java/org/ject/support/testconfig/ApplicationPeriodTest.java
+++ b/src/test/java/org/ject/support/testconfig/ApplicationPeriodTest.java
@@ -37,6 +37,14 @@ public abstract class ApplicationPeriodTest {
                 .thenReturn(Boolean.toString(true));
         when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.SUPPORTER.name())))
                 .thenReturn(Boolean.toString(true));
+        when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.OPS.name())))
+                .thenReturn(Boolean.toString(true));
+        when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.INFRA.name())))
+                .thenReturn(Boolean.toString(true));
+        when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.BX.name())))
+                .thenReturn(Boolean.toString(true));
+        when(valueOperations.get(String.format("%s%s", Constants.RECRUIT_FLAG_PREFIX, JobFamily.ER.name())))
+                .thenReturn(Boolean.toString(true));
         when(redisTemplate.getConnectionFactory()).thenReturn(redisConnectionFactory);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #586 

## 📝 작업 내용

<!-- 이번 PR에서 작업한 내용을 구체적으로 설명해주세요 (이미지 첨부 가능) -->
운영 서포터즈 직군 세분화 반영 (jobfamily 추가, 기존데이터 호환을위해 SUPPORTER 유지)
- OPS(운영팀)
- INFRA(인프라팀)
- BX(BX팀)
- ER(대외협력팀)


## 🙏 리뷰 요구사항 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 직군 선택 항목에 **운영팀(OPS), 인프라팀(INFRA), BX팀(BX), 대외협력팀(ER)** 이 추가되었습니다.
  * 각 직군의 설명이 한국어로 표시되며, 기존과 동일한 설정이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->