### PR TITLE
[FEAT] 일반 구성원 조회/등록 개선 및 프로젝트 페이징 수정

### DIFF
--- a/src/main/java/org/ject/support/admin/member/dto/request/MemberSemesterSearchCondition.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/MemberSemesterSearchCondition.java
@@ -1,7 +1,5 @@
 package org.ject.support.admin.member.dto.request;
 
-import java.util.List;
-
 import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.JobFamily;
@@ -29,16 +27,17 @@ public record MemberSemesterSearchCondition(
 	// 기수
 	@Positive
 	Long semesterId,
-	// 직군 (다중 선택)
-	List<JobFamily> jobFamilies,
-	// 모집 단위 (다중 선택)
-	List<RecruitTypeDetail> recruitTypeDetails,
-	// 신분 (다중 선택)
-	List<CareerDetails> careerDetails,
-	// 팀 (다중 선택)
-	List<@Positive Long> teamIds,
-	// 활동 상태 (다중 선택)
-	List<ActivityStatus> statuses
+	// 직군
+	JobFamily jobFamily,
+	// 모집 단위
+	RecruitTypeDetail recruitTypeDetail,
+	// 신분
+	CareerDetails careerDetails,
+	// 팀
+	@Positive
+	Long teamId,
+	// 활동 상태
+	ActivityStatus status
 ) {
 	//size가 없으면 기본 30개
 	public int getSizeOrDefault() {

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberService.java
@@ -16,8 +16,8 @@ public class AdminMemberService {
 	/*
 	(2026.06.23)
 	1. email로 삭제 포함 구성원 신상 전부 조회
-	2. 삭제된 구성원 존재시: isDeleted를 복구하고 새로 입력받은 값으로 덮어쓰기
-	3. 활성 구성원 존재시: 기존 값 재사용 Todo: 대체 가능한 값은 새로운 입력으로 대체
+	2. 삭제된 구성원 존재시: isDeleted 복구
+	3. 활성 구성원 존재시: 새로 입력받은 값으로 덮어쓰기
 	4. 미 존재시: 새로 생성
 	 */
 
@@ -28,18 +28,13 @@ public class AdminMemberService {
 			.orElseGet(() -> createMember(request));
 	}
 
-	// 기존 구성원 상태에 따라 재사용 또는 복구
+	// 기존 구성원 복구 후 신상정보 갱신
 	private Long useExistingMember(Member member, CreateMemberSemesterRequest request) {
 		if (member.getIsDeleted()) {
-			return restoreMember(member, request);
+			member.restore();
 		}
 
-		return member.getId();
-	}
-
-	// 삭제된 구성원 신상정보 갱신 후 복구
-	private Long restoreMember(Member member, CreateMemberSemesterRequest request) {
-		member.restore(
+		member.updateProfile(
 			request.name(),
 			request.phoneNumber(),
 			request.interestedDomains(),

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberUseCase.java
@@ -2,9 +2,7 @@ package org.ject.support.admin.member.service;
 
 import static org.ject.support.domain.member.exception.MemberErrorCode.*;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
@@ -35,7 +33,7 @@ public class AdminMemberUseCase {
 	public void createMemberSemester(CreateMemberSemesterRequest request) {
 		// 유효성 검증
 		semesterInquiryUsecase.getSemester(request.semesterId());
-		validateTeam(request.semesterId(), request.teamId());
+		validateCreateTeam(request.semesterId(), request.teamId());
 
 		// email 기준 기존 Member 조회 또는 신규 생성
 		Long memberId = adminMemberService.findOrCreateMember(request);
@@ -52,8 +50,8 @@ public class AdminMemberUseCase {
 	) {
 		// 유효성 검증
 		validateSemester(condition.semesterId());
-		validateTeams(condition.semesterId(), condition.teamIds());
-		validateStatuses(condition.statuses(), MemberType.SEMESTER);
+		validateSearchTeam(condition.semesterId(), condition.teamId());
+		validateStatus(condition.status(), MemberType.SEMESTER);
 		// size만큼 조회 + 전체 행 수 조회
 		SearchMemberSemesterPageResult pageResult = adminMemberActivityService.searchMemberSemesterList(condition);
 		// 페이징 값 처리
@@ -95,7 +93,7 @@ public class AdminMemberUseCase {
 	}
 
 	// 선택한 팀의 기수 소속 검증
-	private void validateTeam(Long semesterId, Long teamId) {
+	private void validateCreateTeam(Long semesterId, Long teamId) {
 		if (teamId == null) {
 			return;
 		}
@@ -105,9 +103,9 @@ public class AdminMemberUseCase {
 		}
 	}
 
-	// 넘겨받은 팀 목록 전체의 기수 소속 및 유효성 검증
-	private void validateTeams(Long semesterId, List<Long> teamIds) {
-		if(teamIds == null || teamIds.isEmpty()){
+	// 조회 필터 팀의 기수 소속 및 유효성 검증
+	private void validateSearchTeam(Long semesterId, Long teamId) {
+		if(teamId == null){
 			return;
 		}
 
@@ -116,18 +114,15 @@ public class AdminMemberUseCase {
 			throw new MemberException(REQUIRED_SEMESTER_FOR_TEAM_FILTER);
 		}
 
-		Set<Long> validTeamIds = new HashSet<>(
-			adminMemberTeamService.getTeamIdsBySemesterId(semesterId)
-		);
-
-		if(!validTeamIds.containsAll(teamIds)) {
+		List<Long> validTeamIds = adminMemberTeamService.getTeamIdsBySemesterId(semesterId);
+		if(!validTeamIds.contains(teamId)) {
 			throw new MemberException(NOT_FOUND_TEAM_OF_SEMESTER);
 		}
 	}
 
 	// 구성원 유형에서 허용되는 활동 상태인지 검증
-	private void validateStatuses(List<ActivityStatus> statuses, MemberType type) {
-		if (!ActivityStatus.isAllAvailableFor(statuses, type)) {
+	private void validateStatus(ActivityStatus status, MemberType type) {
+		if (status != null && !status.isAvailableFor(type)) {
 			throw new MemberException(INVALID_ACTIVITY_STATUS);
 		}
 	}

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -78,14 +78,18 @@ public class Member extends BaseTimeEntity {
             .build();
     }
 
-    // 삭제된 구성원 정보가 있는 경우 복구한 뒤 새로 입력한 값으로 덮어쓰기
-    public void restore(
+    // 삭제된 구성원 복구
+    public void restore() {
+        this.isDeleted = false;
+    }
+
+    // 기존 구성원 신상정보를 새 입력값으로 갱신
+    public void updateProfile(
         String name,
         String phoneNumber,
         List<String> interestedDomains,
         Region region
     ) {
-        this.isDeleted = false;
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.interestedDomains = interestedDomains;

--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
@@ -27,7 +27,7 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 
 	private final JPAQueryFactory jpaQueryFactory;
 
-	//다중 값은 in, 단일 값은 eq로 필터링
+	// 단일 값 기준으로 일반 구성원 필터링
 	//id기준 내림차순 - 최신순
 	//size+1개 조회
 	@Override
@@ -47,12 +47,12 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 			.join(memberSemester).on(memberSemester.id.eq(memberActivity.id))
 			.where(
 				cursorLt(condition.cursor()),
-				semesterIdIn(condition.semesterId()),
-				jobFamilyIn(condition.jobFamilies()),
-				careerDetailsIn(condition.careerDetails()),
-				teamIdIn(condition.teamIds()),
-				recruitTypeDetailIn(condition.recruitTypeDetails()),
-				statusIn(condition.statuses()),
+				semesterIdEq(condition.semesterId()),
+				jobFamilyEq(condition.jobFamily()),
+				careerDetailsEq(condition.careerDetails()),
+				teamIdEq(condition.teamId()),
+				recruitTypeDetailEq(condition.recruitTypeDetail()),
+				statusEq(condition.status()),
 				member.isDeleted.isFalse(),
 				memberActivity.isDeleted.isFalse(),
 				memberActivity.memberType.eq(MemberType.SEMESTER)
@@ -68,12 +68,12 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 			.join(member).on(member.id.eq(memberActivity.memberId))
 			.join(memberSemester).on(memberSemester.id.eq(memberActivity.id))
 			.where(
-				semesterIdIn(condition.semesterId()),
-				jobFamilyIn(condition.jobFamilies()),
-				careerDetailsIn(condition.careerDetails()),
-				teamIdIn(condition.teamIds()),
-				recruitTypeDetailIn(condition.recruitTypeDetails()),
-				statusIn(condition.statuses()),
+				semesterIdEq(condition.semesterId()),
+				jobFamilyEq(condition.jobFamily()),
+				careerDetailsEq(condition.careerDetails()),
+				teamIdEq(condition.teamId()),
+				recruitTypeDetailEq(condition.recruitTypeDetail()),
+				statusEq(condition.status()),
 				member.isDeleted.isFalse(),
 				memberActivity.isDeleted.isFalse(),
 				memberActivity.memberType.eq(MemberType.SEMESTER)
@@ -120,38 +120,33 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 		return cursor == null ? null : memberActivity.id.lt(cursor);
 	}
 
-	private BooleanExpression semesterIdIn(Long semesterId) {
+	private BooleanExpression semesterIdEq(Long semesterId) {
 		return semesterId == null ? null
 			: memberSemester.semesterId.eq(semesterId);
 	}
 
-	private BooleanExpression jobFamilyIn(List<JobFamily> jobFamilies) {
-		return jobFamilies == null || jobFamilies.isEmpty()
-			? null
-			: memberActivity.jobFamily.in(jobFamilies);
+	private BooleanExpression jobFamilyEq(JobFamily jobFamily) {
+		return jobFamily == null ? null
+			: memberActivity.jobFamily.eq(jobFamily);
 	}
 
-	private BooleanExpression careerDetailsIn(List<CareerDetails> careerDetails) {
-		return careerDetails == null || careerDetails.isEmpty()
-			? null
-			: memberActivity.careerDetails.in(careerDetails);
+	private BooleanExpression careerDetailsEq(CareerDetails careerDetails) {
+		return careerDetails == null ? null
+			: memberActivity.careerDetails.eq(careerDetails);
 	}
 
-	private BooleanExpression teamIdIn(List<Long> teamIds) {
-		return teamIds == null || teamIds.isEmpty()
-			? null
-			: memberSemester.teamId.in(teamIds);
+	private BooleanExpression teamIdEq(Long teamId) {
+		return teamId == null ? null
+			: memberSemester.teamId.eq(teamId);
 	}
 
-	private BooleanExpression recruitTypeDetailIn(List<RecruitTypeDetail> recruitTypeDetails) {
-		return recruitTypeDetails == null || recruitTypeDetails.isEmpty()
-			? null
-			: memberActivity.recruitTypeDetail.in(recruitTypeDetails);
+	private BooleanExpression recruitTypeDetailEq(RecruitTypeDetail recruitTypeDetail) {
+		return recruitTypeDetail == null ? null
+			: memberActivity.recruitTypeDetail.eq(recruitTypeDetail);
 	}
 
-	private BooleanExpression statusIn(List<ActivityStatus> statuses) {
-		return statuses == null || statuses.isEmpty()
-			? null
-			: memberActivity.activityStatus.in(statuses);
+	private BooleanExpression statusEq(ActivityStatus status) {
+		return status == null ? null
+			: memberActivity.activityStatus.eq(status);
 	}
 }

--- a/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryImpl.java
@@ -42,7 +42,8 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
 
         JPAQuery<Long> countQuery = queryFactory
                 .select(project.count())
-                .from(project);
+                .from(project)
+                .where(eqCategory(category));
 
         return PageResponse.from(content, pageable, countQuery.fetchFirst());
     }

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
@@ -230,11 +230,11 @@ class AdminMemberSemesterControllerTest {
 		mockMvc.perform(get("/admin/members/semester")
 				.param("size", "30")
 				.param("semesterId", String.valueOf(semester.getId()))
-				.param("jobFamilies", "BE")
-				.param("recruitTypeDetails", "REGULAR")
+				.param("jobFamily", "BE")
+				.param("recruitTypeDetail", "REGULAR")
 				.param("careerDetails", "EMPLOYEE")
-				.param("teamIds", String.valueOf(team.getId()))
-				.param("statuses", ActivityStatus.ACTIVE.name()))
+				.param("teamId", String.valueOf(team.getId()))
+				.param("status", ActivityStatus.ACTIVE.name()))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.status").value("SUCCESS"))
 			.andExpect(jsonPath("$.data.content", hasSize(1)))
@@ -248,7 +248,7 @@ class AdminMemberSemesterControllerTest {
 	void 팀_필터만_있으면_일반_구성원_목록을_조회하지_않는다() throws Exception {
 		// when & then
 		mockMvc.perform(get("/admin/members/semester")
-				.param("teamIds", "1"))
+				.param("teamId", "1"))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.status").value(MemberErrorCode.REQUIRED_SEMESTER_FOR_TEAM_FILTER.getCode()));
 	}
@@ -258,7 +258,7 @@ class AdminMemberSemesterControllerTest {
 	void 잘못된_enum_값이면_일반_구성원_목록을_조회하지_않는다() throws Exception {
 		// when & then
 		mockMvc.perform(get("/admin/members/semester")
-				.param("jobFamilies", "WRONG"))
+				.param("jobFamily", "WRONG"))
 			.andExpect(status().isBadRequest());
 	}
 
@@ -267,7 +267,7 @@ class AdminMemberSemesterControllerTest {
 	void 일반_구성원에서_사용할_수_없는_활동_상태면_목록을_조회하지_않는다() throws Exception {
 		// when & then
 		mockMvc.perform(get("/admin/members/semester")
-				.param("statuses", ActivityStatus.DROPOUT.name()))
+				.param("status", ActivityStatus.DROPOUT.name()))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.status").value(MemberErrorCode.INVALID_ACTIVITY_STATUS.getCode()));
 	}

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -105,18 +105,18 @@ class AdminMemberActivityServiceTest {
      */
 
     @Test
-    @DisplayName("다중 필터를 적용해서 일반 구성원 목록을 조회한다")
-    void 다중_필터를_적용해서_일반_구성원_목록을_조회한다() {
+    @DisplayName("단일 필터를 적용해서 일반 구성원 목록을 조회한다")
+    void 단일_필터를_적용해서_일반_구성원_목록을_조회한다() {
         // given
         MemberSemesterSearchCondition condition = new MemberSemesterSearchCondition(
           null,
           20,
           1L,
-          List.of(JobFamily.BE),
-          List.of(RecruitTypeDetail.REGULAR),
-          List.of(CareerDetails.EMPLOYEE),
-          List.of(1L,2L,3L),
-          List.of(ActivityStatus.ACTIVE)
+          JobFamily.BE,
+          RecruitTypeDetail.REGULAR,
+          CareerDetails.EMPLOYEE,
+          1L,
+          ActivityStatus.ACTIVE
         );
 
         List<SearchMemberSemesterProjection> projections = List.of(

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
@@ -80,13 +80,18 @@ class AdminMemberServiceTest {
 	}
 
 	@Test
-	@DisplayName("입력한 이메일로 기존 구성원이 존재하면 새로 저장하지 않는다")
-	void 입력한_이메일로_기존_구성원이_존재하면_새로_저장하지_않는다() {
+	@DisplayName("입력한 이메일로 기존 구성원이 존재하면 값을 덮어쓰고 새로 저장하지 않는다")
+	void 입력한_이메일로_기존_구성원이_존재하면_값을_덮어쓰고_새로_저장하지_않는다() {
 	    // given
 	    CreateMemberSemesterRequest request = createMemberSemesterRequest();
-		Member existMember = mock(Member.class);
-		given(existMember.getId()).willReturn(3L);
-		given(existMember.getIsDeleted()).willReturn(false);
+		Member existMember = Member.create(
+			"기존 구성원",
+			request.email(),
+			"01087654321",
+			List.of("COMMERCE"),
+			Region.BUSAN
+		);
+		ReflectionTestUtils.setField(existMember, "id", 3L);
 
 		given(memberRepository.findByEmailIncludingDeleted(request.email())).willReturn(Optional.of(existMember));
 
@@ -95,6 +100,10 @@ class AdminMemberServiceTest {
 
 	    // then
 		assertThat(memberId).isEqualTo(existMember.getId());
+		assertThat(existMember.getName()).isEqualTo(request.name());
+		assertThat(existMember.getPhoneNumber()).isEqualTo(request.phoneNumber());
+		assertThat(existMember.getInterestedDomains()).containsExactlyElementsOf(request.interestedDomains());
+		assertThat(existMember.getRegion()).isEqualTo(request.region());
 		verify(memberRepository).findByEmailIncludingDeleted(request.email());
 		verify(memberRepository, never()).save(any(Member.class));
 	}

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberUseCaseTest.java
@@ -68,15 +68,15 @@ class AdminMemberUseCaseTest {
 		);
 	}
 
-	private MemberSemesterSearchCondition searchCondition(Integer size, Long semesterId, List<Long> teamIds) {
-		return searchCondition(size, semesterId, teamIds, null);
+	private MemberSemesterSearchCondition searchCondition(Integer size, Long semesterId, Long teamId) {
+		return searchCondition(size, semesterId, teamId, null);
 	}
 
 	private MemberSemesterSearchCondition searchCondition(
 		Integer size,
 		Long semesterId,
-		List<Long> teamIds,
-		List<ActivityStatus> statuses
+		Long teamId,
+		ActivityStatus status
 	) {
 		return new MemberSemesterSearchCondition(
 			null,
@@ -85,8 +85,8 @@ class AdminMemberUseCaseTest {
 			null,
 			null,
 			null,
-			teamIds,
-			statuses
+			teamId,
+			status
 		);
 	}
 
@@ -255,7 +255,7 @@ class AdminMemberUseCaseTest {
 	@DisplayName("팀 필터만 있으면 예외가 발생한다")
 	void 팀_필터만_있으면_예외가_발생한다() {
 		// given
-		MemberSemesterSearchCondition condition = searchCondition(3, null, List.of(1L));
+		MemberSemesterSearchCondition condition = searchCondition(3, null, 1L);
 
 		// when
 		Throwable throwable = catchThrowable(() -> adminMemberUseCase.searchMemberSemester(condition));
@@ -272,7 +272,7 @@ class AdminMemberUseCaseTest {
 	@DisplayName("해당 기수에 없는 팀으로 조회하면 예외가 발생한다")
 	void 해당_기수에_없는_팀으로_조회하면_예외가_발생한다() {
 		// given
-		MemberSemesterSearchCondition condition = searchCondition(3, 1L, List.of(9L));
+		MemberSemesterSearchCondition condition = searchCondition(3, 1L, 9L);
 		given(adminMemberTeamService.getTeamIdsBySemesterId(condition.semesterId()))
 			.willReturn(List.of(1L, 2L, 3L));
 
@@ -292,7 +292,7 @@ class AdminMemberUseCaseTest {
 	@DisplayName("일반 구성원에서 사용할 수 없는 활동 상태로 조회하면 예외가 발생한다")
 	void 일반_구성원에서_사용할_수_없는_활동_상태로_조회하면_예외가_발생한다() {
 		// given
-		MemberSemesterSearchCondition condition = searchCondition(3, null, null, List.of(ActivityStatus.DROPOUT));
+		MemberSemesterSearchCondition condition = searchCondition(3, null, null, ActivityStatus.DROPOUT);
 
 		// when
 		Throwable throwable = catchThrowable(() -> adminMemberUseCase.searchMemberSemester(condition));
@@ -309,7 +309,7 @@ class AdminMemberUseCaseTest {
 	@DisplayName("일반 구성원에서 탈퇴 상태로 목록을 조회한다")
 	void 일반_구성원에서_탈퇴_상태로_목록을_조회한다() {
 		// given
-		MemberSemesterSearchCondition condition = searchCondition(3, null, null, List.of(ActivityStatus.WITHDRAWN));
+		MemberSemesterSearchCondition condition = searchCondition(3, null, null, ActivityStatus.WITHDRAWN);
 		SearchMemberSemesterPageResult pageResult = new SearchMemberSemesterPageResult(List.of(), 0L);
 		given(adminMemberActivityService.searchMemberSemesterList(condition)).willReturn(pageResult);
 

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -44,21 +44,21 @@ class MemberActivityRepositoryTest {
         Long cursor,
         Integer size,
         Long semesterId,
-        List<JobFamily> jobFamilies,
-        List<RecruitTypeDetail> recruitTypeDetails,
-        List<CareerDetails> careerDetails,
-        List<Long> teamIds,
-        List<ActivityStatus> statuses
+        JobFamily jobFamily,
+        RecruitTypeDetail recruitTypeDetail,
+        CareerDetails careerDetails,
+        Long teamId,
+        ActivityStatus status
     ) {
         return new MemberSemesterSearchCondition(
             cursor,
             size,
             semesterId,
-            jobFamilies,
-            recruitTypeDetails,
+            jobFamily,
+            recruitTypeDetail,
             careerDetails,
-            teamIds,
-            statuses
+            teamId,
+            status
         );
     }
 
@@ -361,10 +361,10 @@ class MemberActivityRepositoryTest {
             null,
             30,
             SEMESTER_ID,
-            List.of(JobFamily.BE),
-            List.of(RecruitTypeDetail.REGULAR),
-            List.of(CareerDetails.EMPLOYEE),
-            List.of(1L),
+            JobFamily.BE,
+            RecruitTypeDetail.REGULAR,
+            CareerDetails.EMPLOYEE,
+            1L,
             null
         );
 
@@ -447,7 +447,7 @@ class MemberActivityRepositoryTest {
             null,
             30,
             null,
-            List.of(JobFamily.BE),
+            JobFamily.BE,
             null,
             null,
             null,
@@ -489,7 +489,7 @@ class MemberActivityRepositoryTest {
             30,
             null,
             null,
-            List.of(RecruitTypeDetail.REGULAR),
+            RecruitTypeDetail.REGULAR,
             null,
             null,
             null
@@ -531,7 +531,7 @@ class MemberActivityRepositoryTest {
             null,
             null,
             null,
-            List.of(CareerDetails.EMPLOYEE),
+            CareerDetails.EMPLOYEE,
             null,
             null
         );
@@ -573,7 +573,7 @@ class MemberActivityRepositoryTest {
             null,
             null,
             null,
-            List.of(1L,2L,3L),
+            1L,
             null
         );
         // when
@@ -618,7 +618,7 @@ class MemberActivityRepositoryTest {
             null,
             null,
             null,
-            List.of(ActivityStatus.COMPLETED)
+            ActivityStatus.COMPLETED
         );
 
         // when
@@ -668,10 +668,10 @@ class MemberActivityRepositoryTest {
             cursor.getId(),
             30,
             SEMESTER_ID,
-            List.of(JobFamily.BE),
-            List.of(RecruitTypeDetail.REGULAR),
-            List.of(CareerDetails.EMPLOYEE),
-            List.of(1L),
+            JobFamily.BE,
+            RecruitTypeDetail.REGULAR,
+            CareerDetails.EMPLOYEE,
+            1L,
             null
         );
 

--- a/src/test/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/project/repository/ProjectQueryRepositoryTest.java
@@ -76,10 +76,33 @@ class ProjectQueryRepositoryTest {
 
         // when
         Page<ProjectResponse> result =
-                projectRepository.findProjectsByCategory(Project.Category.SEMESTER_1, PageRequest.of(0, 30));
+                projectRepository.findProjectsByCategory(Project.Category.SEMESTER_1, PageRequest.of(0, 2));
 
         // then
         assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    void 카테고리로_프로젝트_필터링_조회시_범위를_벗어난_페이지는_다음_페이지가_없음() {
+        // given
+        Project project1 = createProject(Project.Category.SEMESTER_1, team1);
+        Project project2 = createProject(Project.Category.SEMESTER_1, team2);
+        Project project3 = createProject(Project.Category.SEMESTER_2, team3);
+        Project project4 = createProject(Project.Category.SEMESTER_2, team1);
+        projectRepository.saveAll(List.of(project1, project2, project3, project4));
+
+        // when
+        Page<ProjectResponse> result =
+                projectRepository.findProjectsByCategory(Project.Category.SEMESTER_1, PageRequest.of(1, 2));
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.hasNext()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

close #597
close #598
close #599

## 📝 작업 내용

- 일반 구성원 목록 조회 필터를 단일 필터 방식으로 변경
- 일반 구성원 추가 시 기존 삭제 데이터 재사용 로직을 덮어쓰기 방식으로 변경
- 프로젝트 목록 조회 시 category 필터가 count 쿼리에도 적용되도록 수정
- 프로젝트 목록 조회 페이징 메타 데이터 회귀 테스트 보강

## 🙏 리뷰 요구사항 (선택)

작은 수정 건이 많아 작업 편의를 위해 여러 이슈를 한 번에 작업했습니다. 양해 부탁드립니다!

대신 작업 내용은 커밋 단위로 깔끔하게 나눠두었습니다!

검증 내용:
- `./gradlew test --tests org.ject.support.domain.project.repository.ProjectQueryRepositoryTest -x jacocoTestCoverageVerification`
- 로컬 API `GET /projects?category=SEMESTER_1&page=0&size=6&sort=sorted` 응답 확인
- 로컬 API `GET /projects?category=SEMESTER_1&page=1&size=6&sort=sorted` 응답 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 구성원 학기 검색 필터를 다중 선택에서 단일 선택 방식으로 변경했습니다.
  * 프로젝트 카테고리별 조회 시 전체 개수와 페이지 정보가 필터 결과와 일치하도록 개선했습니다.
  * 기존 구성원 복구 후 프로필 정보가 최신 요청 값으로 갱신됩니다.
  * 구성원 검색 시 팀과 활동 상태 조건 검증을 강화했습니다.

* **테스트**
  * 단일 필터 검색, 구성원 프로필 갱신, 페이지네이션 정보를 검증하는 테스트를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->