### PR TITLE
[FEAT] 프로젝트 정보 상세조회시 팀원 이름 조회 로직 연결

### DIFF
--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
+import org.ject.support.domain.member.dto.TeamMemberNames;
 
 public interface MemberActivityQueryRepository {
 	List<SearchMemberSemesterProjection> searchMemberSemesters(
@@ -12,4 +13,6 @@ public interface MemberActivityQueryRepository {
 	);
 
 	long countMemberSemesters(MemberSemesterSearchCondition conditon);
+
+	TeamMemberNames findMemberNamesByTeamId(Long teamId);
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
@@ -12,8 +12,10 @@ import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.member.dto.TeamMemberNames;
 import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -78,6 +80,40 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 			).fetchOne();
 
 		return count == null ? 0L : count;
+	}
+
+	// 팀에 소속된 일반 구성원 이름을 직군별로 조회
+	@Override
+	public TeamMemberNames findMemberNamesByTeamId(Long teamId) {
+		List<Tuple> teamMembers = jpaQueryFactory
+			.select(member.name, memberActivity.jobFamily)
+			.from(memberActivity)
+			.join(member).on(member.id.eq(memberActivity.memberId))
+			.join(memberSemester).on(memberSemester.id.eq(memberActivity.id))
+			.where(
+				memberSemester.teamId.eq(teamId),
+				memberActivity.memberType.eq(MemberType.SEMESTER),
+				member.isDeleted.isFalse(),
+				memberActivity.isDeleted.isFalse(),
+				member.name.isNotNull()
+			)
+			.orderBy(memberActivity.id.asc())
+			.fetch();
+
+		return new TeamMemberNames(
+			findNamesByJobFamily(teamMembers, JobFamily.PM),
+			findNamesByJobFamily(teamMembers, JobFamily.PD),
+			findNamesByJobFamily(teamMembers, JobFamily.FE),
+			findNamesByJobFamily(teamMembers, JobFamily.BE)
+		);
+	}
+
+	// 조회 결과에서 지정 직군의 이름만 분리
+	private List<String> findNamesByJobFamily(List<Tuple> teamMembers, JobFamily jobFamily) {
+		return teamMembers.stream()
+			.filter(teamMember -> jobFamily == teamMember.get(memberActivity.jobFamily))
+			.map(teamMember -> teamMember.get(member.name))
+			.toList();
 	}
 
 	private BooleanExpression cursorLt(Long cursor){

--- a/src/main/java/org/ject/support/domain/project/service/ProjectService.java
+++ b/src/main/java/org/ject/support/domain/project/service/ProjectService.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.project.service;
 
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.member.dto.TeamMemberNames;
+import org.ject.support.domain.member.repository.MemberActivityRepository;
 import org.ject.support.domain.project.dto.ProjectDetailResponse;
 import org.ject.support.domain.project.dto.ProjectIntroResponse;
 import org.ject.support.domain.project.dto.ProjectResponse;
@@ -24,6 +25,7 @@ import java.util.List;
 public class ProjectService {
 
     private final ProjectRepository projectRepository;
+    private final MemberActivityRepository memberActivityRepository;
 
     /**
      * 주어진 기수의 프로젝트를 모두 조회합니다.
@@ -44,8 +46,8 @@ public class ProjectService {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ProjectException(ProjectErrorCode.NOT_FOUND_PROJECT));
 
-        // TODO: member_semester.team_id 기반으로 팀 구성원 조회 재개발 필요
-        TeamMemberNames teamMemberNames = new TeamMemberNames(List.of(), List.of(), List.of(), List.of());
+        TeamMemberNames teamMemberNames =
+                memberActivityRepository.findMemberNamesByTeamId(project.getTeam().getId());
 
         List<ProjectIntro> projectIntros = project.getProjectIntros();
 

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -13,6 +13,7 @@ import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.member.dto.TeamMemberNames;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.entity.MemberActivity;
 import org.ject.support.domain.member.entity.MemberSemester;
@@ -81,6 +82,22 @@ class MemberActivityRepositoryTest {
             .careerDetails(careerDetails)
             .experiencePeriod(experiencePeriod)
             .activityStatus(activityStatus)
+            .build());
+    }
+
+    private MemberActivity saveSemesterActivity(
+        String name,
+        String email,
+        Long semesterId,
+        Long teamId,
+        JobFamily jobFamily
+    ) {
+        Member member = memberRepository.save(member().name(name).email(email).build());
+        return memberActivityRepository.saveAndFlush(semesterActivity()
+            .memberId(member.getId())
+            .semesterId(semesterId)
+            .teamId(teamId)
+            .jobFamily(jobFamily)
             .build());
     }
 
@@ -666,5 +683,77 @@ class MemberActivityRepositoryTest {
         // then
         assertThat(results).hasSize(1);
         assertThat(totalCount).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("팀 ID로 일반 구성원 이름을 직군별로 조회한다")
+    void 팀_ID로_일반_구성원_이름을_직군별로_조회한다() {
+        // given
+        Long teamId = 10L;
+        saveSemesterActivity("기획자", "pm@test.com", SEMESTER_ID, teamId, JobFamily.PM);
+        saveSemesterActivity("디자이너", "pd@test.com", SEMESTER_ID, teamId, JobFamily.PD);
+        saveSemesterActivity("프론트1", "fe1@test.com", SEMESTER_ID, teamId, JobFamily.FE);
+        saveSemesterActivity("프론트2", "fe2@test.com", SEMESTER_ID, teamId, JobFamily.FE);
+        saveSemesterActivity("백엔드", "be@test.com", SEMESTER_ID, teamId, JobFamily.BE);
+        saveSemesterActivity("앱", "app@test.com", SEMESTER_ID, teamId, JobFamily.APP);
+        saveSemesterActivity("다른팀", "other@test.com", SEMESTER_ID, 20L, JobFamily.BE);
+
+        // when
+        TeamMemberNames result = memberActivityRepository.findMemberNamesByTeamId(teamId);
+
+        // then
+        assertThat(result.productManagers()).containsExactly("기획자");
+        assertThat(result.productDesigners()).containsExactly("디자이너");
+        assertThat(result.frontendDevelopers()).containsExactly("프론트1", "프론트2");
+        assertThat(result.backendDevelopers()).containsExactly("백엔드");
+    }
+
+    @Test
+    @DisplayName("구성원이 없는 팀은 직군별 빈 목록을 반환한다")
+    void 구성원이_없는_팀은_직군별_빈_목록을_반환한다() {
+        // when
+        TeamMemberNames result = memberActivityRepository.findMemberNamesByTeamId(999L);
+
+        // then
+        assertThat(result.productManagers()).isEmpty();
+        assertThat(result.productDesigners()).isEmpty();
+        assertThat(result.frontendDevelopers()).isEmpty();
+        assertThat(result.backendDevelopers()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("삭제된 구성원과 활동은 팀원 이름 조회에서 제외한다")
+    void 삭제된_구성원과_활동은_팀원_이름_조회에서_제외한다() {
+        // given
+        Long teamId = 10L;
+        saveSemesterActivity("정상 구성원", "active@test.com", SEMESTER_ID, teamId, JobFamily.BE);
+
+        Member deletedMember = memberRepository.save(
+            member().name("삭제 구성원").email("deleted-member@test.com").build()
+        );
+        memberActivityRepository.saveAndFlush(semesterActivity()
+            .memberId(deletedMember.getId())
+            .semesterId(SEMESTER_ID)
+            .teamId(teamId)
+            .jobFamily(JobFamily.BE)
+            .build());
+        memberRepository.delete(deletedMember);
+
+        MemberActivity deletedActivity = saveSemesterActivity(
+            "삭제 활동",
+            "deleted-activity@test.com",
+            SEMESTER_ID,
+            teamId,
+            JobFamily.BE
+        );
+        memberActivityRepository.delete(deletedActivity);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        TeamMemberNames result = memberActivityRepository.findMemberNamesByTeamId(teamId);
+
+        // then
+        assertThat(result.backendDevelopers()).containsExactly("정상 구성원");
     }
 }

--- a/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/org/ject/support/domain/project/service/ProjectServiceTest.java
@@ -3,7 +3,7 @@ package org.ject.support.domain.project.service;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.member.dto.TeamMemberNames;
 import org.ject.support.domain.member.entity.Team;
-import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.member.repository.MemberActivityRepository;
 import org.ject.support.domain.project.dto.ProjectDetailResponse;
 import org.ject.support.domain.project.dto.ProjectIntroResponse;
 import org.ject.support.domain.project.dto.ProjectSummaryResponse;
@@ -35,7 +35,7 @@ class ProjectServiceTest extends UnitTestSupport {
     private ProjectRepository projectRepository;
 
     @Mock
-    private MemberRepository memberRepository;
+    private MemberActivityRepository memberActivityRepository;
 
     private Project project;
     private List<String> projectManagers;
@@ -72,7 +72,8 @@ class ProjectServiceTest extends UnitTestSupport {
     void 프로젝트_상세_조회() {
         // given
         when(projectRepository.findById(1L)).thenReturn(Optional.ofNullable(project));
-        //TODO: team_id 기반으로 member와 activity를 조회해도록 구현 후 검증 추가
+        when(memberActivityRepository.findMemberNamesByTeamId(1L)).thenReturn(
+                new TeamMemberNames(projectManagers, productDesigners, frontendDevelopers, backendDevelopers));
 
         // when
         ProjectDetailResponse result = projectService.findProjectDetails(1L);
@@ -81,6 +82,10 @@ class ProjectServiceTest extends UnitTestSupport {
         assertThat(result.name()).isEqualTo(project.getName());
         assertThat(result.startDate()).isEqualTo(project.getStartDate());
         assertThat(result.endDate()).isEqualTo(project.getEndDate());
+        assertThat(result.teamMemberNames().productManagers()).isEmpty();
+        assertThat(result.teamMemberNames().productDesigners()).containsExactly("designer1");
+        assertThat(result.teamMemberNames().frontendDevelopers()).containsExactly("front1", "front2");
+        assertThat(result.teamMemberNames().backendDevelopers()).containsExactly("back1", "back2", "back3");
         assertThat(result.description()).isEqualTo(project.getDescription());
         assertThat(result.serviceUrl()).isEqualTo(project.getServiceUrl());
         assertThat(result.githubUrl()).isEqualTo(project.getGithubUrl());
@@ -92,7 +97,8 @@ class ProjectServiceTest extends UnitTestSupport {
     void 프로젝트_상세_조회_시_서비스_소개서는_sequence_기준으로_오름차순_정렬() {
         // given
         when(projectRepository.findById(1L)).thenReturn(Optional.ofNullable(project));
-        //TODO: team_id 기반으로 member와 activity를 조회해도록 구현 후 검증 추가
+        when(memberActivityRepository.findMemberNamesByTeamId(1L)).thenReturn(
+                new TeamMemberNames(projectManagers, productDesigners, frontendDevelopers, backendDevelopers));
 
         // when
         ProjectDetailResponse result = projectService.findProjectDetails(1L);
@@ -117,7 +123,8 @@ class ProjectServiceTest extends UnitTestSupport {
     void 프로젝트_상세_조회_시_기술_스택을_배열_형태로_반환() {
         // given
         when(projectRepository.findById(1L)).thenReturn(Optional.ofNullable(project));
-        //TODO: team_id 기반으로 member와 activity를 조회해도록 구현 후 검증 추가
+        when(memberActivityRepository.findMemberNamesByTeamId(1L)).thenReturn(
+                new TeamMemberNames(projectManagers, productDesigners, frontendDevelopers, backendDevelopers));
 
         // when
         ProjectDetailResponse result = projectService.findProjectDetails(1L);


### PR DESCRIPTION
## #️⃣연관된 이슈

close #591

## 📝 작업 내용

- 프로젝트 상세 조회 시 `project.team_id → member_semester → member_activity → member` 경로로 팀원 이름을 조회하도록 연결했습니다.
- `member_activity.job_family`을 기준으로 PM, PD, FE, BE 이름을 기존 `TeamMemberNames` 응답 형식에 맞게 분류했습니다.
- 다른 팀과 삭제된 Member/MemberActivity를 제외하고, 구성원이 없는 팀은 직군별 빈 목록을 반환하도록 처리했습니다.
- Repository 및 Service 테스트를 추가했습니다.

### 검증

- `./gradlew test` 전체 통과
- JaCoCo 커버리지 검증 통과
- 로컬 DB의 프로젝트 1번(HowMeet) 조회 결과와 `GET /projects/1` 응답의 팀원 이름 일치 확인

## 🙏 리뷰 요구사항 (선택)

- 활동 상태는 과거 프로젝트의 완료 구성원도 노출해야 하므로 필터링하지 않고, `SEMESTER` 유형과 삭제 여부만 적용했습니다. 이 조회 기준을 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 프로젝트 상세 정보에서 팀 구성원의 이름을 직군별로 표시합니다.
  * PM, PD, 프론트엔드, 백엔드 구성원을 정확히 구분해 제공합니다.
  * 구성원이 없거나 삭제된 구성원·활동은 결과에서 제외됩니다.

* **테스트**
  * 직군별 구성원 조회, 빈 팀, 삭제 데이터 제외 시나리오를 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->