### PR TITLE
[FEAT] 운영 서포터즈 구성원 추가 API 개발

### DIFF
--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersApiSpec.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersApiSpec.java
@@ -1,0 +1,18 @@
+package org.ject.support.admin.member.controller;
+
+import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "AdminMemberSupporters", description = "운영 서포터즈 구성원 API")
+public interface AdminMemberSupportersApiSpec {
+
+	@Operation(
+		summary = "운영 서포터즈 구성원 추가",
+		description = "운영 서포터즈 구성원을 추가합니다."
+	)
+	void createAdminMemberSupporters(@RequestBody @Valid CreateMemberSupportersRequest request);
+}

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersController.java
@@ -1,0 +1,27 @@
+package org.ject.support.admin.member.controller;
+
+import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
+import org.ject.support.admin.member.service.AdminMemberSupportersUseCase;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/admin/members/supporters")
+@RequiredArgsConstructor
+public class AdminMemberSupportersController implements AdminMemberSupportersApiSpec {
+
+	private final AdminMemberSupportersUseCase adminMemberSupportersUseCase;
+
+	// 운영 서포터즈 구성원 추가
+	@Override
+	@PostMapping
+	public void createAdminMemberSupporters(
+		@RequestBody @Valid CreateMemberSupportersRequest request) {
+		adminMemberSupportersUseCase.createMemberSupporters(request);
+	}
+}

--- a/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberMakersRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberMakersRequest.java
@@ -2,6 +2,7 @@ package org.ject.support.admin.member.dto.request;
 
 import java.util.List;
 
+import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.Availability;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.CareerLevel;
@@ -19,7 +20,7 @@ import jakarta.validation.constraints.Size;
 
 public record CreateMemberMakersRequest(
 
-	// 필수 항목: 이름, 전화번호, 이메일, 직군(포자션), 지원자 신분, 소속, 모집단위
+	// 필수 항목: 이름, 전화번호, 이메일, 직군(포지션), 활동 상태, 지원자 신분, 소속, 모집단위
 
 	@NotBlank(message = "이름을 입력해주세요")
 	@Size(max = 20, message = "이름은 20자 이하로 입력해주세요.")
@@ -46,6 +47,9 @@ public record CreateMemberMakersRequest(
 
 	@NotNull(message = "모집 단위를 선택해주세요")
 	RecruitTypeDetail recruitTypeDetail,
+
+	@NotNull(message = "활동 상태를 선택해주세요")
+	ActivityStatus activityStatus,
 
 	// 선택 항목: 거주지역, 관심도메인, 직무관련경험, 멘토링 가능 여부, 프로젝트 충원 가능 여부, 연사 가능 여부, 경력, 기술, 회사, 공유 가능한 전문 주제, 활동 증명서 번호, 비고
 

--- a/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberSemesterRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberSemesterRequest.java
@@ -2,6 +2,7 @@ package org.ject.support.admin.member.dto.request;
 
 import java.util.List;
 
+import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
@@ -17,7 +18,7 @@ import jakarta.validation.constraints.Size;
 public record CreateMemberSemesterRequest(
 
 	/*
-	필수 항목: 이름, 전화번호, 이메일, 직군(포지션), 지원자 신분, 모집단위, 기수id
+	필수 항목: 이름, 전화번호, 이메일, 직군(포지션), 활동 상태, 지원자 신분, 모집단위, 기수id
 	선택 항목: 팀id, 비고, 관심도메인, 거주지역, 직무 관련 경험
 	 */
 	@NotBlank(message = "이름을 입력해주세요")
@@ -39,6 +40,9 @@ public record CreateMemberSemesterRequest(
 
 	@NotNull(message = "모집 단위를 선택해주세요")
 	RecruitTypeDetail recruitTypeDetail,
+
+	@NotNull(message = "활동 상태를 선택해주세요")
+	ActivityStatus activityStatus,
 
 	@NotNull(message = "지원자 신분을 선택해주세요")
 	CareerDetails careerDetails,

--- a/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberSupportersRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberSupportersRequest.java
@@ -1,0 +1,66 @@
+package org.ject.support.admin.member.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.ject.support.domain.member.ActivityStatus;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.member.Region;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CreateMemberSupportersRequest(
+
+	@NotBlank(message = "이름을 입력해주세요")
+	@Size(max = 20, message = "이름은 20자 이하로 입력해주세요.")
+	@Pattern(regexp = "^[^\\s]+$", message = "이름은 공백없이 입력해주세요")
+	String name,
+
+	@NotBlank(message = "전화번호를 입력해주세요")
+	@Pattern(regexp = "^010\\d{8}$", message = "010으로 시작하는 11자리 숫자를 입력해주세요.")
+	String phoneNumber,
+
+	@NotBlank(message = "이메일을 입력해주세요.")
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	@Size(max = 30, message = "이메일은 30자 이하로 입력해주세요.")
+	String email,
+
+	@NotNull(message = "소속을 선택해주세요")
+	MemberType memberType,
+
+	@NotNull(message = "포지션을 선택해주세요")
+	JobFamily jobFamily,
+
+	@NotNull(message = "모집 단위를 선택해주세요")
+	RecruitTypeDetail recruitTypeDetail,
+
+	@NotNull(message = "활동 상태를 선택해주세요")
+	ActivityStatus activityStatus,
+
+	LocalDate startDate,
+
+	LocalDate endDate,
+
+	@Size(max = 20, message = "활동 증명서 번호는 20자 이하로 입력해주세요.")
+	String activityCertNumber,
+
+	@Size(max = 100, message = "비고는 100자 이하로 입력해주세요.")
+	String memo
+) implements CreateMemberRequest {
+
+	@Override
+	public List<String> interestedDomains() {
+		return null;
+	}
+
+	@Override
+	public Region region() {
+		return null;
+	}
+}

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
@@ -7,6 +7,7 @@ import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
 import org.ject.support.admin.member.dto.result.MemberMakersListPageResult;
@@ -16,7 +17,6 @@ import org.ject.support.domain.member.entity.MemberActivity;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberActivityRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -75,6 +75,27 @@ public class AdminMemberActivityService {
 		memberActivityRepository.save(memberActivity);
 	}
 
+	// 운영 서포터즈 구성원 추가
+	public void createMemberSupportersActivity(CreateMemberSupportersRequest request, Long memberId) {
+		// 운영 서포터즈 타입과 ACTIVE 중복 여부 검증
+		validateSupportersMemberType(request.memberType());
+		validateDuplicateActiveSupportersActivity(memberId);
+
+		// MemberActivity생성, 내부에서 MemberSupporters 생성
+		MemberActivity memberActivity = MemberActivity.createSupportersActivity(
+			memberId,
+			request.jobFamily(),
+			request.recruitTypeDetail(),
+			request.activityStatus(),
+			request.startDate(),
+			request.endDate(),
+			request.activityCertNumber(),
+			request.memo()
+		);
+
+		memberActivityRepository.save(memberActivity);
+	}
+
 	// 동적 필터로 일반 구성원 목록 조회
 	public SearchMemberSemesterPageResult searchMemberSemesterList(MemberSemesterSearchCondition condition) {
 		// size+1로 조회 (다음 페이지 유무 확인)
@@ -111,6 +132,20 @@ public class AdminMemberActivityService {
 	private void validateDuplicateActiveMakersActivity(Long memberId) {
 		if (memberActivityRepository.existsActiveMakersActivityByMemberId(memberId)) {
 			throw new MemberException(ALREADY_EXIST_ACTIVE_MEMBER_MAKERS_ACTIVITY);
+		}
+	}
+
+	// 운영 서포터즈 구성원 타입 검증
+	private void validateSupportersMemberType(MemberType memberType) {
+		if (memberType != MemberType.SUPPORTERS) {
+			throw new MemberException(INVALID_MEMBER_TYPE);
+		}
+	}
+
+	// ACTIVE 상태인 운영 서포터즈 활동 존재 여부 검증
+	private void validateDuplicateActiveSupportersActivity(Long memberId) {
+		if (memberActivityRepository.existsActiveSupportersActivityByMemberId(memberId)) {
+			throw new MemberException(ALREADY_EXIST_ACTIVE_MEMBER_SUPPORTERS_ACTIVITY);
 		}
 	}
 }

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
@@ -53,7 +53,7 @@ public class AdminMemberActivityService {
 	// 메이커스팀 구성원 추가
 	public void createMemberMakersActivity(CreateMemberMakersRequest request, Long memberId) {
 		// ACTIVE 상태로 추가할 때 기존 활동 중 이력 검증
-		if (request.activityStatus() == ActivityStatus.ACTIVE) {
+		if (ActivityStatus.isActive(request.activityStatus())) {
 			validateDuplicateActiveMakersActivity(memberId);
 		}
 
@@ -83,8 +83,7 @@ public class AdminMemberActivityService {
 	// 운영 서포터즈 구성원 추가
 	public void createMemberSupportersActivity(CreateMemberSupportersRequest request, Long memberId) {
 		// 운영 서포터즈 타입과 ACTIVE 중복 여부 검증
-		validateSupportersMemberType(request.memberType());
-		if (request.activityStatus() == ActivityStatus.ACTIVE) {
+		if (ActivityStatus.isActive(request.activityStatus())) {
 			validateDuplicateActiveSupportersActivity(memberId);
 		}
 
@@ -139,13 +138,6 @@ public class AdminMemberActivityService {
 	private void validateDuplicateActiveMakersActivity(Long memberId) {
 		if (memberActivityRepository.existsActiveMakersActivityByMemberId(memberId)) {
 			throw new MemberException(ALREADY_EXIST_ACTIVE_MEMBER_MAKERS_ACTIVITY);
-		}
-	}
-
-	// 운영 서포터즈 구성원 타입 검증
-	private void validateSupportersMemberType(MemberType memberType) {
-		if (memberType != MemberType.SUPPORTERS) {
-			throw new MemberException(INVALID_MEMBER_TYPE);
 		}
 	}
 

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
@@ -12,6 +12,7 @@ import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
 import org.ject.support.admin.member.dto.result.MemberMakersListPageResult;
 import org.ject.support.admin.member.dto.result.SearchMemberSemesterPageResult;
+import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.entity.MemberActivity;
 import org.ject.support.domain.member.exception.MemberException;
@@ -79,7 +80,9 @@ public class AdminMemberActivityService {
 	public void createMemberSupportersActivity(CreateMemberSupportersRequest request, Long memberId) {
 		// 운영 서포터즈 타입과 ACTIVE 중복 여부 검증
 		validateSupportersMemberType(request.memberType());
-		validateDuplicateActiveSupportersActivity(memberId);
+		if (request.activityStatus() == ActivityStatus.ACTIVE) {
+			validateDuplicateActiveSupportersActivity(memberId);
+		}
 
 		// MemberActivity생성, 내부에서 MemberSupporters 생성
 		MemberActivity memberActivity = MemberActivity.createSupportersActivity(

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
@@ -39,6 +39,7 @@ public class AdminMemberActivityService {
 			memberId,
 			request.jobFamily(),
 			request.recruitTypeDetail(),
+			request.activityStatus(),
 			request.careerDetails(),
 			request.experiencePeriod(),
 			request.memo(),
@@ -51,14 +52,17 @@ public class AdminMemberActivityService {
 
 	// 메이커스팀 구성원 추가
 	public void createMemberMakersActivity(CreateMemberMakersRequest request, Long memberId) {
-		// 추가하려는 대상이 이미 활동 중인 상태인지 검증
-		validateDuplicateActiveMakersActivity(memberId);
+		// ACTIVE 상태로 추가할 때 기존 활동 중 이력 검증
+		if (request.activityStatus() == ActivityStatus.ACTIVE) {
+			validateDuplicateActiveMakersActivity(memberId);
+		}
 
 		// MemberActivity생성, 내부에서 MemberMakers 생성
 		MemberActivity memberActivity = MemberActivity.createMakersActivity(
 			memberId,
 			request.jobFamily(),
 			request.recruitTypeDetail(),
+			request.activityStatus(),
 			request.careerDetails(),
 			request.experiencePeriod(),
 			request.memo(),

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberSupportersUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberSupportersUseCase.java
@@ -16,6 +16,7 @@ public class AdminMemberSupportersUseCase {
 	// 운영 서포터즈 구성원 추가
 	@Transactional
 	public void createMemberSupporters(CreateMemberSupportersRequest request) {
+		// TODO: ACTIVE 구성원 동시 등록 경쟁 조건 점검 및 해결 필요
 		// email 기준 기존 Member 조회 또는 신규 생성
 		Long memberId = adminMemberService.findOrCreateMember(request);
 

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberSupportersUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberSupportersUseCase.java
@@ -1,0 +1,25 @@
+package org.ject.support.admin.member.service;
+
+import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberSupportersUseCase {
+
+	private final AdminMemberService adminMemberService;
+	private final AdminMemberActivityService adminMemberActivityService;
+
+	// 운영 서포터즈 구성원 추가
+	@Transactional
+	public void createMemberSupporters(CreateMemberSupportersRequest request) {
+		// email 기준 기존 Member 조회 또는 신규 생성
+		Long memberId = adminMemberService.findOrCreateMember(request);
+
+		// memberId 기준 MemberActivity와 MemberSupporters 생성 및 저장
+		adminMemberActivityService.createMemberSupportersActivity(request, memberId);
+	}
+}

--- a/src/main/java/org/ject/support/domain/member/ActivityStatus.java
+++ b/src/main/java/org/ject/support/domain/member/ActivityStatus.java
@@ -32,4 +32,8 @@ public enum ActivityStatus {
         return statuses.stream()
             .allMatch(status -> status.isAvailableFor(type));
     }
+
+    public static boolean isActive(ActivityStatus status) {
+        return status == ACTIVE;
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/ActivityStatus.java
+++ b/src/main/java/org/ject/support/domain/member/ActivityStatus.java
@@ -19,7 +19,8 @@ public enum ActivityStatus {
     public boolean isAvailableFor(MemberType type) {
         return switch (type) {
             case SEMESTER -> this == ACTIVE || this == COMPLETED || this == WITHDRAWN;
-            case MAKERS, SUPPORTERS -> this == ACTIVE || this == ENDED || this == DROPOUT;
+            case MAKERS -> this == ACTIVE || this == ENDED || this == DROPOUT;
+            case SUPPORTERS -> this == ACTIVE || this == ENDED || this == DROPOUT;
         };
     }
 

--- a/src/main/java/org/ject/support/domain/member/JobFamily.java
+++ b/src/main/java/org/ject/support/domain/member/JobFamily.java
@@ -20,4 +20,12 @@ public enum JobFamily {
 
     private final String description;
     private final boolean portfolioRequired;
+
+    public boolean isAvailableFor(MemberType memberType) {
+        return switch (memberType) {
+            case SEMESTER -> this == PM || this == PD || this == FE || this == BE || this == APP;
+            case MAKERS -> this == PM || this == PD || this == FE || this == BE;
+            case SUPPORTERS -> this == OPS || this == INFRA || this == BX || this == ER;
+        };
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
@@ -88,6 +88,9 @@ public class MemberActivity extends BaseTimeEntity {
     @OneToOne(mappedBy = "memberActivity", fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
     private MemberMakers memberMakers;
 
+    @OneToOne(mappedBy = "memberActivity", fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
+    private MemberSupporters memberSupporters;
+
     // 일반 구성원 활동과 관리 항목 생성
     public static MemberActivity createSemesterActivity(
         Long memberId,
@@ -99,6 +102,8 @@ public class MemberActivity extends BaseTimeEntity {
         Long semesterId,
         Long teamId
     ){
+        validateJobFamily(MemberType.SEMESTER, jobFamily);
+
         MemberActivity memberActivity = MemberActivity.builder()
             .memberId(memberId)
             .memberType(MemberType.SEMESTER)
@@ -132,6 +137,8 @@ public class MemberActivity extends BaseTimeEntity {
         String expertTopics,
         String activityCertNumber
     ){
+        validateJobFamily(MemberType.MAKERS, jobFamily);
+
         MemberActivity memberActivity = MemberActivity.builder()
             .memberId(memberId)
             .memberType(MemberType.MAKERS)
@@ -157,13 +164,38 @@ public class MemberActivity extends BaseTimeEntity {
         return memberActivity;
     }
 
-    //Todo: 운영 서포터즈 구성원 활동과 관리 항목 생성
+    // 운영 서포터즈 구성원 활동과 관리 항목 생성
+    public static MemberActivity createSupportersActivity(
+        Long memberId,
+        JobFamily jobFamily,
+        RecruitTypeDetail recruitTypeDetail,
+        ActivityStatus activityStatus,
+        LocalDate startDate,
+        LocalDate endDate,
+        String activityCertNumber,
+        String memo
+    ){
+        validateJobFamily(MemberType.SUPPORTERS, jobFamily);
+        validateActivityStatus(MemberType.SUPPORTERS, activityStatus);
+
+        MemberActivity memberActivity = MemberActivity.builder()
+            .memberId(memberId)
+            .memberType(MemberType.SUPPORTERS)
+            .jobFamily(jobFamily)
+            .recruitTypeDetail(recruitTypeDetail)
+            .activityStatus(activityStatus)
+            .startDate(startDate)
+            .endDate(endDate)
+            .memo(memo)
+            .build();
+        // 애그리거트 루트인 MemberActivity쪽에서 식별 관계인 엔티티 생성 책임
+        memberActivity.memberSupporters = MemberSupporters.create(memberActivity, activityCertNumber);
+        return memberActivity;
+    }
 
     // 구성원 유형에 맞는 활동 상태로 변경
     public void updateActivityStatus(ActivityStatus activityStatus) {
-        if (!activityStatus.isAvailableFor(memberType)) {
-            throw new MemberException(MemberErrorCode.INVALID_ACTIVITY_STATUS);
-        }
+        validateActivityStatus(memberType, activityStatus);
 
         this.activityStatus = activityStatus;
     }
@@ -171,5 +203,19 @@ public class MemberActivity extends BaseTimeEntity {
     // 구성원 활동 삭제 처리
     public void delete(){
         this.isDeleted = true;
+    }
+
+    // 구성원 유형별 활동 상태 검증
+    private static void validateActivityStatus(MemberType memberType, ActivityStatus activityStatus) {
+        if (!activityStatus.isAvailableFor(memberType)) {
+            throw new MemberException(MemberErrorCode.INVALID_ACTIVITY_STATUS);
+        }
+    }
+
+    // 구성원 유형별 포지션 검증
+    private static void validateJobFamily(MemberType memberType, JobFamily jobFamily) {
+        if (!jobFamily.isAvailableFor(memberType)) {
+            throw new MemberException(MemberErrorCode.INVALID_JOB_FAMILY);
+        }
     }
 }

--- a/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
@@ -96,6 +96,7 @@ public class MemberActivity extends BaseTimeEntity {
         Long memberId,
         JobFamily jobFamily,
         RecruitTypeDetail recruitTypeDetail,
+        ActivityStatus activityStatus,
         CareerDetails careerDetails,
         ExperiencePeriod experiencePeriod,
         String memo,
@@ -103,12 +104,14 @@ public class MemberActivity extends BaseTimeEntity {
         Long teamId
     ){
         validateJobFamily(MemberType.SEMESTER, jobFamily);
+        validateActivityStatus(MemberType.SEMESTER, activityStatus);
 
         MemberActivity memberActivity = MemberActivity.builder()
             .memberId(memberId)
             .memberType(MemberType.SEMESTER)
             .jobFamily(jobFamily)
             .recruitTypeDetail(recruitTypeDetail)
+            .activityStatus(activityStatus)
             .careerDetails(careerDetails)
             .experiencePeriod(experiencePeriod)
             .memo(memo)
@@ -124,6 +127,7 @@ public class MemberActivity extends BaseTimeEntity {
         Long memberId,
         JobFamily jobFamily,
         RecruitTypeDetail recruitTypeDetail,
+        ActivityStatus activityStatus,
         CareerDetails careerDetails,
         ExperiencePeriod experiencePeriod,
         String memo,
@@ -138,12 +142,14 @@ public class MemberActivity extends BaseTimeEntity {
         String activityCertNumber
     ){
         validateJobFamily(MemberType.MAKERS, jobFamily);
+        validateActivityStatus(MemberType.MAKERS, activityStatus);
 
         MemberActivity memberActivity = MemberActivity.builder()
             .memberId(memberId)
             .memberType(MemberType.MAKERS)
             .jobFamily(jobFamily)
             .recruitTypeDetail(recruitTypeDetail)
+            .activityStatus(activityStatus)
             .careerDetails(careerDetails)
             .experiencePeriod(experiencePeriod)
             .memo(memo)

--- a/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
@@ -177,6 +177,7 @@ public class MemberActivity extends BaseTimeEntity {
     ){
         validateJobFamily(MemberType.SUPPORTERS, jobFamily);
         validateActivityStatus(MemberType.SUPPORTERS, activityStatus);
+        validateActivityPeriod(startDate, endDate);
 
         MemberActivity memberActivity = MemberActivity.builder()
             .memberId(memberId)
@@ -207,15 +208,25 @@ public class MemberActivity extends BaseTimeEntity {
 
     // 구성원 유형별 활동 상태 검증
     private static void validateActivityStatus(MemberType memberType, ActivityStatus activityStatus) {
-        if (!activityStatus.isAvailableFor(memberType)) {
+        if (activityStatus == null || !activityStatus.isAvailableFor(memberType)) {
             throw new MemberException(MemberErrorCode.INVALID_ACTIVITY_STATUS);
         }
     }
 
     // 구성원 유형별 포지션 검증
     private static void validateJobFamily(MemberType memberType, JobFamily jobFamily) {
-        if (!jobFamily.isAvailableFor(memberType)) {
+        if (jobFamily == null || !jobFamily.isAvailableFor(memberType)) {
             throw new MemberException(MemberErrorCode.INVALID_JOB_FAMILY);
+        }
+    }
+
+    // 활동 시작일과 종료일 순서 검증
+    private static void validateActivityPeriod(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null && endDate != null) {
+            throw new MemberException(MemberErrorCode.INVALID_ACTIVITY_PERIOD);
+        }
+        if (startDate != null && endDate != null && endDate.isBefore(startDate)) {
+            throw new MemberException(MemberErrorCode.INVALID_ACTIVITY_PERIOD);
         }
     }
 }

--- a/src/main/java/org/ject/support/domain/member/entity/MemberSupporters.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberSupporters.java
@@ -13,7 +13,7 @@ import org.ject.support.domain.base.BaseTimeEntity;
 
 @Entity
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @Table(name = "member_supporters")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -29,4 +29,12 @@ public class MemberSupporters extends BaseTimeEntity {
 
     @Column(length = 20)
     private String activityCertNumber;
+
+    // 운영 서포터즈 관리 항목 생성
+    public static MemberSupporters create(MemberActivity memberActivity, String activityCertNumber) {
+        return MemberSupporters.builder()
+            .memberActivity(memberActivity)
+            .activityCertNumber(activityCertNumber)
+            .build();
+    }
 }

--- a/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
@@ -23,6 +23,7 @@ public enum MemberErrorCode implements ErrorCode {
     INVALID_MEMBER_TYPE(BAD_REQUEST, "MEMBER-11", "구성원 유형이 올바르지 않습니다."),
     INVALID_JOB_FAMILY(BAD_REQUEST, "MEMBER-12", "구성원 유형에 맞지 않는 직군입니다."),
     ALREADY_EXIST_ACTIVE_MEMBER_SUPPORTERS_ACTIVITY(CONFLICT, "MEMBER-13", "이미 활동 중인 운영 서포터즈 구성원입니다."),
+    INVALID_ACTIVITY_PERIOD(BAD_REQUEST, "MEMBER-14", "활동 기간이 올바르지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
@@ -20,6 +20,9 @@ public enum MemberErrorCode implements ErrorCode {
     REQUIRED_SEMESTER_FOR_TEAM_FILTER(BAD_REQUEST, "MEMBER-8", "팀 필터를 사용할 때는 기수를 함께 선택해야 합니다."),
     INVALID_ACTIVITY_STATUS(BAD_REQUEST, "MEMBER-9", "구성원 유형에 맞지 않는 활동 상태입니다."),
     ALREADY_EXIST_ACTIVE_MEMBER_MAKERS_ACTIVITY(CONFLICT, "MEMBER-10", "이미 활동 중인 메이커스팀 구성원입니다."),
+    INVALID_MEMBER_TYPE(BAD_REQUEST, "MEMBER-11", "구성원 유형이 올바르지 않습니다."),
+    INVALID_JOB_FAMILY(BAD_REQUEST, "MEMBER-12", "구성원 유형에 맞지 않는 직군입니다."),
+    ALREADY_EXIST_ACTIVE_MEMBER_SUPPORTERS_ACTIVITY(CONFLICT, "MEMBER-13", "이미 활동 중인 운영 서포터즈 구성원입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityRepository.java
@@ -32,4 +32,13 @@ public interface MemberActivityRepository extends JpaRepository<MemberActivity, 
 		  and ma.activityStatus = org.ject.support.domain.member.ActivityStatus.ACTIVE
 		""")
 	boolean existsActiveMakersActivityByMemberId(@Param("memberId") Long memberId);
+
+	@Query("""
+		select count(ma) > 0
+		from MemberActivity ma
+		where ma.memberId = :memberId
+		  and ma.memberType = org.ject.support.domain.member.MemberType.SUPPORTERS
+		  and ma.activityStatus = org.ject.support.domain.member.ActivityStatus.ACTIVE
+		""")
+	boolean existsActiveSupportersActivityByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
@@ -82,7 +82,7 @@ class AdminMemberMakersControllerTest {
 		assertThat(member.getInterestedDomains()).containsExactlyElementsOf(request.interestedDomains());
 		assertThat(member.getRegion()).isEqualTo(request.region());
 		assertThat(memberActivity.getMemberType()).isEqualTo(MemberType.MAKERS);
-		assertThat(memberActivity.getActivityStatus()).isEqualTo(ActivityStatus.ACTIVE);
+		assertThat(memberActivity.getActivityStatus()).isEqualTo(request.activityStatus());
 		assertThat(memberActivity.getJobFamily()).isEqualTo(request.jobFamily());
 		assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(request.recruitTypeDetail());
 		assertThat(memberActivity.getCareerDetails()).isEqualTo(request.careerDetails());
@@ -267,6 +267,7 @@ class AdminMemberMakersControllerTest {
 			CareerDetails.EMPLOYEE,
 			MakersTeam.TEAM_1,
 			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ACTIVE,
 			Region.SEOUL,
 			List.of("HEALTHCARE", "FINTECH", "AI"),
 			ExperiencePeriod.ONE_TO_TWO,

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
@@ -91,6 +91,11 @@ class AdminMemberSemesterControllerTest {
 			MemberType.SEMESTER,
 			semester.getId()
 		)).isTrue();
+		MemberActivity memberActivity = memberActivityRepository.findAll().stream()
+			.filter(activity -> activity.getMemberId().equals(member.getId()))
+			.findFirst()
+			.orElseThrow();
+		assertThat(memberActivity.getActivityStatus()).isEqualTo(request.activityStatus());
 	}
 
 	@Test
@@ -129,6 +134,7 @@ class AdminMemberSemesterControllerTest {
 			"01012345678",
 			JobFamily.BE,
 			RecruitTypeDetail.REGULAR,
+			ActivityStatus.COMPLETED,
 			CareerDetails.EMPLOYEE,
 			semester.getId(),
 			null,
@@ -279,6 +285,7 @@ class AdminMemberSemesterControllerTest {
 			"01012345678",
 			JobFamily.BE,
 			RecruitTypeDetail.REGULAR,
+			ActivityStatus.COMPLETED,
 			CareerDetails.EMPLOYEE,
 			semesterId,
 			teamId,

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberSupportersControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberSupportersControllerTest.java
@@ -1,0 +1,161 @@
+package org.ject.support.admin.member.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.member.fixture.MemberFixture.member;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
+import org.ject.support.domain.member.ActivityStatus;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.entity.MemberActivity;
+import org.ject.support.domain.member.exception.MemberErrorCode;
+import org.ject.support.domain.member.repository.MemberActivityRepository;
+import org.ject.support.domain.member.repository.MemberRepository;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+import org.ject.support.testconfig.AuthenticatedUser;
+import org.ject.support.testconfig.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+@Transactional
+@AuthenticatedUser(isAdmin = true)
+@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
+class AdminMemberSupportersControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private MemberActivityRepository memberActivityRepository;
+
+	@Test
+	@DisplayName("운영 서포터즈 구성원을 추가한다")
+	void 운영_서포터즈_구성원을_추가한다() throws Exception {
+		// given
+		String email = uniqueEmail("supporter");
+		CreateMemberSupportersRequest request = createMemberSupportersRequest(email, JobFamily.OPS, "memo");
+
+		// when
+		mockMvc.perform(post("/admin/members/supporters")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("SUCCESS"));
+
+		// then
+		Member member = memberRepository.findByEmail(email).orElseThrow();
+		MemberActivity memberActivity = findOnlyActivity(member.getId());
+
+		assertThat(member.getName()).isEqualTo(request.name());
+		assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
+		assertThat(memberActivity.getMemberType()).isEqualTo(MemberType.SUPPORTERS);
+		assertThat(memberActivity.getJobFamily()).isEqualTo(request.jobFamily());
+		assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(request.recruitTypeDetail());
+		assertThat(memberActivity.getActivityStatus()).isEqualTo(request.activityStatus());
+		assertThat(memberActivity.getStartDate()).isEqualTo(request.startDate());
+		assertThat(memberActivity.getEndDate()).isEqualTo(request.endDate());
+		assertThat(memberActivity.getMemo()).isEqualTo(request.memo());
+		assertThat(memberActivity.getMemberSupporters().getActivityCertNumber()).isEqualTo(request.activityCertNumber());
+	}
+
+	@Test
+	@DisplayName("운영 서포터즈에 맞지 않는 포지션이면 추가하지 않는다")
+	void 운영_서포터즈에_맞지_않는_포지션이면_추가하지_않는다() throws Exception {
+		// given
+		CreateMemberSupportersRequest request = createMemberSupportersRequest(uniqueEmail("invalid"), JobFamily.FE, "memo");
+
+		// when & then
+		mockMvc.perform(post("/admin/members/supporters")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value(MemberErrorCode.INVALID_JOB_FAMILY.getCode()));
+	}
+
+	@Test
+	@DisplayName("활동 중인 운영 서포터즈 구성원이 있으면 추가하지 않는다")
+	void 활동_중인_운영_서포터즈_구성원이_있으면_추가하지_않는다() throws Exception {
+		// given
+		String email = uniqueEmail("duplicate");
+		CreateMemberSupportersRequest request = createMemberSupportersRequest(email, JobFamily.BX, "memo");
+		CreateMemberSupportersRequest activeRequest = new CreateMemberSupportersRequest(
+			request.name(),
+			request.phoneNumber(),
+			request.email(),
+			request.memberType(),
+			request.jobFamily(),
+			request.recruitTypeDetail(),
+			ActivityStatus.ACTIVE,
+			request.startDate(),
+			request.endDate(),
+			request.activityCertNumber(),
+			request.memo()
+		);
+
+		mockMvc.perform(post("/admin/members/supporters")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(activeRequest)))
+			.andExpect(status().isOk());
+
+		// when & then
+		mockMvc.perform(post("/admin/members/supporters")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(activeRequest)))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.status")
+				.value(MemberErrorCode.ALREADY_EXIST_ACTIVE_MEMBER_SUPPORTERS_ACTIVITY.getCode()));
+	}
+
+	private CreateMemberSupportersRequest createMemberSupportersRequest(String email, JobFamily jobFamily, String memo) {
+		return new CreateMemberSupportersRequest(
+			"김서포터",
+			"01012345678",
+			email,
+			MemberType.SUPPORTERS,
+			jobFamily,
+			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ENDED,
+			java.time.LocalDate.of(2025, 5, 19),
+			java.time.LocalDate.of(2025, 12, 19),
+			"SP-001",
+			memo
+		);
+	}
+
+	private MemberActivity findOnlyActivity(Long memberId) {
+		java.util.List<MemberActivity> activities = memberActivityRepository.findAll().stream()
+			.filter(activity -> activity.getMemberId().equals(memberId))
+			.toList();
+
+		assertThat(activities).hasSize(1);
+		return activities.get(0);
+	}
+
+	private String uniqueEmail(String prefix) {
+		return prefix + uniqueSuffix() + "@t.kr";
+	}
+
+	private String uniqueSuffix() {
+		String suffix = String.valueOf(System.nanoTime());
+		return suffix.substring(suffix.length() - 6);
+	}
+}

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -168,7 +168,6 @@ class AdminMemberActivityServiceTest {
         // given
         CreateMemberSupportersRequest request = createMemberSupportersRequest();
         Long memberId = 1L;
-        given(memberActivityRepository.existsActiveSupportersActivityByMemberId(memberId)).willReturn(false);
 
         // when
         adminMemberActivityService.createMemberSupportersActivity(request, memberId);
@@ -187,13 +186,27 @@ class AdminMemberActivityServiceTest {
         assertThat(memberActivity.getEndDate()).isEqualTo(request.endDate());
         assertThat(memberActivity.getMemo()).isEqualTo(request.memo());
         assertThat(memberActivity.getMemberSupporters().getActivityCertNumber()).isEqualTo(request.activityCertNumber());
+        verify(memberActivityRepository, never()).existsActiveSupportersActivityByMemberId(memberId);
     }
 
     @Test
-    @DisplayName("운영 서포터즈로 활동 중인 이력이 있으면 예외가 발생한다")
-    void 운영_서포터즈로_활동_중인_이력이_있으면_예외가_발생한다() {
+    @DisplayName("활동 중 상태로 운영 서포터즈를 추가할 때 기존 활동 중 이력이 있으면 예외가 발생한다")
+    void 활동_중_상태로_운영_서포터즈를_추가할_때_기존_활동_중_이력이_있으면_예외가_발생한다() {
         // given
-        CreateMemberSupportersRequest request = createMemberSupportersRequest();
+        CreateMemberSupportersRequest original = createMemberSupportersRequest();
+        CreateMemberSupportersRequest request = new CreateMemberSupportersRequest(
+            original.name(),
+            original.phoneNumber(),
+            original.email(),
+            original.memberType(),
+            original.jobFamily(),
+            original.recruitTypeDetail(),
+            ActivityStatus.ACTIVE,
+            original.startDate(),
+            original.endDate(),
+            original.activityCertNumber(),
+            original.memo()
+        );
         Long memberId = 1L;
         given(memberActivityRepository.existsActiveSupportersActivityByMemberId(memberId)).willReturn(true);
 

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -75,6 +75,7 @@ class AdminMemberActivityServiceTest {
         assertThat(memberActivity.getMemberId()).isEqualTo(memberId);
         assertThat(memberActivity.getJobFamily()).isEqualTo(request.jobFamily());
         assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(request.recruitTypeDetail());
+        assertThat(memberActivity.getActivityStatus()).isEqualTo(request.activityStatus());
         assertThat(memberActivity.getCareerDetails()).isEqualTo(request.careerDetails());
         assertThat(memberActivity.getExperiencePeriod()).isEqualTo(request.experiencePeriod());
         assertThat(memberActivity.getMemo()).isEqualTo(request.memo());
@@ -108,12 +109,11 @@ class AdminMemberActivityServiceTest {
     }
 
     @Test
-    @DisplayName("메이커스팀으로 활동 중인 이력이 없으면 신규 메이커스팀 활동 이력을 생성한다")
-    void 메이커스팀으로_활동_중인_이력이_없으면_신규_메이커스팀_활동_이력을_생성한다() {
+    @DisplayName("활동 종료 상태로 메이커스팀을 추가하면 기존 활동 중 이력을 조회하지 않고 저장한다")
+    void 활동_종료_상태로_메이커스팀을_추가하면_기존_활동_중_이력을_조회하지_않고_저장한다() {
         // given
         CreateMemberMakersRequest request = createMemberMakersRequest();
         Long memberId = 1L;
-        given(memberActivityRepository.existsActiveMakersActivityByMemberId(memberId)).willReturn(false);
 
         // when
         adminMemberActivityService.createMemberMakersActivity(request, memberId);
@@ -127,6 +127,7 @@ class AdminMemberActivityServiceTest {
         assertThat(memberActivity.getMemberType()).isEqualTo(MemberType.MAKERS);
         assertThat(memberActivity.getJobFamily()).isEqualTo(request.jobFamily());
         assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(request.recruitTypeDetail());
+        assertThat(memberActivity.getActivityStatus()).isEqualTo(request.activityStatus());
         assertThat(memberActivity.getCareerDetails()).isEqualTo(request.careerDetails());
         assertThat(memberActivity.getExperiencePeriod()).isEqualTo(request.experiencePeriod());
         assertThat(memberActivity.getMemo()).isEqualTo(request.memo());
@@ -139,13 +140,14 @@ class AdminMemberActivityServiceTest {
         assertThat(memberActivity.getMemberMakers().getCompany()).isEqualTo(request.company());
         assertThat(memberActivity.getMemberMakers().getExpertTopics()).isEqualTo(request.expertTopics());
         assertThat(memberActivity.getMemberMakers().getActivityCertNumber()).isEqualTo(request.activityCertNumber());
+        verify(memberActivityRepository, never()).existsActiveMakersActivityByMemberId(memberId);
     }
 
     @Test
-    @DisplayName("메이커스팀으로 활동 중인 이력이 있으면 예외가 발생한다")
-    void 메이커스팀으로_활동_중인_이력이_있으면_예외가_발생한다() {
+    @DisplayName("활동 중 상태로 메이커스팀을 추가할 때 기존 활동 중 이력이 있으면 예외가 발생한다")
+    void 활동_중_상태로_메이커스팀을_추가할_때_기존_활동_중_이력이_있으면_예외가_발생한다() {
         // given
-        CreateMemberMakersRequest request = createMemberMakersRequest();
+        CreateMemberMakersRequest request = createMemberMakersRequest(ActivityStatus.ACTIVE);
         Long memberId = 1L;
         given(memberActivityRepository.existsActiveMakersActivityByMemberId(memberId)).willReturn(true);
 
@@ -338,6 +340,7 @@ class AdminMemberActivityServiceTest {
             "01012345678",
             JobFamily.BE,
             RecruitTypeDetail.REGULAR,
+            ActivityStatus.COMPLETED,
             CareerDetails.EMPLOYEE,
             1L,
             2L,
@@ -349,6 +352,10 @@ class AdminMemberActivityServiceTest {
     }
 
     private CreateMemberMakersRequest createMemberMakersRequest() {
+        return createMemberMakersRequest(ActivityStatus.ENDED);
+    }
+
+    private CreateMemberMakersRequest createMemberMakersRequest(ActivityStatus activityStatus) {
         return new CreateMemberMakersRequest(
             "김메이커",
             "maker@ject.kr",
@@ -357,6 +364,7 @@ class AdminMemberActivityServiceTest {
             CareerDetails.EMPLOYEE,
             MakersTeam.TEAM_1,
             RecruitTypeDetail.REGULAR,
+            activityStatus,
             Region.SEOUL,
             List.of("HEALTHCARE", "FINTECH", "AI"),
             ExperiencePeriod.ONE_TO_TWO,

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -225,38 +225,6 @@ class AdminMemberActivityServiceTest {
         verify(memberActivityRepository, never()).save(any(MemberActivity.class));
     }
 
-    @Test
-    @DisplayName("운영 서포터즈가 아닌 구성원 유형이면 활동 이력을 생성하지 않는다")
-    void 운영_서포터즈가_아닌_구성원_유형이면_활동_이력을_생성하지_않는다() {
-        // given
-        CreateMemberSupportersRequest original = createMemberSupportersRequest();
-        CreateMemberSupportersRequest request = new CreateMemberSupportersRequest(
-            original.name(),
-            original.phoneNumber(),
-            original.email(),
-            MemberType.MAKERS,
-            original.jobFamily(),
-            original.recruitTypeDetail(),
-            original.activityStatus(),
-            original.startDate(),
-            original.endDate(),
-            original.activityCertNumber(),
-            original.memo()
-        );
-
-        // when
-        Throwable throwable = catchThrowable(() ->
-            adminMemberActivityService.createMemberSupportersActivity(request, 1L)
-        );
-
-        // then
-        assertThat(throwable)
-            .isInstanceOf(MemberException.class)
-            .extracting("errorCode")
-            .isEqualTo(MemberErrorCode.INVALID_MEMBER_TYPE);
-        verify(memberActivityRepository, never()).save(any(MemberActivity.class));
-    }
-
     /**
      * 일반 구성원 목록 조회 테스트
      */

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -14,6 +14,7 @@ import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
 import org.ject.support.admin.member.dto.result.SearchMemberSemesterPageResult;
 import org.ject.support.common.response.CursorPageResponse;
@@ -161,6 +162,86 @@ class AdminMemberActivityServiceTest {
         verify(memberActivityRepository, never()).save(any(MemberActivity.class));
     }
 
+    @Test
+    @DisplayName("운영 서포터즈로 활동 중인 이력이 없으면 신규 운영 서포터즈 활동 이력을 생성한다")
+    void 운영_서포터즈로_활동_중인_이력이_없으면_신규_운영_서포터즈_활동_이력을_생성한다() {
+        // given
+        CreateMemberSupportersRequest request = createMemberSupportersRequest();
+        Long memberId = 1L;
+        given(memberActivityRepository.existsActiveSupportersActivityByMemberId(memberId)).willReturn(false);
+
+        // when
+        adminMemberActivityService.createMemberSupportersActivity(request, memberId);
+
+        // then
+        ArgumentCaptor<MemberActivity> captor = ArgumentCaptor.forClass(MemberActivity.class);
+        verify(memberActivityRepository).save(captor.capture());
+
+        MemberActivity memberActivity = captor.getValue();
+        assertThat(memberActivity.getMemberId()).isEqualTo(memberId);
+        assertThat(memberActivity.getMemberType()).isEqualTo(MemberType.SUPPORTERS);
+        assertThat(memberActivity.getJobFamily()).isEqualTo(request.jobFamily());
+        assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(request.recruitTypeDetail());
+        assertThat(memberActivity.getActivityStatus()).isEqualTo(request.activityStatus());
+        assertThat(memberActivity.getStartDate()).isEqualTo(request.startDate());
+        assertThat(memberActivity.getEndDate()).isEqualTo(request.endDate());
+        assertThat(memberActivity.getMemo()).isEqualTo(request.memo());
+        assertThat(memberActivity.getMemberSupporters().getActivityCertNumber()).isEqualTo(request.activityCertNumber());
+    }
+
+    @Test
+    @DisplayName("운영 서포터즈로 활동 중인 이력이 있으면 예외가 발생한다")
+    void 운영_서포터즈로_활동_중인_이력이_있으면_예외가_발생한다() {
+        // given
+        CreateMemberSupportersRequest request = createMemberSupportersRequest();
+        Long memberId = 1L;
+        given(memberActivityRepository.existsActiveSupportersActivityByMemberId(memberId)).willReturn(true);
+
+        // when
+        Throwable throwable = catchThrowable(() ->
+            adminMemberActivityService.createMemberSupportersActivity(request, memberId)
+        );
+
+        // then
+        assertThat(throwable)
+            .isInstanceOf(MemberException.class)
+            .extracting("errorCode")
+            .isEqualTo(MemberErrorCode.ALREADY_EXIST_ACTIVE_MEMBER_SUPPORTERS_ACTIVITY);
+        verify(memberActivityRepository, never()).save(any(MemberActivity.class));
+    }
+
+    @Test
+    @DisplayName("운영 서포터즈가 아닌 구성원 유형이면 활동 이력을 생성하지 않는다")
+    void 운영_서포터즈가_아닌_구성원_유형이면_활동_이력을_생성하지_않는다() {
+        // given
+        CreateMemberSupportersRequest original = createMemberSupportersRequest();
+        CreateMemberSupportersRequest request = new CreateMemberSupportersRequest(
+            original.name(),
+            original.phoneNumber(),
+            original.email(),
+            MemberType.MAKERS,
+            original.jobFamily(),
+            original.recruitTypeDetail(),
+            original.activityStatus(),
+            original.startDate(),
+            original.endDate(),
+            original.activityCertNumber(),
+            original.memo()
+        );
+
+        // when
+        Throwable throwable = catchThrowable(() ->
+            adminMemberActivityService.createMemberSupportersActivity(request, 1L)
+        );
+
+        // then
+        assertThat(throwable)
+            .isInstanceOf(MemberException.class)
+            .extracting("errorCode")
+            .isEqualTo(MemberErrorCode.INVALID_MEMBER_TYPE);
+        verify(memberActivityRepository, never()).save(any(MemberActivity.class));
+    }
+
     /**
      * 일반 구성원 목록 조회 테스트
      */
@@ -274,6 +355,22 @@ class AdminMemberActivityServiceTest {
             "JECT",
             "백오피스",
             "MK-001",
+            "memo"
+        );
+    }
+
+    private CreateMemberSupportersRequest createMemberSupportersRequest() {
+        return new CreateMemberSupportersRequest(
+            "김서포터",
+            "01012341234",
+            "supporter@ject.kr",
+            MemberType.SUPPORTERS,
+            JobFamily.OPS,
+            RecruitTypeDetail.REGULAR,
+            ActivityStatus.ENDED,
+            java.time.LocalDate.of(2025, 5, 19),
+            java.time.LocalDate.of(2025, 12, 19),
+            "SP-001",
             "memo"
         );
     }

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberSemesterUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberSemesterUseCaseTest.java
@@ -58,6 +58,7 @@ class AdminMemberSemesterUseCaseTest {
 			"01012345678",
 			JobFamily.BE,
 			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ACTIVE,
 			CareerDetails.EMPLOYEE,
 			1L,
 			teamId,

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
@@ -39,6 +40,7 @@ class AdminMemberServiceTest {
 			"01012345678",
 			JobFamily.BE,
 			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ACTIVE,
 			CareerDetails.EMPLOYEE,
 			1L,
 			null,

--- a/src/test/java/org/ject/support/domain/member/ActivityStatusTest.java
+++ b/src/test/java/org/ject/support/domain/member/ActivityStatusTest.java
@@ -43,8 +43,8 @@ class ActivityStatusTest {
     }
 
     @Test
-    @DisplayName("메이커스와 운영은 활동 중 활동 종료 중도 이탈 상태를 사용할 수 있다")
-    void 메이커스와_운영은_활동_중_활동_종료_중도_이탈_상태를_사용할_수_있다() {
+    @DisplayName("메이커스는 활동 중 활동 종료 중도 이탈 상태를 사용할 수 있다")
+    void 메이커스는_활동_중_활동_종료_중도_이탈_상태를_사용할_수_있다() {
         // given
         List<ActivityStatus> statuses = List.of(
             ActivityStatus.ACTIVE,
@@ -54,16 +54,14 @@ class ActivityStatusTest {
 
         // when
         boolean makersResult = ActivityStatus.isAllAvailableFor(statuses, MemberType.MAKERS);
-        boolean supportersResult = ActivityStatus.isAllAvailableFor(statuses, MemberType.SUPPORTERS);
 
         // then
         assertThat(makersResult).isTrue();
-        assertThat(supportersResult).isTrue();
     }
 
     @Test
-    @DisplayName("메이커스와 운영은 완주 탈퇴 상태를 사용할 수 없다")
-    void 메이커스와_운영은_완주_탈퇴_상태를_사용할_수_없다() {
+    @DisplayName("메이커스는 완주 탈퇴 상태를 사용할 수 없다")
+    void 메이커스는_완주_탈퇴_상태를_사용할_수_없다() {
         // given
         List<ActivityStatus> statuses = List.of(
             ActivityStatus.COMPLETED,
@@ -72,10 +70,41 @@ class ActivityStatusTest {
 
         // when
         boolean makersResult = ActivityStatus.isAllAvailableFor(statuses, MemberType.MAKERS);
-        boolean supportersResult = ActivityStatus.isAllAvailableFor(statuses, MemberType.SUPPORTERS);
 
         // then
         assertThat(makersResult).isFalse();
-        assertThat(supportersResult).isFalse();
+    }
+
+    @Test
+    @DisplayName("운영 서포터즈는 활동 중 활동 종료 중도 이탈 상태를 사용할 수 있다")
+    void 운영_서포터즈는_활동_중_활동_종료_중도_이탈_상태를_사용할_수_있다() {
+        // given
+        List<ActivityStatus> statuses = List.of(
+            ActivityStatus.ACTIVE,
+            ActivityStatus.ENDED,
+            ActivityStatus.DROPOUT
+        );
+
+        // when
+        boolean result = ActivityStatus.isAllAvailableFor(statuses, MemberType.SUPPORTERS);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("운영 서포터즈는 완주 탈퇴 상태를 사용할 수 없다")
+    void 운영_서포터즈는_완주_탈퇴_상태를_사용할_수_없다() {
+        // given
+        List<ActivityStatus> statuses = List.of(
+            ActivityStatus.COMPLETED,
+            ActivityStatus.WITHDRAWN
+        );
+
+        // when
+        boolean result = ActivityStatus.isAllAvailableFor(statuses, MemberType.SUPPORTERS);
+
+        // then
+        assertThat(result).isFalse();
     }
 }

--- a/src/test/java/org/ject/support/domain/member/ActivityStatusTest.java
+++ b/src/test/java/org/ject/support/domain/member/ActivityStatusTest.java
@@ -10,6 +10,36 @@ import org.junit.jupiter.api.Test;
 class ActivityStatusTest {
 
     @Test
+    @DisplayName("활동 상태가 ACTIVE이면 true를 반환한다")
+    void 활동_상태가_ACTIVE이면_true를_반환한다() {
+        // when
+        boolean result = ActivityStatus.isActive(ActivityStatus.ACTIVE);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("활동 상태가 ACTIVE가 아니면 false를 반환한다")
+    void 활동_상태가_ACTIVE가_아니면_false를_반환한다() {
+        // when
+        boolean result = ActivityStatus.isActive(ActivityStatus.ENDED);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("활동 상태가 null이면 false를 반환한다")
+    void 활동_상태가_null이면_false를_반환한다() {
+        // when
+        boolean result = ActivityStatus.isActive(null);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
     @DisplayName("일반 구성원은 활동 중 완주 탈퇴 상태를 사용할 수 있다")
     void 일반_구성원은_활동_중_완주_탈퇴_상태를_사용할_수_있다() {
         // given

--- a/src/test/java/org/ject/support/domain/member/JobFamilyTest.java
+++ b/src/test/java/org/ject/support/domain/member/JobFamilyTest.java
@@ -2,6 +2,8 @@ package org.ject.support.domain.member;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -80,5 +82,32 @@ class JobFamilyTest {
     @DisplayName("프로덕트 디자이너는 포트폴리오가 필수다")
     void 프로덕트_디자이너는_포트폴리오가_필수다() {
         assertThat(JobFamily.PD.isPortfolioRequired()).isTrue();
+    }
+
+    @Test
+    @DisplayName("정규 기수에서 사용할 수 있는 직군을 반환한다")
+    void 정규_기수에서_사용할_수_있는_직군을_반환한다() {
+        assertThat(availableJobFamilies(MemberType.SEMESTER))
+            .containsExactlyInAnyOrder(JobFamily.PM, JobFamily.PD, JobFamily.FE, JobFamily.BE, JobFamily.APP);
+    }
+
+    @Test
+    @DisplayName("메이커스에서 사용할 수 있는 직군을 반환한다")
+    void 메이커스에서_사용할_수_있는_직군을_반환한다() {
+        assertThat(availableJobFamilies(MemberType.MAKERS))
+            .containsExactlyInAnyOrder(JobFamily.PM, JobFamily.PD, JobFamily.FE, JobFamily.BE);
+    }
+
+    @Test
+    @DisplayName("운영 서포터즈에서 사용할 수 있는 직군을 반환한다")
+    void 운영_서포터즈에서_사용할_수_있는_직군을_반환한다() {
+        assertThat(availableJobFamilies(MemberType.SUPPORTERS))
+            .containsExactlyInAnyOrder(JobFamily.OPS, JobFamily.INFRA, JobFamily.BX, JobFamily.ER);
+    }
+
+    private JobFamily[] availableJobFamilies(MemberType memberType) {
+        return Arrays.stream(JobFamily.values())
+            .filter(jobFamily -> jobFamily.isAvailableFor(memberType))
+            .toArray(JobFamily[]::new);
     }
 }

--- a/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
+++ b/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.member.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.ject.support.domain.member.fixture.SemesterActivityFixture.semesterActivity;
 
@@ -184,6 +185,113 @@ class MemberActivityTest {
 			.isInstanceOf(MemberException.class)
 			.extracting("errorCode")
 			.isEqualTo(MemberErrorCode.INVALID_ACTIVITY_STATUS);
+	}
+
+	@Test
+	@DisplayName("직군이 없으면 예외가 발생한다")
+	void 직군이_없으면_예외가_발생한다() {
+		// when
+		Throwable throwable = catchThrowable(() -> MemberActivity.createSupportersActivity(
+			1L,
+			null,
+			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ACTIVE,
+			null,
+			null,
+			null,
+			null
+		));
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.INVALID_JOB_FAMILY);
+	}
+
+	@Test
+	@DisplayName("활동 상태가 없으면 예외가 발생한다")
+	void 활동_상태가_없으면_예외가_발생한다() {
+		// when
+		Throwable throwable = catchThrowable(() -> MemberActivity.createSupportersActivity(
+			1L,
+			JobFamily.OPS,
+			RecruitTypeDetail.REGULAR,
+			null,
+			null,
+			null,
+			null,
+			null
+		));
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.INVALID_ACTIVITY_STATUS);
+	}
+
+	@Test
+	@DisplayName("활동 종료일이 시작일보다 빠르면 예외가 발생한다")
+	void 활동_종료일이_시작일보다_빠르면_예외가_발생한다() {
+		// when
+		Throwable throwable = catchThrowable(() -> MemberActivity.createSupportersActivity(
+			1L,
+			JobFamily.OPS,
+			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ENDED,
+			java.time.LocalDate.of(2025, 12, 19),
+			java.time.LocalDate.of(2025, 5, 19),
+			null,
+			null
+		));
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.INVALID_ACTIVITY_PERIOD);
+	}
+
+	@Test
+	@DisplayName("시작일 없이 종료일만 있으면 예외가 발생한다")
+	void 시작일_없이_종료일만_있으면_예외가_발생한다() {
+		// when
+		Throwable throwable = catchThrowable(() -> MemberActivity.createSupportersActivity(
+			1L,
+			JobFamily.OPS,
+			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ENDED,
+			null,
+			java.time.LocalDate.of(2025, 12, 19),
+			null,
+			null
+		));
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.INVALID_ACTIVITY_PERIOD);
+	}
+
+	@Test
+	@DisplayName("종료일이 없거나 시작일과 같으면 활동 기간을 허용한다")
+	void 종료일이_없거나_시작일과_같으면_활동_기간을_허용한다() {
+		java.time.LocalDate activityDate = java.time.LocalDate.of(2025, 5, 19);
+
+		assertThatCode(() -> MemberActivity.createSupportersActivity(
+			1L, JobFamily.OPS, RecruitTypeDetail.REGULAR, ActivityStatus.ACTIVE,
+			null, null, null, null
+		)).doesNotThrowAnyException();
+		assertThatCode(() -> MemberActivity.createSupportersActivity(
+			1L, JobFamily.OPS, RecruitTypeDetail.REGULAR, ActivityStatus.ACTIVE,
+			activityDate, null, null, null
+		)).doesNotThrowAnyException();
+		assertThatCode(() -> MemberActivity.createSupportersActivity(
+			1L, JobFamily.OPS, RecruitTypeDetail.REGULAR, ActivityStatus.ENDED,
+			activityDate, activityDate, null, null
+		)).doesNotThrowAnyException();
 	}
 
 	@Test

--- a/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
+++ b/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
@@ -113,6 +113,80 @@ class MemberActivityTest {
 	}
 
 	@Test
+	@DisplayName("운영 서포터즈 활동을 생성하면 관리 항목이 함께 생성된다")
+	void 운영_서포터즈_활동을_생성하면_관리_항목이_함께_생성된다() {
+		// when
+		MemberActivity memberActivity = MemberActivity.createSupportersActivity(
+			1L,
+			JobFamily.OPS,
+			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ENDED,
+			java.time.LocalDate.of(2025, 5, 19),
+			java.time.LocalDate.of(2025, 12, 19),
+			"SP-001",
+			"운영 서포터즈 메모"
+		);
+		MemberSupporters memberSupporters = memberActivity.getMemberSupporters();
+
+		// then
+		assertThat(memberActivity.getMemberId()).isEqualTo(1L);
+		assertThat(memberActivity.getMemberType()).isEqualTo(MemberType.SUPPORTERS);
+		assertThat(memberActivity.getJobFamily()).isEqualTo(JobFamily.OPS);
+		assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(RecruitTypeDetail.REGULAR);
+		assertThat(memberActivity.getActivityStatus()).isEqualTo(ActivityStatus.ENDED);
+		assertThat(memberActivity.getStartDate()).isEqualTo(java.time.LocalDate.of(2025, 5, 19));
+		assertThat(memberActivity.getEndDate()).isEqualTo(java.time.LocalDate.of(2025, 12, 19));
+		assertThat(memberActivity.getMemo()).isEqualTo("운영 서포터즈 메모");
+		assertThat(memberSupporters).isNotNull();
+		assertThat(memberSupporters.getMemberActivity()).isSameAs(memberActivity);
+		assertThat(memberSupporters.getActivityCertNumber()).isEqualTo("SP-001");
+	}
+
+	@Test
+	@DisplayName("구성원 유형에 맞지 않는 포지션으로 활동을 생성하면 예외가 발생한다")
+	void 구성원_유형에_맞지_않는_포지션으로_활동을_생성하면_예외가_발생한다() {
+		// when
+		Throwable throwable = catchThrowable(() -> MemberActivity.createSupportersActivity(
+			1L,
+			JobFamily.FE,
+			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ACTIVE,
+			null,
+			null,
+			null,
+			null
+		));
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.INVALID_JOB_FAMILY);
+	}
+
+	@Test
+	@DisplayName("운영 서포터즈에 맞지 않는 활동 상태로 생성하면 예외가 발생한다")
+	void 운영_서포터즈에_맞지_않는_활동_상태로_생성하면_예외가_발생한다() {
+		// when
+		Throwable throwable = catchThrowable(() -> MemberActivity.createSupportersActivity(
+			1L,
+			JobFamily.OPS,
+			RecruitTypeDetail.REGULAR,
+			ActivityStatus.COMPLETED,
+			null,
+			null,
+			null,
+			null
+		));
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.INVALID_ACTIVITY_STATUS);
+	}
+
+	@Test
 	@DisplayName("팀을 선택하지 않으면 팀 정보 없이 일반 구성원 활동을 생성한다")
 	void 팀을_선택하지_않으면_팀_정보_없이_일반_구성원_활동을_생성한다() {
 		// given

--- a/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
+++ b/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
@@ -3,6 +3,7 @@ package org.ject.support.domain.member.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.ject.support.domain.member.fixture.MakersActivityFixture.makersActivity;
 import static org.ject.support.domain.member.fixture.SemesterActivityFixture.semesterActivity;
 
 import org.ject.support.domain.member.ActivityStatus;
@@ -41,15 +42,17 @@ class MemberActivityTest {
 	}
 
 	@Test
-	@DisplayName("일반 구성원 활동은 ACTIVE 상태로 생성된다")
-	void 일반_구성원_활동은_ACTIVE_상태로_생성된다() {
+	@DisplayName("일반 구성원 활동은 요청한 상태로 생성된다")
+	void 일반_구성원_활동은_요청한_상태로_생성된다() {
 		// given
 
 		// when
-		MemberActivity memberActivity = semesterActivity().build();
+		MemberActivity memberActivity = semesterActivity()
+			.activityStatus(ActivityStatus.COMPLETED)
+			.build();
 
 		// then
-		assertThat(memberActivity.getActivityStatus()).isEqualTo(ActivityStatus.ACTIVE);
+		assertThat(memberActivity.getActivityStatus()).isEqualTo(ActivityStatus.COMPLETED);
 		assertThat(memberActivity.getIsDeleted()).isFalse();
 	}
 
@@ -77,6 +80,7 @@ class MemberActivityTest {
 			1L,
 			JobFamily.FE,
 			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ENDED,
 			CareerDetails.EMPLOYEE,
 			ExperiencePeriod.ONE_TO_TWO,
 			"테스트 메모",
@@ -97,6 +101,7 @@ class MemberActivityTest {
 		assertThat(memberActivity.getMemberType()).isEqualTo(MemberType.MAKERS);
 		assertThat(memberActivity.getJobFamily()).isEqualTo(JobFamily.FE);
 		assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(RecruitTypeDetail.REGULAR);
+		assertThat(memberActivity.getActivityStatus()).isEqualTo(ActivityStatus.ENDED);
 		assertThat(memberActivity.getCareerDetails()).isEqualTo(CareerDetails.EMPLOYEE);
 		assertThat(memberActivity.getExperiencePeriod()).isEqualTo(ExperiencePeriod.ONE_TO_TWO);
 		assertThat(memberActivity.getMemo()).isEqualTo("테스트 메모");
@@ -111,6 +116,36 @@ class MemberActivityTest {
 		assertThat(memberMakers.getCompany()).isEqualTo("JECT");
 		assertThat(memberMakers.getExpertTopics()).isEqualTo("백오피스");
 		assertThat(memberMakers.getActivityCertNumber()).isEqualTo("MK-001");
+	}
+
+	@Test
+	@DisplayName("일반 구성원에 맞지 않는 활동 상태로 생성하면 예외가 발생한다")
+	void 일반_구성원에_맞지_않는_활동_상태로_생성하면_예외가_발생한다() {
+		// when
+		Throwable throwable = catchThrowable(() -> semesterActivity()
+			.activityStatus(ActivityStatus.DROPOUT)
+			.build());
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.INVALID_ACTIVITY_STATUS);
+	}
+
+	@Test
+	@DisplayName("메이커스팀에 맞지 않는 활동 상태로 생성하면 예외가 발생한다")
+	void 메이커스팀에_맞지_않는_활동_상태로_생성하면_예외가_발생한다() {
+		// when
+		Throwable throwable = catchThrowable(() -> makersActivity()
+			.activityStatus(ActivityStatus.COMPLETED)
+			.build());
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.INVALID_ACTIVITY_STATUS);
 	}
 
 	@Test

--- a/src/test/java/org/ject/support/domain/member/fixture/MakersActivityFixture.java
+++ b/src/test/java/org/ject/support/domain/member/fixture/MakersActivityFixture.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.member.fixture;
 
 import org.ject.support.domain.member.Availability;
+import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.CareerLevel;
 import org.ject.support.domain.member.ExperiencePeriod;
@@ -14,6 +15,7 @@ public final class MakersActivityFixture {
     private Long memberId = 1L;
     private JobFamily jobFamily = JobFamily.FE;
     private MakersTeam makersTeam = MakersTeam.TEAM_1;
+    private ActivityStatus activityStatus = ActivityStatus.ACTIVE;
     private boolean deleted = false;
 
     private MakersActivityFixture() {
@@ -38,6 +40,11 @@ public final class MakersActivityFixture {
         return this;
     }
 
+    public MakersActivityFixture activityStatus(ActivityStatus activityStatus) {
+        this.activityStatus = activityStatus;
+        return this;
+    }
+
     public MakersActivityFixture deleted() {
         this.deleted = true;
         return this;
@@ -48,6 +55,7 @@ public final class MakersActivityFixture {
             memberId,
             jobFamily,
             RecruitTypeDetail.REGULAR,
+            activityStatus,
             CareerDetails.EMPLOYEE,
             ExperiencePeriod.ONE_TO_TWO,
             "테스트 메모",

--- a/src/test/java/org/ject/support/domain/member/fixture/SemesterActivityFixture.java
+++ b/src/test/java/org/ject/support/domain/member/fixture/SemesterActivityFixture.java
@@ -82,13 +82,13 @@ public final class SemesterActivityFixture {
             memberId,
             jobFamily,
             recruitTypeDetail,
+            activityStatus,
             careerDetails,
             experiencePeriod,
             memo,
             semesterId,
             teamId
         );
-        memberActivity.updateActivityStatus(activityStatus);
         if (deleted) {
             memberActivity.delete();
         }

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -151,6 +151,19 @@ class MemberActivityRepositoryTest {
         return memberActivity;
     }
 
+    private MemberActivity createSupportersActivity(Long memberId, ActivityStatus activityStatus) {
+        return MemberActivity.createSupportersActivity(
+            memberId,
+            JobFamily.OPS,
+            RecruitTypeDetail.REGULAR,
+            activityStatus,
+            null,
+            null,
+            "SP-001",
+            "테스트 메모"
+        );
+    }
+
     /**
      * 일반 구성원 추가 테스트
      */
@@ -288,6 +301,48 @@ class MemberActivityRepositoryTest {
 
         // when
         boolean result = memberActivityRepository.existsActiveMakersActivityByMemberId(member.getId());
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("운영 서포터즈로 활동 중인 이력이 존재하면 true를 반환한다")
+    void 운영_서포터즈로_활동_중인_이력이_존재하면_true를_반환한다() {
+        // given
+        Member member = memberRepository.save(member().email("supporters@test.com").build());
+        memberActivityRepository.saveAndFlush(createSupportersActivity(member.getId(), ActivityStatus.ACTIVE));
+
+        // when
+        boolean result = memberActivityRepository.existsActiveSupportersActivityByMemberId(member.getId());
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("운영 서포터즈 활동이 ACTIVE가 아니면 false를 반환한다")
+    void 운영_서포터즈_활동이_ACTIVE가_아니면_false를_반환한다() {
+        // given
+        Member member = memberRepository.save(member().email("ended-supporters@test.com").build());
+        memberActivityRepository.saveAndFlush(createSupportersActivity(member.getId(), ActivityStatus.ENDED));
+
+        // when
+        boolean result = memberActivityRepository.existsActiveSupportersActivityByMemberId(member.getId());
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("다른 유형의 ACTIVE 활동이면 운영 서포터즈 활동 조회에서 false를 반환한다")
+    void 다른_유형의_ACTIVE_활동이면_운영_서포터즈_활동_조회에서_false를_반환한다() {
+        // given
+        Member member = memberRepository.save(member().email("active-makers@test.com").build());
+        memberActivityRepository.saveAndFlush(createMakersActivity(member.getId(), ActivityStatus.ACTIVE));
+
+        // when
+        boolean result = memberActivityRepository.existsActiveSupportersActivityByMemberId(member.getId());
 
         // then
         assertThat(result).isFalse();

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -134,6 +134,7 @@ class MemberActivityRepositoryTest {
             memberId,
             JobFamily.FE,
             RecruitTypeDetail.REGULAR,
+            activityStatus,
             CareerDetails.EMPLOYEE,
             ExperiencePeriod.ONE_TO_TWO,
             "테스트 메모",
@@ -147,7 +148,6 @@ class MemberActivityRepositoryTest {
             "백오피스",
             "MK-001"
         );
-        memberActivity.updateActivityStatus(activityStatus);
         return memberActivity;
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #607

## 📝 작업 내용

- 운영 서포터즈 구성원 추가 요청 DTO와 관리자 API를 구현했습니다.
- 운영 서포터즈 활동 생성 시 `MemberActivity`와 `MemberSupporters`가 함께 생성되도록 연관관계를 구성했습니다.
- 구성원 유형별로 사용할 수 있는 `JobFamily`와 `ActivityStatus`를 검증하도록 도메인 로직을 추가했습니다.
- 동일 구성원에게 ACTIVE 상태의 운영 서포터즈 활동이 중복 생성되지 않도록 검증했습니다.
- 도메인, Repository, Service, Controller 계층의 정상·예외 흐름 테스트를 보강했습니다.

## ✅ 테스트

- `./gradlew test`
- JaCoCo 커버리지 검증 통과

## 🙏 리뷰 요구사항 (선택)

- 운영 서포터즈 허용 직군(`OPS`, `INFRA`, `BX`, `ER`)과 활동 상태(`ACTIVE`, `ENDED`, `DROPOUT`) 범위가 정책과 일치하는지 확인 부탁드립니다.
- ACTIVE 활동 중복 검증과 `MemberActivity`–`MemberSupporters` 생명주기 구성이 적절한지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 운영 서포터즈 구성원을 추가하는 관리자 POST 엔드포인트를 제공합니다.
  * 요청 시 직군/활동 상태/활동 기간/인증서 번호 등을 검증하며, 필요 시 멤버를 자동 등록합니다.
* **버그 수정**
  * 직군·활동 상태·활동 기간의 유효성 규칙을 강화하고, 활성 운영 서포터즈 활동의 중복 등록을 차단합니다.
  * 메이커스/일반(세미스터) 구성원 생성에서도 활동 상태 반영 및 검증을 개선했습니다.
* **테스트**
  * 성공/유효성 실패/중복 충돌 시나리오에 대한 통합·도메인 테스트를 추가·보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->