### PR TITLE
[FEAT] 메이커스팀 구성원 상세 조회 API 개발

### DIFF
--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersApiSpec.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersApiSpec.java
@@ -2,9 +2,11 @@ package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
+import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
 import org.ject.support.common.response.CursorPageResponse;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,4 +26,10 @@ public interface AdminMemberMakersApiSpec {
 		description = "메이커스팀 구성원 목록을 조회합니다."
 	)
 	CursorPageResponse<MemberMakersListResponse> getAdminMemberMakersList(@ModelAttribute MemberMakersListRequest request);
+
+	@Operation(
+		summary = "메이커스팀 구성원 상세 조회",
+		description = "메이커스팀 구성원을 상세 조회합니다."
+	)
+	MemberMakersDetailResponse getAdminMemberMakersDetail(@PathVariable Long memberActivityId);
 }

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersController.java
@@ -2,11 +2,13 @@ package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
+import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
 import org.ject.support.admin.member.service.AdminMemberMakersUseCase;
 import org.ject.support.common.response.CursorPageResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,4 +38,11 @@ public class AdminMemberMakersController implements AdminMemberMakersApiSpec{
 		@ModelAttribute @Valid MemberMakersListRequest request) {
 		return adminMemberMakersUseCase.getMemberMakersList(request);
 	}
+
+	@Override
+	@GetMapping("/{memberActivityId}")
+	public MemberMakersDetailResponse getAdminMemberMakersDetail(@PathVariable(name = "memberActivityId") Long memberActivityId) {
+		return adminMemberMakersUseCase.getMemberMakersDetail(memberActivityId);
+	}
+
 }

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersController.java
@@ -41,7 +41,7 @@ public class AdminMemberMakersController implements AdminMemberMakersApiSpec{
 
 	@Override
 	@GetMapping("/{memberActivityId}")
-	public MemberMakersDetailResponse getAdminMemberMakersDetail(@PathVariable(name = "memberActivityId") Long memberActivityId) {
+	public MemberMakersDetailResponse getAdminMemberMakersDetail(@PathVariable Long memberActivityId) {
 		return adminMemberMakersUseCase.getMemberMakersDetail(memberActivityId);
 	}
 

--- a/src/main/java/org/ject/support/admin/member/dto/projection/MemberMakersDetailProjection.java
+++ b/src/main/java/org/ject/support/admin/member/dto/projection/MemberMakersDetailProjection.java
@@ -1,0 +1,59 @@
+package org.ject.support.admin.member.dto.projection;
+
+import java.util.List;
+
+import org.ject.support.domain.member.ActivityStatus;
+import org.ject.support.domain.member.Availability;
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.CareerLevel;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MakersTeam;
+import org.ject.support.domain.member.Region;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+
+public record MemberMakersDetailProjection(
+	Long id,
+
+	String name,
+
+	String email,
+
+	String phoneNumber,
+
+	JobFamily jobFamily,
+
+	CareerDetails careerDetails,
+
+	MakersTeam makersTeam,
+
+	RecruitTypeDetail recruitTypeDetail,
+
+	Region region,
+
+	List<String> interestedDomains,
+
+	ExperiencePeriod experiencePeriod,
+
+	Availability mentoringAvailability,
+
+	Availability projectSupplementAvailability,
+
+	Availability speakerAvailability,
+
+	CareerLevel careerLevel,
+
+	ActivityStatus activityStatus,
+
+	String skills,
+
+	String company,
+
+	String expertTopics,
+
+	String activityCertNumber,
+
+	String memo
+
+) {
+}

--- a/src/main/java/org/ject/support/admin/member/dto/response/MemberMakersDetailResponse.java
+++ b/src/main/java/org/ject/support/admin/member/dto/response/MemberMakersDetailResponse.java
@@ -1,0 +1,85 @@
+package org.ject.support.admin.member.dto.response;
+
+import java.util.List;
+
+import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
+import org.ject.support.domain.member.ActivityStatus;
+import org.ject.support.domain.member.Availability;
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.CareerLevel;
+import org.ject.support.domain.member.ExperiencePeriod;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MakersTeam;
+import org.ject.support.domain.member.Region;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+
+public record MemberMakersDetailResponse(
+	Long id,
+
+	String name,
+
+	String email,
+
+	String phoneNumber,
+
+	JobFamily jobFamily,
+
+	CareerDetails careerDetails,
+
+	MakersTeam makersTeam,
+
+	RecruitTypeDetail recruitTypeDetail,
+
+	Region region,
+
+	List<String> interestedDomains,
+
+	ExperiencePeriod experiencePeriod,
+
+	Availability mentoringAvailability,
+
+	Availability projectSupplementAvailability,
+
+	Availability speakerAvailability,
+
+	CareerLevel careerLevel,
+
+	ActivityStatus activityStatus,
+
+	String skills,
+
+	String company,
+
+	String expertTopics,
+
+	String activityCertNumber,
+
+	String memo
+
+) {
+	public static MemberMakersDetailResponse from(MemberMakersDetailProjection projection) {
+		return new MemberMakersDetailResponse(
+			projection.id(),
+			projection.name(),
+			projection.email(),
+			projection.phoneNumber(),
+			projection.jobFamily(),
+			projection.careerDetails(),
+			projection.makersTeam(),
+			projection.recruitTypeDetail(),
+			projection.region(),
+			projection.interestedDomains(),
+			projection.experiencePeriod(),
+			projection.mentoringAvailability(),
+			projection.projectSupplementAvailability(),
+			projection.speakerAvailability(),
+			projection.careerLevel(),
+			projection.activityStatus(),
+			projection.skills(),
+			projection.company(),
+			projection.expertTopics(),
+			projection.activityCertNumber(),
+			projection.memo()
+		);
+	}
+}

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
@@ -1,5 +1,8 @@
 package org.ject.support.admin.member.service;
 
+import static org.ject.support.domain.member.exception.MemberErrorCode.*;
+
+import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
@@ -16,9 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-
-import static org.ject.support.domain.member.exception.MemberErrorCode.ALREADY_EXIST_ACTIVE_MEMBER_MAKERS_ACTIVITY;
-import static org.ject.support.domain.member.exception.MemberErrorCode.ALREADY_EXIST_MEMBER_SEMESTER_ACTIVITY;
 
 import java.util.List;
 
@@ -91,6 +91,11 @@ public class AdminMemberActivityService {
 		return new MemberMakersListPageResult(projections, count);
 	}
 
+	// 메이커스팀 구성원 상세 조회
+	public MemberMakersDetailProjection getMemberMakersDetail(Long memberActivityId) {
+		return memberActivityRepository.findMemberMakersDetail(memberActivityId)
+			.orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+	}
 	/*
 	유틸, 검증 함수
 	 */

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberMakersUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberMakersUseCase.java
@@ -2,9 +2,11 @@ package org.ject.support.admin.member.service;
 
 import java.util.List;
 
+import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
+import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
 import org.ject.support.admin.member.dto.result.MemberMakersListPageResult;
 import org.ject.support.common.response.CursorPageResponse;
@@ -31,6 +33,7 @@ public class AdminMemberMakersUseCase {
 		adminMemberActivityService.createMemberMakersActivity(request, memberId);
 	}
 
+	// 메이커스팀 구성원 목록 조회(커서 기반 페이징)
 	@Transactional(readOnly = true)
 	public CursorPageResponse<MemberMakersListResponse> getMemberMakersList(MemberMakersListRequest request) {
 		// 목록 조회
@@ -59,5 +62,12 @@ public class AdminMemberMakersUseCase {
 			nextCursor,
 			totalCount
 		);
+	}
+
+	// 메이커스팀 구성원 상세조회
+	@Transactional(readOnly = true)
+	public MemberMakersDetailResponse getMemberMakersDetail(Long memberActivityId) {
+		MemberMakersDetailProjection projection = adminMemberActivityService.getMemberMakersDetail(memberActivityId);
+		return MemberMakersDetailResponse.from(projection);
 	}
 }

--- a/src/main/java/org/ject/support/domain/member/entity/Member.java
+++ b/src/main/java/org/ject/support/domain/member/entity/Member.java
@@ -95,4 +95,9 @@ public class Member extends BaseTimeEntity {
         this.interestedDomains = interestedDomains;
         this.region = region;
     }
+
+    // 구성원 삭제 처리
+    public void delete(){
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
@@ -167,4 +167,9 @@ public class MemberActivity extends BaseTimeEntity {
 
         this.activityStatus = activityStatus;
     }
+
+    // 구성원 활동 삭제 처리
+    public void delete(){
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepository.java
@@ -1,7 +1,9 @@
 package org.ject.support.domain.member.repository;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
@@ -20,4 +22,6 @@ public interface MemberActivityQueryRepository {
 	List<MemberMakersListProjection> findMemberMakersList(Long cursor, Integer limit);
 
 	long countMemberMakersList();
+
+	Optional<MemberMakersDetailProjection> findMemberMakersDetail(Long memberActivityId);
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
@@ -6,7 +6,9 @@ import static org.ject.support.domain.member.entity.QMemberMakers.*;
 import static org.ject.support.domain.member.entity.QMemberSemester.*;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
@@ -26,6 +28,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRepository {
+
+	//Todo: 구성원 관리의모든 dto 필드명을 엔티티 기준으로 재정렬
 
 	private final JPAQueryFactory jpaQueryFactory;
 
@@ -152,6 +156,47 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 			).fetchOne();
 
 		return count == null ? 0L : count;
+	}
+
+	@Override
+	public Optional<MemberMakersDetailProjection> findMemberMakersDetail(Long memberActivityId) {
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.select(Projections.constructor(
+					MemberMakersDetailProjection.class,
+					memberActivity.id,
+					member.name,
+					member.email,
+					member.phoneNumber,
+					memberActivity.jobFamily,
+					memberActivity.careerDetails,
+					memberMakers.makersTeam,
+					memberActivity.recruitTypeDetail,
+					member.region,
+					member.interestedDomains,
+					memberActivity.experiencePeriod,
+					memberMakers.mentoringAvailability,
+					memberMakers.projectSupplementAvailability,
+					memberMakers.speakerAvailability,
+					memberMakers.careerLevel,
+					memberActivity.activityStatus,
+					memberMakers.skills,
+					memberMakers.company,
+					memberMakers.expertTopics,
+					memberMakers.activityCertNumber,
+					memberActivity.memo
+				))
+				.from(memberActivity)
+				.join(member).on(member.id.eq(memberActivity.memberId))
+				.join(memberMakers).on(memberActivity.id.eq(memberMakers.id))
+				.where(
+					memberActivity.id.eq(memberActivityId),
+					member.isDeleted.isFalse(),
+					memberActivity.isDeleted.isFalse(),
+					memberActivity.memberType.eq(MemberType.MAKERS)
+				)
+				.fetchOne()
+		);
 	}
 
 	// 조회 결과에서 지정 직군의 이름만 분리

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
@@ -231,6 +231,33 @@ class AdminMemberMakersControllerTest {
 			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
 	}
 
+	@Test
+	@DisplayName("메이커스팀 구성원 상세를 조회한다")
+	void 메이커스팀_구성원_상세를_조회한다() throws Exception {
+		// given
+		MemberActivity memberActivity = saveMakersActivity(uniqueEmail("detail"), JobFamily.FE, MakersTeam.TEAM_1);
+
+		// when & then
+		mockMvc.perform(get("/admin/members/makers/{memberActivityId}", memberActivity.getId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("SUCCESS"))
+			.andExpect(jsonPath("$.data.id").value(memberActivity.getId()))
+			.andExpect(jsonPath("$.data.name").value("김젝트"))
+			.andExpect(jsonPath("$.data.email").exists())
+			.andExpect(jsonPath("$.data.jobFamily").value(JobFamily.FE.name()))
+			.andExpect(jsonPath("$.data.makersTeam").value(MakersTeam.TEAM_1.name()))
+			.andExpect(jsonPath("$.data.activityStatus").value(ActivityStatus.ACTIVE.name()));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 메이커스팀 구성원 상세를 조회하지 않는다")
+	void 존재하지_않는_메이커스팀_구성원_상세를_조회하지_않는다() throws Exception {
+		// when & then
+		mockMvc.perform(get("/admin/members/makers/{memberActivityId}", 999999999L))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.status").value(MemberErrorCode.NOT_FOUND_MEMBER.getCode()));
+	}
+
 	private CreateMemberMakersRequest createMemberMakersRequest(String email) {
 		return new CreateMemberMakersRequest(
 			"김메이커",

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -8,7 +8,9 @@ import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.verify;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
@@ -201,6 +203,40 @@ class AdminMemberActivityServiceTest {
         verify(memberActivityRepository).countMemberSemesters(condition);
     }
 
+    @Test
+    @DisplayName("메이커스팀 구성원 상세를 조회한다")
+    void 메이커스팀_구성원_상세를_조회한다() {
+        // given
+        Long memberActivityId = 1L;
+        MemberMakersDetailProjection projection = memberMakersDetailProjection(memberActivityId);
+        given(memberActivityRepository.findMemberMakersDetail(memberActivityId)).willReturn(Optional.of(projection));
+
+        // when
+        MemberMakersDetailProjection result = adminMemberActivityService.getMemberMakersDetail(memberActivityId);
+
+        // then
+        assertThat(result).isEqualTo(projection);
+        verify(memberActivityRepository).findMemberMakersDetail(memberActivityId);
+    }
+
+    @Test
+    @DisplayName("메이커스팀 구성원 상세가 없으면 예외가 발생한다")
+    void 메이커스팀_구성원_상세가_없으면_예외가_발생한다() {
+        // given
+        Long memberActivityId = 1L;
+        given(memberActivityRepository.findMemberMakersDetail(memberActivityId)).willReturn(Optional.empty());
+
+        // when
+        Throwable throwable = catchThrowable(() -> adminMemberActivityService.getMemberMakersDetail(memberActivityId));
+
+        // then
+        assertThat(throwable)
+            .isInstanceOf(MemberException.class)
+            .extracting("errorCode")
+            .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+        verify(memberActivityRepository).findMemberMakersDetail(memberActivityId);
+    }
+
     private CreateMemberSemesterRequest createMemberSemesterRequest() {
         return new CreateMemberSemesterRequest(
             "김젝트",
@@ -234,6 +270,32 @@ class AdminMemberActivityServiceTest {
             Availability.AVAILABLE_BY_TOPIC,
             Availability.CONSIDER_LATER,
             CareerLevel.JUNIOR,
+            "Spring",
+            "JECT",
+            "백오피스",
+            "MK-001",
+            "memo"
+        );
+    }
+
+    private MemberMakersDetailProjection memberMakersDetailProjection(Long memberActivityId) {
+        return new MemberMakersDetailProjection(
+            memberActivityId,
+            "김메이커",
+            "maker@ject.kr",
+            "01087654321",
+            JobFamily.FE,
+            CareerDetails.EMPLOYEE,
+            MakersTeam.TEAM_1,
+            RecruitTypeDetail.REGULAR,
+            Region.SEOUL,
+            List.of("HEALTHCARE"),
+            ExperiencePeriod.ONE_TO_TWO,
+            Availability.HIGHLY_AVAILABLE,
+            Availability.AVAILABLE_BY_TOPIC,
+            Availability.CONSIDER_LATER,
+            CareerLevel.JUNIOR,
+            ActivityStatus.ACTIVE,
             "Spring",
             "JECT",
             "백오피스",

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberMakersUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberMakersUseCaseTest.java
@@ -5,14 +5,21 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 
 import java.util.List;
+import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
+import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
 import org.ject.support.admin.member.dto.result.MemberMakersListPageResult;
 import org.ject.support.common.response.CursorPageResponse;
 import org.ject.support.domain.member.ActivityStatus;
+import org.ject.support.domain.member.Availability;
+import org.ject.support.domain.member.CareerDetails;
+import org.ject.support.domain.member.CareerLevel;
+import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MakersTeam;
+import org.ject.support.domain.member.Region;
 import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -88,6 +95,26 @@ class AdminMemberMakersUseCaseTest {
 		assertThat(response.totalCount()).isEqualTo(2L);
 	}
 
+	@Test
+	@DisplayName("메이커스팀 구성원 상세를 조회해 응답으로 가공 후 반환한다")
+	void 메이커스팀_구성원_상세를_조회해_응답으로_가궁_후_변환한다() {
+		// given
+		Long memberActivityId = 1L;
+		MemberMakersDetailProjection projection = makersDetailProjection(memberActivityId);
+		given(adminMemberActivityService.getMemberMakersDetail(memberActivityId)).willReturn(projection);
+
+		// when
+		MemberMakersDetailResponse response = adminMemberMakersUseCase.getMemberMakersDetail(memberActivityId);
+
+		// then
+		assertThat(response.id()).isEqualTo(projection.id());
+		assertThat(response.name()).isEqualTo(projection.name());
+		assertThat(response.email()).isEqualTo(projection.email());
+		assertThat(response.makersTeam()).isEqualTo(projection.makersTeam());
+		assertThat(response.activityStatus()).isEqualTo(projection.activityStatus());
+		verify(adminMemberActivityService).getMemberMakersDetail(memberActivityId);
+	}
+
 	private MemberMakersListProjection makersProjection(Long memberActivityId, String name) {
 		return new MemberMakersListProjection(
 			memberActivityId,
@@ -98,6 +125,32 @@ class AdminMemberMakersUseCaseTest {
 			MakersTeam.TEAM_1,
 			RecruitTypeDetail.REGULAR,
 			ActivityStatus.ACTIVE,
+			"memo"
+		);
+	}
+
+	private MemberMakersDetailProjection makersDetailProjection(Long memberActivityId) {
+		return new MemberMakersDetailProjection(
+			memberActivityId,
+			"김메이커",
+			"maker@ject.kr",
+			"01087654321",
+			JobFamily.FE,
+			CareerDetails.EMPLOYEE,
+			MakersTeam.TEAM_1,
+			RecruitTypeDetail.REGULAR,
+			Region.SEOUL,
+			List.of("HEALTHCARE"),
+			ExperiencePeriod.ONE_TO_TWO,
+			Availability.HIGHLY_AVAILABLE,
+			Availability.AVAILABLE_BY_TOPIC,
+			Availability.CONSIDER_LATER,
+			CareerLevel.JUNIOR,
+			ActivityStatus.ACTIVE,
+			"Spring",
+			"JECT",
+			"백오피스",
+			"MK-001",
 			"memo"
 		);
 	}

--- a/src/test/java/org/ject/support/domain/member/fixture/MakersActivityFixture.java
+++ b/src/test/java/org/ject/support/domain/member/fixture/MakersActivityFixture.java
@@ -14,6 +14,7 @@ public final class MakersActivityFixture {
     private Long memberId = 1L;
     private JobFamily jobFamily = JobFamily.FE;
     private MakersTeam makersTeam = MakersTeam.TEAM_1;
+    private boolean deleted = false;
 
     private MakersActivityFixture() {
     }
@@ -37,8 +38,13 @@ public final class MakersActivityFixture {
         return this;
     }
 
+    public MakersActivityFixture deleted() {
+        this.deleted = true;
+        return this;
+    }
+
     public MemberActivity build() {
-        return MemberActivity.createMakersActivity(
+        MemberActivity memberActivity = MemberActivity.createMakersActivity(
             memberId,
             jobFamily,
             RecruitTypeDetail.REGULAR,
@@ -55,5 +61,9 @@ public final class MakersActivityFixture {
             "백오피스",
             "MK-001"
         );
+        if (deleted) {
+            memberActivity.delete();
+        }
+        return memberActivity;
     }
 }

--- a/src/test/java/org/ject/support/domain/member/fixture/MemberFixture.java
+++ b/src/test/java/org/ject/support/domain/member/fixture/MemberFixture.java
@@ -11,6 +11,7 @@ public final class MemberFixture {
     private String phoneNumber = "01012345678";
     private List<String> interestedDomains = List.of("커머스");
     private Region region = Region.SEOUL;
+    private boolean deleted = false;
 
     private MemberFixture() {
     }
@@ -44,7 +45,16 @@ public final class MemberFixture {
         return this;
     }
 
+    public MemberFixture deleted() {
+        this.deleted = true;
+        return this;
+    }
+
     public Member build() {
-        return Member.create(name, email, phoneNumber, interestedDomains, region);
+        Member member = Member.create(name, email, phoneNumber, interestedDomains, region);
+        if (deleted) {
+            member.delete();
+        }
+        return member;
     }
 }

--- a/src/test/java/org/ject/support/domain/member/fixture/SemesterActivityFixture.java
+++ b/src/test/java/org/ject/support/domain/member/fixture/SemesterActivityFixture.java
@@ -18,6 +18,7 @@ public final class SemesterActivityFixture {
     private String memo = "테스트 메모";
     private Long semesterId = 2L;
     private Long teamId = 3L;
+    private boolean deleted = false;
 
     private SemesterActivityFixture() {
     }
@@ -71,6 +72,11 @@ public final class SemesterActivityFixture {
         return this;
     }
 
+    public SemesterActivityFixture deleted() {
+        this.deleted = true;
+        return this;
+    }
+
     public MemberActivity build() {
         MemberActivity memberActivity = MemberActivity.createSemesterActivity(
             memberId,
@@ -83,6 +89,9 @@ public final class SemesterActivityFixture {
             teamId
         );
         memberActivity.updateActivityStatus(activityStatus);
+        if (deleted) {
+            memberActivity.delete();
+        }
         return memberActivity;
     }
 }

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -9,6 +9,7 @@ import jakarta.persistence.EntityManager;
 import java.util.List;
 
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
+import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
 import org.ject.support.domain.member.ActivityStatus;
@@ -925,5 +926,69 @@ class MemberActivityRepositoryTest {
                 secondActivity.getId(),
                 firstActivity.getId()
             );
+    }
+
+    @Test
+    @DisplayName("메이커스팀 구성원 상세를 조회한다")
+    void 메이커스팀_구성원_상세를_조회한다() {
+        // given
+        Member member = memberRepository.save(member()
+            .email("makers-detail@test.com")
+            .build());
+        MemberActivity memberActivity = memberActivityRepository.saveAndFlush(
+            makersActivity().memberId(member.getId()).build()
+        );
+
+        // when
+        MemberMakersDetailProjection projection = memberActivityRepository.findMemberMakersDetail(memberActivity.getId())
+            .orElseThrow();
+
+        // then
+        assertThat(projection.id()).isEqualTo(memberActivity.getId());
+        assertThat(projection.name()).isEqualTo(member.getName());
+        assertThat(projection.email()).isEqualTo(member.getEmail());
+        assertThat(projection.jobFamily()).isEqualTo(memberActivity.getJobFamily());
+        assertThat(projection.makersTeam()).isEqualTo(memberActivity.getMemberMakers().getMakersTeam());
+        assertThat(projection.activityStatus()).isEqualTo(memberActivity.getActivityStatus());
+    }
+
+    @Test
+    @DisplayName("삭제된 메이커스팀 활동은 상세 조회하지 않는다")
+    void 삭제된_메이커스팀_활동은_상세_조회하지_않는다() {
+        // given
+        Member member = memberRepository.save(member()
+            .email("del-act@test.com")
+            .build());
+        MemberActivity memberActivity = memberActivityRepository.saveAndFlush(
+            makersActivity()
+                .memberId(member.getId())
+                .deleted()
+                .build()
+        );
+
+        // when
+        boolean exists = memberActivityRepository.findMemberMakersDetail(memberActivity.getId()).isPresent();
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("삭제된 구성원의 메이커스팀 활동은 상세 조회하지 않는다")
+    void 삭제된_구성원의_메이커스팀_활동은_상세_조회하지_않는다() {
+        // given
+        Member member = memberRepository.save(member()
+            .email("del-mem@test.com")
+            .deleted()
+            .build());
+        MemberActivity memberActivity = memberActivityRepository.saveAndFlush(
+            makersActivity().memberId(member.getId()).build()
+        );
+
+        // when
+        boolean exists = memberActivityRepository.findMemberMakersDetail(memberActivity.getId()).isPresent();
+
+        // then
+        assertThat(exists).isFalse();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #539

## 📝 작업 내용

- 메이커스팀 구성원 상세 조회 응답 DTO와 Projection을 추가했습니다.
- `GET /admin/members/makers/{memberActivityId}` API를 연결했습니다.
- 삭제된 Member/MemberActivity는 상세 조회에서 제외하도록 쿼리 조건을 적용했습니다.
- 테스트 픽스처에 삭제 상태 설정을 추가하고 Repository, Service, UseCase, Controller 테스트를 보강했습니다.

## 🙏 리뷰 요구사항 (선택)

- 상세 조회 쿼리에서 목록 조회와 동일하게 삭제 데이터가 제외되는지 확인 부탁드립니다.
- 응답 필드가 명세에 필요한 메이커스팀 구성원 상세 항목을 모두 포함하는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 메이커스팀 구성원의 상세 정보를 조회할 수 있는 관리자용 API가 추가되었습니다.
  * 기본 정보(이름/이메일/연락처)와 직군·경력·팀·지역·관심 분야, 활동 상태 및 가능 여부, 전문 분야 및 메모 등을 함께 제공합니다.
* **개선 사항**
  * 삭제 처리된 구성원 또는 활동은 상세 조회 결과에서 제외됩니다.
  * 존재하지 않는 대상 조회 시 명확한 404 오류가 반환됩니다.
* **테스트**
  * 상세 조회 성공/실패 케이스 및 매핑 검증 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->