### PR TITLE
[FIX] 프로젝트 상세 팀원 이름 조회 활동 상태 필터 추가

### DIFF
--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
@@ -93,6 +93,7 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 			.where(
 				memberSemester.teamId.eq(teamId),
 				memberActivity.memberType.eq(MemberType.SEMESTER),
+				memberActivity.activityStatus.in(ActivityStatus.ACTIVE, ActivityStatus.COMPLETED),
 				member.isDeleted.isFalse(),
 				memberActivity.isDeleted.isFalse(),
 				member.name.isNotNull()

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -722,6 +722,31 @@ class MemberActivityRepositoryTest {
     }
 
     @Test
+    @DisplayName("활동 상태가 탈퇴인 일반 구성원은 팀원 이름 조회에서 제외한다")
+    void 활동_상태가_탈퇴인_일반_구성원은_팀원_이름_조회에서_제외한다() {
+        // given
+        Long teamId = 10L;
+        saveSemesterActivity("정상 구성원", "active-name@test.com", SEMESTER_ID, teamId, JobFamily.BE);
+
+        Member withdrawnMember = memberRepository.save(
+            member().name("탈퇴 구성원").email("withdrawn-name@test.com").build()
+        );
+        memberActivityRepository.saveAndFlush(semesterActivity()
+            .memberId(withdrawnMember.getId())
+            .semesterId(SEMESTER_ID)
+            .teamId(teamId)
+            .jobFamily(JobFamily.BE)
+            .activityStatus(ActivityStatus.WITHDRAWN)
+            .build());
+
+        // when
+        TeamMemberNames result = memberActivityRepository.findMemberNamesByTeamId(teamId);
+
+        // then
+        assertThat(result.backendDevelopers()).containsExactly("정상 구성원");
+    }
+
+    @Test
     @DisplayName("삭제된 구성원과 활동은 팀원 이름 조회에서 제외한다")
     void 삭제된_구성원과_활동은_팀원_이름_조회에서_제외한다() {
         // given


### PR DESCRIPTION
## #️⃣연관된 이슈

close #601

## 📝 작업 내용

- 프로젝트 상세 조회 시 팀원 이름 조회 대상에 활동 상태 필터 추가
- 일반 구성원 활동 상태가 `ACTIVE`, `COMPLETED`인 경우만 직군별 팀원 이름에 포함
- `WITHDRAWN` 상태 일반 구성원이 팀원 이름 조회에서 제외되는 테스트 보강

## 🙏 리뷰 요구사항 (선택)

- 프로젝트 상세 조회의 직군별 팀원 이름 응답에서 비활동 상태 구성원이 제외되는지 확인 부탁드립니다.
- 운영 코드와 테스트 코드를 각각 `[fix]`, `[test]` 커밋으로 분리했습니다.

검증 내용:
- `./gradlew test --tests org.ject.support.domain.member.repository.MemberActivityRepositoryTest -x jacocoTestCoverageVerification`
- 로컬 API 4기 프로젝트 목록 및 상세 조회 확인
