### PR TITLE
feat/#589 프로젝트 GitHub URL 및 4기 카테고리 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/jectalk/controller/JectalkApiSpec.java
+++ b/src/main/java/org/ject/support/domain/jectalk/controller/JectalkApiSpec.java
@@ -19,6 +19,6 @@ public interface JectalkApiSpec {
     )
     Page<JectalkResponse> findJectalks(
             @PageableDefault(size = 12) Pageable pageable,
-            @Parameter(description = "기수 (SEMESTER_1, SEMESTER_2, SEMESTER_3)", example = "SEMESTER_1")
+            @Parameter(description = "기수 (SEMESTER_1, SEMESTER_2, SEMESTER_3, SEMESTER_4)", example = "SEMESTER_1")
             @RequestParam(required = false) Project.Category category);
 }

--- a/src/main/java/org/ject/support/domain/project/dto/ProjectDetailResponse.java
+++ b/src/main/java/org/ject/support/domain/project/dto/ProjectDetailResponse.java
@@ -18,6 +18,7 @@ public record ProjectDetailResponse(
         List<String> badges,
         String description,
         String serviceUrl,
+        String githubUrl,
         ProjectIntroResponse bannerImageUrl,
         List<ProjectIntroResponse> sampleImageUrls,
         List<ProjectIntroResponse> descriptionImageUrls
@@ -41,6 +42,7 @@ public record ProjectDetailResponse(
                 .badges(project.getBadges())
                 .description(project.getDescription())
                 .serviceUrl(project.getServiceUrl())
+                .githubUrl(project.getGithubUrl())
                 .bannerImageUrl(bannerImageUrl)
                 .sampleImageUrls(sampleImageUrls)
                 .descriptionImageUrls(descriptionImageUrls)

--- a/src/main/java/org/ject/support/domain/project/entity/Project.java
+++ b/src/main/java/org/ject/support/domain/project/entity/Project.java
@@ -67,6 +67,9 @@ public class Project extends BaseTimeEntity {
     @Column(length = 2083)
     private String serviceUrl;
 
+    @Column(length = 2083)
+    private String githubUrl;
+
     @Column(length = 50, nullable = false)
     private String serviceType;
 
@@ -90,7 +93,8 @@ public class Project extends BaseTimeEntity {
 
         SEMESTER_1(1, "1기"),
         SEMESTER_2(2, "2기"),
-        SEMESTER_3(3, "3기");
+        SEMESTER_3(3, "3기"),
+        SEMESTER_4(4, "4기");
 
         private final int order;
         private final String displayName;

--- a/src/main/resources/db/migration/V34__add_github_url_to_project.sql
+++ b/src/main/resources/db/migration/V34__add_github_url_to_project.sql
@@ -1,0 +1,2 @@
+ALTER TABLE project
+    ADD COLUMN github_url VARCHAR(2083) NULL AFTER service_url;

--- a/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
@@ -62,6 +62,7 @@ class ProjectServiceTest extends UnitTestSupport {
                 .description("description")
                 .thumbnailUrl("thumbnail.png")
                 .serviceUrl("service.com")
+                .githubUrl("https://github.com/JECT-Study/project")
                 .team(Team.builder().id(1L).name("team").semesterId(1L).build())
                 .projectIntros(List.of(serviceIntro1, serviceIntro2, serviceIntro3, devIntro1))
                 .build();
@@ -82,6 +83,7 @@ class ProjectServiceTest extends UnitTestSupport {
         assertThat(result.endDate()).isEqualTo(project.getEndDate());
         assertThat(result.description()).isEqualTo(project.getDescription());
         assertThat(result.serviceUrl()).isEqualTo(project.getServiceUrl());
+        assertThat(result.githubUrl()).isEqualTo(project.getGithubUrl());
         assertThat(result.sampleImageUrls()).hasSize(3);
         assertThat(result.descriptionImageUrls()).hasSize(1);
     }
@@ -148,6 +150,9 @@ class ProjectServiceTest extends UnitTestSupport {
 
         assertThat(summary.categorySummaries().get(3).categoryName()).isEqualTo(Project.Category.SEMESTER_3.name());
         assertThat(summary.categorySummaries().get(3).count()).isEqualTo(0L);
+
+        assertThat(summary.categorySummaries().get(4).categoryName()).isEqualTo(Project.Category.SEMESTER_4.name());
+        assertThat(summary.categorySummaries().get(4).count()).isEqualTo(0L);
     }
 
     private ProjectIntro createProjectIntro(Long id, String imageUrl, Category category, int sequence) {


### PR DESCRIPTION
## 작업 내용

- 프로젝트에 nullable `githubUrl`을 추가하고 상세 조회 응답에서 `serviceUrl`과 함께 반환합니다.
- `Project.Category`에 `SEMESTER_4`를 추가합니다.
- `project.github_url VARCHAR(2083) NULL` 컬럼을 추가하는 Flyway V34 마이그레이션을 포함합니다.
- 프로젝트 상세 응답 및 4기 요약 동작 테스트를 보강합니다.

## 변경 이유

운영 서비스 URL과 GitHub URL은 서로 독립적인 값입니다. 두 URL이 모두 있거나 하나만 있을 수 있으며, 모두 없으면 연결할 링크가 없는 프로젝트입니다. `isActive`나 `linkType` 같은 중복 상태값은 추가하지 않았습니다.

## 테스트

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew test --tests org.ject.support.domain.project.service.ProjectServiceTest -x jacocoTestCoverageVerification` 성공
- 전체 `./gradlew test`: 로컬 Docker 미실행으로 Redis Testcontainers 초기화 관련 32건 실패

## 배포 및 데이터 반영

- 스키마 변경: Flyway V34 적용 필요
- 운영 S3에 4기 프로젝트 이미지 88개 업로드 및 CloudFront 응답 확인 완료
- 운영 DB의 4기 프로젝트 등록과 기존 7개 프로젝트 URL 변경은 별도 운영 데이터 작업으로 진행합니다.

## 관련 이슈

#589

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 프로젝트 상세 정보에 GitHub 저장소 URL이 표시됩니다.
  * 프로젝트 분류에 4기(SEMESTER_4)가 추가되었습니다.

* **문서**
  * Jectalk 조회 API 문서에서 SEMESTER_4 선택 옵션이 안내됩니다.

* **데이터베이스**
  * 프로젝트의 GitHub URL 저장을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->