### PR TITLE
[FEAT] 메이커스팀 구성원 목록 조회 API 개발

### DIFF
--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersApiSpec.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersApiSpec.java
@@ -1,6 +1,10 @@
 package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
+import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
+import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
+import org.ject.support.common.response.CursorPageResponse;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,4 +18,10 @@ public interface AdminMemberMakersApiSpec {
 		description = "메이커스팀 구성원을 추가합니다."
 	)
 	void createAdminMemberMakers(@RequestBody @Valid CreateMemberMakersRequest request);
+
+	@Operation(
+		summary = "메이커스팀 구성원 목록 조회",
+		description = "메이커스팀 구성원 목록을 조회합니다."
+	)
+	CursorPageResponse<MemberMakersListResponse> getAdminMemberMakersList(@ModelAttribute MemberMakersListRequest request);
 }

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersController.java
@@ -1,7 +1,12 @@
 package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
+import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
+import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
 import org.ject.support.admin.member.service.AdminMemberMakersUseCase;
+import org.ject.support.common.response.CursorPageResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,5 +28,12 @@ public class AdminMemberMakersController implements AdminMemberMakersApiSpec{
 	public void createAdminMemberMakers(
 		@RequestBody @Valid CreateMemberMakersRequest request) {
 		adminMemberMakersUseCase.createMemberMakers(request);
+	}
+
+	@Override
+	@GetMapping
+	public CursorPageResponse<MemberMakersListResponse> getAdminMemberMakersList(
+		@ModelAttribute @Valid MemberMakersListRequest request) {
+		return adminMemberMakersUseCase.getMemberMakersList(request);
 	}
 }

--- a/src/main/java/org/ject/support/admin/member/dto/projection/MemberMakersListProjection.java
+++ b/src/main/java/org/ject/support/admin/member/dto/projection/MemberMakersListProjection.java
@@ -1,0 +1,19 @@
+package org.ject.support.admin.member.dto.projection;
+
+import org.ject.support.domain.member.ActivityStatus;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MakersTeam;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+
+public record MemberMakersListProjection(
+	Long memberActivityId,
+	String name,
+	String email,
+	String phoneNumber,
+	JobFamily jobFamily,
+	MakersTeam makersTeam,
+	RecruitTypeDetail recruitTypeDetail,
+	ActivityStatus activityStatus,
+	String memo
+) {
+}

--- a/src/main/java/org/ject/support/admin/member/dto/request/MemberMakersListRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/MemberMakersListRequest.java
@@ -1,0 +1,20 @@
+package org.ject.support.admin.member.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+
+public record MemberMakersListRequest(
+	@Positive
+	Long cursor,
+
+	// 정책 변경에 대비해 여유롭게 설정
+	@Min(1)
+	@Max(100)
+	Integer size
+) {
+	//size가 없으면 기본 30개
+	public int getSizeOrDefault() {
+		return size == null ? 30 : size;
+	}
+}

--- a/src/main/java/org/ject/support/admin/member/dto/response/MemberMakersListResponse.java
+++ b/src/main/java/org/ject/support/admin/member/dto/response/MemberMakersListResponse.java
@@ -1,0 +1,33 @@
+package org.ject.support.admin.member.dto.response;
+
+import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
+import org.ject.support.domain.member.ActivityStatus;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MakersTeam;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+
+public record MemberMakersListResponse(
+	Long memberActivityId,
+	String name,
+	String email,
+	String phoneNumber,
+	JobFamily jobFamily,
+	MakersTeam makersTeam,
+	RecruitTypeDetail recruitTypeDetail,
+	ActivityStatus activityStatus,
+	String memo
+) {
+	public static MemberMakersListResponse from(MemberMakersListProjection projection) {
+		return new MemberMakersListResponse(
+			projection.memberActivityId(),
+			projection.name(),
+			projection.email(),
+			projection.phoneNumber(),
+			projection.jobFamily(),
+			projection.makersTeam(),
+			projection.recruitTypeDetail(),
+			projection.activityStatus(),
+			projection.memo()
+		);
+	}
+}

--- a/src/main/java/org/ject/support/admin/member/dto/result/MemberMakersListPageResult.java
+++ b/src/main/java/org/ject/support/admin/member/dto/result/MemberMakersListPageResult.java
@@ -1,0 +1,11 @@
+package org.ject.support.admin.member.dto.result;
+
+import java.util.List;
+
+import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
+
+public record MemberMakersListPageResult(
+	List<MemberMakersListProjection> content,
+	long totalCount
+) {
+}

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
@@ -1,9 +1,12 @@
 package org.ject.support.admin.member.service;
 
+import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
+import org.ject.support.admin.member.dto.result.MemberMakersListPageResult;
 import org.ject.support.admin.member.dto.result.SearchMemberSemesterPageResult;
 import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.entity.MemberActivity;
@@ -45,6 +48,7 @@ public class AdminMemberActivityService {
 		memberActivityRepository.save(memberActivity);
 	}
 
+	// 메이커스팀 구성원 추가
 	public void createMemberMakersActivity(CreateMemberMakersRequest request, Long memberId) {
 		// 추가하려는 대상이 이미 활동 중인 상태인지 검증
 		validateDuplicateActiveMakersActivity(memberId);
@@ -80,6 +84,12 @@ public class AdminMemberActivityService {
 		return new SearchMemberSemesterPageResult(projections, totalCount);
 	}
 
+	// 메이커스팀 구성원 목록 조회
+	public MemberMakersListPageResult getMemberMakersList(MemberMakersListRequest request) {
+		List<MemberMakersListProjection> projections = memberActivityRepository.findMemberMakersList(request.cursor(), request.getSizeOrDefault()+1);
+		long count = memberActivityRepository.countMemberMakersList();
+		return new MemberMakersListPageResult(projections, count);
+	}
 
 	/*
 	유틸, 검증 함수

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberMakersUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberMakersUseCase.java
@@ -1,6 +1,13 @@
 package org.ject.support.admin.member.service;
 
+import java.util.List;
+
+import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
+import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
+import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
+import org.ject.support.admin.member.dto.result.MemberMakersListPageResult;
+import org.ject.support.common.response.CursorPageResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,5 +29,35 @@ public class AdminMemberMakersUseCase {
 
 		// memberId 기준 MemberActivity와 MemberMakers 생성 및 저장
 		adminMemberActivityService.createMemberMakersActivity(request, memberId);
+	}
+
+	@Transactional(readOnly = true)
+	public CursorPageResponse<MemberMakersListResponse> getMemberMakersList(MemberMakersListRequest request) {
+		// 목록 조회
+		MemberMakersListPageResult pageResult = adminMemberActivityService.getMemberMakersList(request);
+
+		// 페이징 값 처리
+		boolean hasNext = pageResult.content().size() > request.getSizeOrDefault();
+		long totalCount = pageResult.totalCount();
+		List<MemberMakersListProjection> content = hasNext
+			? pageResult.content().subList(0, request.getSizeOrDefault())
+			: pageResult.content();
+
+		List<MemberMakersListResponse> responses = content.stream()
+			.map(MemberMakersListResponse::from)
+			.toList();
+
+		Long nextCursor = hasNext && !content.isEmpty()
+			? content.get(content.size() - 1).memberActivityId()
+			: null;
+
+		// 응답
+		return CursorPageResponse.of(
+			responses,
+			request.getSizeOrDefault(),
+			hasNext,
+			nextCursor,
+			totalCount
+		);
 	}
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepository.java
@@ -2,6 +2,7 @@ package org.ject.support.domain.member.repository;
 
 import java.util.List;
 
+import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
 import org.ject.support.domain.member.dto.TeamMemberNames;
@@ -15,4 +16,8 @@ public interface MemberActivityQueryRepository {
 	long countMemberSemesters(MemberSemesterSearchCondition conditon);
 
 	TeamMemberNames findMemberNamesByTeamId(Long teamId);
+
+	List<MemberMakersListProjection> findMemberMakersList(Long cursor, Integer limit);
+
+	long countMemberMakersList();
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
@@ -2,10 +2,12 @@ package org.ject.support.domain.member.repository;
 
 import static org.ject.support.domain.member.entity.QMember.*;
 import static org.ject.support.domain.member.entity.QMemberActivity.*;
+import static org.ject.support.domain.member.entity.QMemberMakers.*;
 import static org.ject.support.domain.member.entity.QMemberSemester.*;
 
 import java.util.List;
 
+import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
 import org.ject.support.domain.member.ActivityStatus;
@@ -107,6 +109,48 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 			findNamesByJobFamily(teamMembers, JobFamily.FE),
 			findNamesByJobFamily(teamMembers, JobFamily.BE)
 		);
+	}
+
+	@Override
+	public List<MemberMakersListProjection> findMemberMakersList(Long cursor, Integer limit) {
+		return jpaQueryFactory.select(Projections.constructor(
+			MemberMakersListProjection.class,
+			memberActivity.id,
+			member.name,
+			member.email,
+			member.phoneNumber,
+			memberActivity.jobFamily,
+			memberMakers.makersTeam,
+			memberActivity.recruitTypeDetail,
+			memberActivity.activityStatus,
+			memberActivity.memo
+		))
+			.from(member)
+			.join(memberActivity).on(member.id.eq(memberActivity.memberId))
+			.join(memberMakers).on(memberActivity.id.eq(memberMakers.id))
+			.where(
+				cursorLt(cursor),
+				member.isDeleted.isFalse(),
+				memberActivity.isDeleted.isFalse(),
+				memberActivity.memberType.eq(MemberType.MAKERS)
+			).orderBy(memberActivity.id.desc())
+			.limit(limit)
+			.fetch();
+
+	}
+
+	@Override
+	public long countMemberMakersList() {
+		Long count = jpaQueryFactory.select(memberActivity.id.count())
+			.from(memberActivity)
+			.join(member).on(member.id.eq(memberActivity.memberId))
+			.where(
+				member.isDeleted.isFalse(),
+				memberActivity.isDeleted.isFalse(),
+				memberActivity.memberType.eq(MemberType.MAKERS)
+			).fetchOne();
+
+		return count == null ? 0L : count;
 	}
 
 	// 조회 결과에서 지정 직군의 이름만 분리

--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
@@ -144,6 +144,7 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 		Long count = jpaQueryFactory.select(memberActivity.id.count())
 			.from(memberActivity)
 			.join(member).on(member.id.eq(memberActivity.memberId))
+			.join(memberMakers).on(memberActivity.id.eq(memberMakers.id))
 			.where(
 				member.isDeleted.isFalse(),
 				memberActivity.isDeleted.isFalse(),

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
@@ -1,7 +1,10 @@
 package org.ject.support.admin.member.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.ject.support.domain.member.fixture.MakersActivityFixture.makersActivity;
 import static org.ject.support.domain.member.fixture.MemberFixture.member;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -145,6 +148,89 @@ class AdminMemberMakersControllerTest {
 		assertThat(memberActivity.getMemberMakers().getMakersTeam()).isEqualTo(request.makersTeam());
 	}
 
+	@Test
+	@DisplayName("메이커스팀 구성원 목록을 조회한다")
+	void 메이커스팀_구성원_목록을_조회한다() throws Exception {
+		// given
+		MemberActivity firstActivity = saveMakersActivity(uniqueEmail("list1"), JobFamily.FE, MakersTeam.TEAM_1);
+		MemberActivity secondActivity = saveMakersActivity(uniqueEmail("list2"), JobFamily.BE, MakersTeam.TEAM_2);
+
+		// when & then
+		mockMvc.perform(get("/admin/members/makers")
+				.param("size", "30"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("SUCCESS"))
+			.andExpect(jsonPath("$.data.content").isArray())
+			.andExpect(jsonPath("$.data.content[0].memberActivityId").value(secondActivity.getId()))
+			.andExpect(jsonPath("$.data.content[0].jobFamily").value(JobFamily.BE.name()))
+			.andExpect(jsonPath("$.data.content[0].makersTeam").value(MakersTeam.TEAM_2.name()))
+			.andExpect(jsonPath("$.data.content[1].memberActivityId").value(firstActivity.getId()))
+			.andExpect(jsonPath("$.data.size").value(30))
+			.andExpect(jsonPath("$.data.hasNext").value(false))
+			.andExpect(jsonPath("$.data.nextCursor").value(nullValue()))
+			.andExpect(jsonPath("$.data.totalCount").value(2));
+	}
+
+	@Test
+	@DisplayName("cursor 이후 메이커스팀 구성원 목록을 조회한다")
+	void cursor_이후_메이커스팀_구성원_목록을_조회한다() throws Exception {
+		// given
+		MemberActivity firstActivity = saveMakersActivity(uniqueEmail("cursor1"), JobFamily.FE, MakersTeam.TEAM_1);
+		MemberActivity secondActivity = saveMakersActivity(uniqueEmail("cursor2"), JobFamily.BE, MakersTeam.TEAM_1);
+		MemberActivity thirdActivity = saveMakersActivity(uniqueEmail("cursor3"), JobFamily.PM, MakersTeam.TEAM_2);
+
+		mockMvc.perform(get("/admin/members/makers")
+				.param("size", "2"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content[0].memberActivityId").value(thirdActivity.getId()))
+			.andExpect(jsonPath("$.data.content[1].memberActivityId").value(secondActivity.getId()))
+			.andExpect(jsonPath("$.data.hasNext").value(true))
+			.andExpect(jsonPath("$.data.nextCursor").value(secondActivity.getId()))
+			.andExpect(jsonPath("$.data.totalCount").value(3));
+
+		// when & then
+		mockMvc.perform(get("/admin/members/makers")
+				.param("cursor", String.valueOf(secondActivity.getId()))
+				.param("size", "2"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("SUCCESS"))
+			.andExpect(jsonPath("$.data.content[0].memberActivityId").value(firstActivity.getId()))
+			.andExpect(jsonPath("$.data.hasNext").value(false))
+			.andExpect(jsonPath("$.data.nextCursor").value(nullValue()))
+			.andExpect(jsonPath("$.data.totalCount").value(3));
+	}
+
+	@Test
+	@DisplayName("size가 1보다 작으면 메이커스팀 구성원 목록을 조회하지 않는다")
+	void size가_1보다_작으면_메이커스팀_구성원_목록을_조회하지_않는다() throws Exception {
+		// when & then
+		mockMvc.perform(get("/admin/members/makers")
+				.param("size", "0"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
+	}
+
+	@Test
+	@DisplayName("size가 100보다 크면 메이커스팀 구성원 목록을 조회하지 않는다")
+	void size가_100보다_크면_메이커스팀_구성원_목록을_조회하지_않는다() throws Exception {
+		// when & then
+		mockMvc.perform(get("/admin/members/makers")
+				.param("size", "101"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
+	}
+
+	@Test
+	@DisplayName("cursor가 1보다 작으면 메이커스팀 구성원 목록을 조회하지 않는다")
+	void cursor가_1보다_작으면_메이커스팀_구성원_목록을_조회하지_않는다() throws Exception {
+		// when & then
+		mockMvc.perform(get("/admin/members/makers")
+				.param("cursor", "0")
+				.param("size", "2"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
+	}
+
 	private CreateMemberMakersRequest createMemberMakersRequest(String email) {
 		return new CreateMemberMakersRequest(
 			"김메이커",
@@ -176,6 +262,18 @@ class AdminMemberMakersControllerTest {
 
 		assertThat(activities).hasSize(1);
 		return activities.get(0);
+	}
+
+	private MemberActivity saveMakersActivity(String email, JobFamily jobFamily, MakersTeam makersTeam) {
+		Member member = memberRepository.save(member()
+			.email(email)
+			.build());
+
+		return memberActivityRepository.saveAndFlush(makersActivity()
+			.memberId(member.getId())
+			.jobFamily(jobFamily)
+			.makersTeam(makersTeam)
+			.build());
 	}
 
 	private String uniqueEmail(String prefix) {

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberMakersUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberMakersUseCaseTest.java
@@ -1,0 +1,104 @@
+package org.ject.support.admin.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+
+import java.util.List;
+import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
+import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
+import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
+import org.ject.support.admin.member.dto.result.MemberMakersListPageResult;
+import org.ject.support.common.response.CursorPageResponse;
+import org.ject.support.domain.member.ActivityStatus;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MakersTeam;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminMemberMakersUseCaseTest {
+
+	@Mock
+	private AdminMemberService adminMemberService;
+
+	@Mock
+	private AdminMemberActivityService adminMemberActivityService;
+
+	@InjectMocks
+	private AdminMemberMakersUseCase adminMemberMakersUseCase;
+
+	@Test
+	@DisplayName("조회 결과가 size보다 많으면 다음 커서를 반환한다")
+	void 조회_결과가_size보다_많으면_다음_커서를_반환한다() {
+		// given
+		MemberMakersListRequest request = new MemberMakersListRequest(null, 2);
+		MemberMakersListPageResult pageResult = new MemberMakersListPageResult(
+			List.of(
+				makersProjection(5L, "첫번째"),
+				makersProjection(4L, "두번째"),
+				makersProjection(3L, "세번째")
+			),
+			3L
+		);
+		given(adminMemberActivityService.getMemberMakersList(request)).willReturn(pageResult);
+
+		// when
+		CursorPageResponse<MemberMakersListResponse> response =
+			adminMemberMakersUseCase.getMemberMakersList(request);
+
+		// then
+		assertThat(response.content()).hasSize(2);
+		assertThat(response.content())
+			.extracting(MemberMakersListResponse::memberActivityId)
+			.containsExactly(5L, 4L);
+		assertThat(response.hasNext()).isTrue();
+		assertThat(response.nextCursor()).isEqualTo(4L);
+		assertThat(response.totalCount()).isEqualTo(3L);
+		verify(adminMemberActivityService).getMemberMakersList(request);
+	}
+
+	@Test
+	@DisplayName("조회 결과가 size보다 적으면 다음 커서를 반환하지 않는다")
+	void 조회_결과가_size보다_적으면_다음_커서를_반환하지_않는다() {
+		// given
+		MemberMakersListRequest request = new MemberMakersListRequest(4L, 3);
+		MemberMakersListPageResult pageResult = new MemberMakersListPageResult(
+			List.of(
+				makersProjection(3L, "첫번째"),
+				makersProjection(2L, "두번째")
+			),
+			2L
+		);
+		given(adminMemberActivityService.getMemberMakersList(request)).willReturn(pageResult);
+
+		// when
+		CursorPageResponse<MemberMakersListResponse> response =
+			adminMemberMakersUseCase.getMemberMakersList(request);
+
+		// then
+		assertThat(response.content()).hasSize(2);
+		assertThat(response.hasNext()).isFalse();
+		assertThat(response.nextCursor()).isNull();
+		assertThat(response.totalCount()).isEqualTo(2L);
+	}
+
+	private MemberMakersListProjection makersProjection(Long memberActivityId, String name) {
+		return new MemberMakersListProjection(
+			memberActivityId,
+			name,
+			name + "@ject.kr",
+			"01012345678",
+			JobFamily.FE,
+			MakersTeam.TEAM_1,
+			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ACTIVE,
+			"memo"
+		);
+	}
+}

--- a/src/test/java/org/ject/support/domain/member/fixture/MakersActivityFixture.java
+++ b/src/test/java/org/ject/support/domain/member/fixture/MakersActivityFixture.java
@@ -1,0 +1,59 @@
+package org.ject.support.domain.member.fixture;
+
+import org.ject.support.domain.member.Availability;
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.CareerLevel;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MakersTeam;
+import org.ject.support.domain.member.entity.MemberActivity;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+
+public final class MakersActivityFixture {
+
+    private Long memberId = 1L;
+    private JobFamily jobFamily = JobFamily.FE;
+    private MakersTeam makersTeam = MakersTeam.TEAM_1;
+
+    private MakersActivityFixture() {
+    }
+
+    public static MakersActivityFixture makersActivity() {
+        return new MakersActivityFixture();
+    }
+
+    public MakersActivityFixture memberId(Long memberId) {
+        this.memberId = memberId;
+        return this;
+    }
+
+    public MakersActivityFixture jobFamily(JobFamily jobFamily) {
+        this.jobFamily = jobFamily;
+        return this;
+    }
+
+    public MakersActivityFixture makersTeam(MakersTeam makersTeam) {
+        this.makersTeam = makersTeam;
+        return this;
+    }
+
+    public MemberActivity build() {
+        return MemberActivity.createMakersActivity(
+            memberId,
+            jobFamily,
+            RecruitTypeDetail.REGULAR,
+            CareerDetails.EMPLOYEE,
+            ExperiencePeriod.ONE_TO_TWO,
+            "테스트 메모",
+            makersTeam,
+            Availability.HIGHLY_AVAILABLE,
+            Availability.AVAILABLE_BY_TOPIC,
+            Availability.CONSIDER_LATER,
+            CareerLevel.JUNIOR,
+            "Spring",
+            "JECT",
+            "백오피스",
+            "MK-001"
+        );
+    }
+}

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -1,11 +1,14 @@
 package org.ject.support.domain.member.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.member.fixture.MakersActivityFixture.*;
 import static org.ject.support.domain.member.fixture.MemberFixture.member;
 import static org.ject.support.domain.member.fixture.SemesterActivityFixture.semesterActivity;
 
 import jakarta.persistence.EntityManager;
 import java.util.List;
+
+import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
 import org.ject.support.domain.member.ActivityStatus;
@@ -834,5 +837,93 @@ class MemberActivityRepositoryTest {
 
         // then
         assertThat(result.backendDevelopers()).containsExactly("정상 구성원");
+    }
+    @Test
+    @DisplayName("메이커스팀 구성원 목록을 최신순으로 조회한다")
+    void 메이커스팀_구성원_목록을_최신순으로_조회한다() {
+        // given
+        Member first = memberRepository.save(member().email("makers1@test.com").build());
+        Member second = memberRepository.save(member().email("makers2@test.com").build());
+        Member third = memberRepository.save(member().email("makers3@test.com").build());
+
+        MemberActivity firstAcivity = memberActivityRepository.saveAndFlush(makersActivity().memberId(first.getId()).build());
+        MemberActivity secondAcivity = memberActivityRepository.saveAndFlush(makersActivity().memberId(second.getId()).build());
+        MemberActivity thirdAcivity = memberActivityRepository.saveAndFlush(makersActivity().memberId(third.getId()).build());
+        // when
+        List<MemberMakersListProjection> projections = memberActivityRepository.findMemberMakersList(null,4);
+        // then
+        assertThat(projections).hasSize(3);
+        assertThat(projections)
+            .extracting(MemberMakersListProjection::memberActivityId)
+            .containsExactly(
+                thirdAcivity.getId(),
+                secondAcivity.getId(),
+                firstAcivity.getId()
+            );
+    }
+
+    @Test
+    @DisplayName("cursor 이후 메이커스팀 구성원 목록을 조회한다")
+    void cursor_이후_메이커스팀_구성원_목록을_조회한다() {
+        // given
+        Member first = memberRepository.save(member().email("makers1@test.com").build());
+        Member second = memberRepository.save(member().email("makers2@test.com").build());
+        Member third = memberRepository.save(member().email("makers3@test.com").build());
+
+        MemberActivity firstAcivity = memberActivityRepository.saveAndFlush(makersActivity().memberId(first.getId()).build());
+        MemberActivity secondAcivity = memberActivityRepository.saveAndFlush(makersActivity().memberId(second.getId()).build());
+        MemberActivity thirdAcivity = memberActivityRepository.saveAndFlush(makersActivity().memberId(third.getId()).build());
+
+        Long cursor = thirdAcivity.getId().longValue();
+        // when
+        List<MemberMakersListProjection> projections = memberActivityRepository.findMemberMakersList(cursor,4);
+        // then
+        assertThat(projections).hasSize(2);
+        assertThat(projections)
+            .extracting(MemberMakersListProjection::memberActivityId)
+            .containsExactly(
+                secondAcivity.getId(),
+                firstAcivity.getId()
+            );
+    }
+
+    @Test
+    @DisplayName("메이커스팀 구성원 목록 전체 개수를 조회한다")
+    void 메이커스팀_구성원_목록_전체_개수를_조회한다() {
+        // given
+        Member first = memberRepository.save(member().email("makers1@test.com").build());
+        Member second = memberRepository.save(member().email("makers2@test.com").build());
+        Member third = memberRepository.save(member().email("makers3@test.com").build());
+
+        memberActivityRepository.saveAndFlush(makersActivity().memberId(first.getId()).build());
+        memberActivityRepository.saveAndFlush(makersActivity().memberId(second.getId()).build());
+        memberActivityRepository.saveAndFlush(makersActivity().memberId(third.getId()).build());
+        // when
+        long count = memberActivityRepository.countMemberMakersList();
+        // then
+        assertThat(count).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("일반 구성원 활동은 메이커스팀 목록에서 제외한다")
+    void 일반_구성원_활동은_메이커스팀_목록에서_제외한다() {
+        // given
+        Member first = memberRepository.save(member().email("makers1@test.com").build());
+        Member second = memberRepository.save(member().email("makers2@test.com").build());
+        Member semester = memberRepository.save(member().email("semester1@test.com").build());
+
+        MemberActivity firstActivity = memberActivityRepository.saveAndFlush(makersActivity().memberId(first.getId()).build());
+        MemberActivity secondActivity = memberActivityRepository.saveAndFlush(makersActivity().memberId(second.getId()).build());
+        MemberActivity semesterActivity = memberActivityRepository.saveAndFlush(semesterActivity().memberId(semester.getId()).build());
+        // when
+        List<MemberMakersListProjection> projections = memberActivityRepository.findMemberMakersList(null,4);
+        // then
+        assertThat(projections).hasSize(2);
+        assertThat(projections)
+            .extracting(MemberMakersListProjection::memberActivityId)
+            .containsExactly(
+                secondActivity.getId(),
+                firstActivity.getId()
+            );
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #538

## 📝 작업 내용

- 메이커스팀 구성원 목록 조회 요청/응답 DTO를 추가했습니다.
- GET `/admin/members/makers` 목록 조회 API를 연결했습니다.
- QueryDSL 기반 cursor 목록 조회 및 전체 개수 조회 쿼리를 구현했습니다.
- service, controller E2E, repository 테스트를 보강했습니다.

## 🙏 리뷰 요구사항 (선택)

변경 흐름을 DTO, API 연결, 쿼리 구현, 테스트 보강 커밋으로 나누어 두었습니다. 가능하면 커밋 단위로 리뷰 부탁드립니다.

관련 테스트는 통과 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 관리자에서 메이커스팀 구성원 목록을 조회할 수 있습니다.
  * 이름, 연락처, 직군, 팀, 모집 유형, 활동 상태, 메모 등 상세 정보를 제공합니다.
  * 커서 기반 페이지 이동과 전체 개수 제공을 지원합니다.
* **개선**
  * 조회 파라미터(커서/페이지 크기) 입력값을 검증하고, 페이지 크기 기본값을 적용합니다.
* **테스트**
  * 목록 정렬, 커서 이동, 전체 개수 매핑, 잘못된 입력에 대한 검증을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->