### PR TITLE
[FEAT] 일반, 메이커스팀 구성원 추가 활동 상태 보강

### DIFF
--- a/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberMakersRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberMakersRequest.java
@@ -2,6 +2,7 @@ package org.ject.support.admin.member.dto.request;
 
 import java.util.List;
 
+import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.Availability;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.CareerLevel;
@@ -19,7 +20,7 @@ import jakarta.validation.constraints.Size;
 
 public record CreateMemberMakersRequest(
 
-	// 필수 항목: 이름, 전화번호, 이메일, 직군(포자션), 지원자 신분, 소속, 모집단위
+	// 필수 항목: 이름, 전화번호, 이메일, 직군(포지션), 활동 상태, 지원자 신분, 소속, 모집단위
 
 	@NotBlank(message = "이름을 입력해주세요")
 	@Size(max = 20, message = "이름은 20자 이하로 입력해주세요.")
@@ -46,6 +47,9 @@ public record CreateMemberMakersRequest(
 
 	@NotNull(message = "모집 단위를 선택해주세요")
 	RecruitTypeDetail recruitTypeDetail,
+
+	@NotNull(message = "활동 상태를 선택해주세요")
+	ActivityStatus activityStatus,
 
 	// 선택 항목: 거주지역, 관심도메인, 직무관련경험, 멘토링 가능 여부, 프로젝트 충원 가능 여부, 연사 가능 여부, 경력, 기술, 회사, 공유 가능한 전문 주제, 활동 증명서 번호, 비고
 

--- a/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberSemesterRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/CreateMemberSemesterRequest.java
@@ -2,6 +2,7 @@ package org.ject.support.admin.member.dto.request;
 
 import java.util.List;
 
+import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
@@ -17,7 +18,7 @@ import jakarta.validation.constraints.Size;
 public record CreateMemberSemesterRequest(
 
 	/*
-	필수 항목: 이름, 전화번호, 이메일, 직군(포지션), 지원자 신분, 모집단위, 기수id
+	필수 항목: 이름, 전화번호, 이메일, 직군(포지션), 활동 상태, 지원자 신분, 모집단위, 기수id
 	선택 항목: 팀id, 비고, 관심도메인, 거주지역, 직무 관련 경험
 	 */
 	@NotBlank(message = "이름을 입력해주세요")
@@ -39,6 +40,9 @@ public record CreateMemberSemesterRequest(
 
 	@NotNull(message = "모집 단위를 선택해주세요")
 	RecruitTypeDetail recruitTypeDetail,
+
+	@NotNull(message = "활동 상태를 선택해주세요")
+	ActivityStatus activityStatus,
 
 	@NotNull(message = "지원자 신분을 선택해주세요")
 	CareerDetails careerDetails,

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
@@ -39,6 +39,7 @@ public class AdminMemberActivityService {
 			memberId,
 			request.jobFamily(),
 			request.recruitTypeDetail(),
+			request.activityStatus(),
 			request.careerDetails(),
 			request.experiencePeriod(),
 			request.memo(),
@@ -51,14 +52,17 @@ public class AdminMemberActivityService {
 
 	// 메이커스팀 구성원 추가
 	public void createMemberMakersActivity(CreateMemberMakersRequest request, Long memberId) {
-		// 추가하려는 대상이 이미 활동 중인 상태인지 검증
-		validateDuplicateActiveMakersActivity(memberId);
+		// ACTIVE 상태로 추가할 때 기존 활동 중 이력 검증
+		if (request.activityStatus() == ActivityStatus.ACTIVE) {
+			validateDuplicateActiveMakersActivity(memberId);
+		}
 
 		// MemberActivity생성, 내부에서 MemberMakers 생성
 		MemberActivity memberActivity = MemberActivity.createMakersActivity(
 			memberId,
 			request.jobFamily(),
 			request.recruitTypeDetail(),
+			request.activityStatus(),
 			request.careerDetails(),
 			request.experiencePeriod(),
 			request.memo(),

--- a/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberActivity.java
@@ -96,6 +96,7 @@ public class MemberActivity extends BaseTimeEntity {
         Long memberId,
         JobFamily jobFamily,
         RecruitTypeDetail recruitTypeDetail,
+        ActivityStatus activityStatus,
         CareerDetails careerDetails,
         ExperiencePeriod experiencePeriod,
         String memo,
@@ -103,12 +104,14 @@ public class MemberActivity extends BaseTimeEntity {
         Long teamId
     ){
         validateJobFamily(MemberType.SEMESTER, jobFamily);
+        validateActivityStatus(MemberType.SEMESTER, activityStatus);
 
         MemberActivity memberActivity = MemberActivity.builder()
             .memberId(memberId)
             .memberType(MemberType.SEMESTER)
             .jobFamily(jobFamily)
             .recruitTypeDetail(recruitTypeDetail)
+            .activityStatus(activityStatus)
             .careerDetails(careerDetails)
             .experiencePeriod(experiencePeriod)
             .memo(memo)
@@ -124,6 +127,7 @@ public class MemberActivity extends BaseTimeEntity {
         Long memberId,
         JobFamily jobFamily,
         RecruitTypeDetail recruitTypeDetail,
+        ActivityStatus activityStatus,
         CareerDetails careerDetails,
         ExperiencePeriod experiencePeriod,
         String memo,
@@ -138,12 +142,14 @@ public class MemberActivity extends BaseTimeEntity {
         String activityCertNumber
     ){
         validateJobFamily(MemberType.MAKERS, jobFamily);
+        validateActivityStatus(MemberType.MAKERS, activityStatus);
 
         MemberActivity memberActivity = MemberActivity.builder()
             .memberId(memberId)
             .memberType(MemberType.MAKERS)
             .jobFamily(jobFamily)
             .recruitTypeDetail(recruitTypeDetail)
+            .activityStatus(activityStatus)
             .careerDetails(careerDetails)
             .experiencePeriod(experiencePeriod)
             .memo(memo)

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
@@ -82,7 +82,7 @@ class AdminMemberMakersControllerTest {
 		assertThat(member.getInterestedDomains()).containsExactlyElementsOf(request.interestedDomains());
 		assertThat(member.getRegion()).isEqualTo(request.region());
 		assertThat(memberActivity.getMemberType()).isEqualTo(MemberType.MAKERS);
-		assertThat(memberActivity.getActivityStatus()).isEqualTo(ActivityStatus.ACTIVE);
+		assertThat(memberActivity.getActivityStatus()).isEqualTo(request.activityStatus());
 		assertThat(memberActivity.getJobFamily()).isEqualTo(request.jobFamily());
 		assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(request.recruitTypeDetail());
 		assertThat(memberActivity.getCareerDetails()).isEqualTo(request.careerDetails());
@@ -267,6 +267,7 @@ class AdminMemberMakersControllerTest {
 			CareerDetails.EMPLOYEE,
 			MakersTeam.TEAM_1,
 			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ACTIVE,
 			Region.SEOUL,
 			List.of("HEALTHCARE", "FINTECH", "AI"),
 			ExperiencePeriod.ONE_TO_TWO,

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
@@ -91,6 +91,11 @@ class AdminMemberSemesterControllerTest {
 			MemberType.SEMESTER,
 			semester.getId()
 		)).isTrue();
+		MemberActivity memberActivity = memberActivityRepository.findAll().stream()
+			.filter(activity -> activity.getMemberId().equals(member.getId()))
+			.findFirst()
+			.orElseThrow();
+		assertThat(memberActivity.getActivityStatus()).isEqualTo(request.activityStatus());
 	}
 
 	@Test
@@ -129,6 +134,7 @@ class AdminMemberSemesterControllerTest {
 			"01012345678",
 			JobFamily.BE,
 			RecruitTypeDetail.REGULAR,
+			ActivityStatus.COMPLETED,
 			CareerDetails.EMPLOYEE,
 			semester.getId(),
 			null,
@@ -279,6 +285,7 @@ class AdminMemberSemesterControllerTest {
 			"01012345678",
 			JobFamily.BE,
 			RecruitTypeDetail.REGULAR,
+			ActivityStatus.COMPLETED,
 			CareerDetails.EMPLOYEE,
 			semesterId,
 			teamId,

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -75,6 +75,7 @@ class AdminMemberActivityServiceTest {
         assertThat(memberActivity.getMemberId()).isEqualTo(memberId);
         assertThat(memberActivity.getJobFamily()).isEqualTo(request.jobFamily());
         assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(request.recruitTypeDetail());
+        assertThat(memberActivity.getActivityStatus()).isEqualTo(request.activityStatus());
         assertThat(memberActivity.getCareerDetails()).isEqualTo(request.careerDetails());
         assertThat(memberActivity.getExperiencePeriod()).isEqualTo(request.experiencePeriod());
         assertThat(memberActivity.getMemo()).isEqualTo(request.memo());
@@ -108,12 +109,11 @@ class AdminMemberActivityServiceTest {
     }
 
     @Test
-    @DisplayName("메이커스팀으로 활동 중인 이력이 없으면 신규 메이커스팀 활동 이력을 생성한다")
-    void 메이커스팀으로_활동_중인_이력이_없으면_신규_메이커스팀_활동_이력을_생성한다() {
+    @DisplayName("활동 종료 상태로 메이커스팀을 추가하면 기존 활동 중 이력을 조회하지 않고 저장한다")
+    void 활동_종료_상태로_메이커스팀을_추가하면_기존_활동_중_이력을_조회하지_않고_저장한다() {
         // given
         CreateMemberMakersRequest request = createMemberMakersRequest();
         Long memberId = 1L;
-        given(memberActivityRepository.existsActiveMakersActivityByMemberId(memberId)).willReturn(false);
 
         // when
         adminMemberActivityService.createMemberMakersActivity(request, memberId);
@@ -127,6 +127,7 @@ class AdminMemberActivityServiceTest {
         assertThat(memberActivity.getMemberType()).isEqualTo(MemberType.MAKERS);
         assertThat(memberActivity.getJobFamily()).isEqualTo(request.jobFamily());
         assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(request.recruitTypeDetail());
+        assertThat(memberActivity.getActivityStatus()).isEqualTo(request.activityStatus());
         assertThat(memberActivity.getCareerDetails()).isEqualTo(request.careerDetails());
         assertThat(memberActivity.getExperiencePeriod()).isEqualTo(request.experiencePeriod());
         assertThat(memberActivity.getMemo()).isEqualTo(request.memo());
@@ -139,13 +140,14 @@ class AdminMemberActivityServiceTest {
         assertThat(memberActivity.getMemberMakers().getCompany()).isEqualTo(request.company());
         assertThat(memberActivity.getMemberMakers().getExpertTopics()).isEqualTo(request.expertTopics());
         assertThat(memberActivity.getMemberMakers().getActivityCertNumber()).isEqualTo(request.activityCertNumber());
+        verify(memberActivityRepository, never()).existsActiveMakersActivityByMemberId(memberId);
     }
 
     @Test
-    @DisplayName("메이커스팀으로 활동 중인 이력이 있으면 예외가 발생한다")
-    void 메이커스팀으로_활동_중인_이력이_있으면_예외가_발생한다() {
+    @DisplayName("활동 중 상태로 메이커스팀을 추가할 때 기존 활동 중 이력이 있으면 예외가 발생한다")
+    void 활동_중_상태로_메이커스팀을_추가할_때_기존_활동_중_이력이_있으면_예외가_발생한다() {
         // given
-        CreateMemberMakersRequest request = createMemberMakersRequest();
+        CreateMemberMakersRequest request = createMemberMakersRequest(ActivityStatus.ACTIVE);
         Long memberId = 1L;
         given(memberActivityRepository.existsActiveMakersActivityByMemberId(memberId)).willReturn(true);
 
@@ -338,6 +340,7 @@ class AdminMemberActivityServiceTest {
             "01012345678",
             JobFamily.BE,
             RecruitTypeDetail.REGULAR,
+            ActivityStatus.COMPLETED,
             CareerDetails.EMPLOYEE,
             1L,
             2L,
@@ -349,6 +352,10 @@ class AdminMemberActivityServiceTest {
     }
 
     private CreateMemberMakersRequest createMemberMakersRequest() {
+        return createMemberMakersRequest(ActivityStatus.ENDED);
+    }
+
+    private CreateMemberMakersRequest createMemberMakersRequest(ActivityStatus activityStatus) {
         return new CreateMemberMakersRequest(
             "김메이커",
             "maker@ject.kr",
@@ -357,6 +364,7 @@ class AdminMemberActivityServiceTest {
             CareerDetails.EMPLOYEE,
             MakersTeam.TEAM_1,
             RecruitTypeDetail.REGULAR,
+            activityStatus,
             Region.SEOUL,
             List.of("HEALTHCARE", "FINTECH", "AI"),
             ExperiencePeriod.ONE_TO_TWO,

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberSemesterUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberSemesterUseCaseTest.java
@@ -58,6 +58,7 @@ class AdminMemberSemesterUseCaseTest {
 			"01012345678",
 			JobFamily.BE,
 			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ACTIVE,
 			CareerDetails.EMPLOYEE,
 			1L,
 			teamId,

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
@@ -39,6 +40,7 @@ class AdminMemberServiceTest {
 			"01012345678",
 			JobFamily.BE,
 			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ACTIVE,
 			CareerDetails.EMPLOYEE,
 			1L,
 			null,

--- a/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
+++ b/src/test/java/org/ject/support/domain/member/entity/MemberActivityTest.java
@@ -3,6 +3,7 @@ package org.ject.support.domain.member.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.ject.support.domain.member.fixture.MakersActivityFixture.makersActivity;
 import static org.ject.support.domain.member.fixture.SemesterActivityFixture.semesterActivity;
 
 import org.ject.support.domain.member.ActivityStatus;
@@ -41,15 +42,17 @@ class MemberActivityTest {
 	}
 
 	@Test
-	@DisplayName("일반 구성원 활동은 ACTIVE 상태로 생성된다")
-	void 일반_구성원_활동은_ACTIVE_상태로_생성된다() {
+	@DisplayName("일반 구성원 활동은 요청한 상태로 생성된다")
+	void 일반_구성원_활동은_요청한_상태로_생성된다() {
 		// given
 
 		// when
-		MemberActivity memberActivity = semesterActivity().build();
+		MemberActivity memberActivity = semesterActivity()
+			.activityStatus(ActivityStatus.COMPLETED)
+			.build();
 
 		// then
-		assertThat(memberActivity.getActivityStatus()).isEqualTo(ActivityStatus.ACTIVE);
+		assertThat(memberActivity.getActivityStatus()).isEqualTo(ActivityStatus.COMPLETED);
 		assertThat(memberActivity.getIsDeleted()).isFalse();
 	}
 
@@ -77,6 +80,7 @@ class MemberActivityTest {
 			1L,
 			JobFamily.FE,
 			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ENDED,
 			CareerDetails.EMPLOYEE,
 			ExperiencePeriod.ONE_TO_TWO,
 			"테스트 메모",
@@ -97,6 +101,7 @@ class MemberActivityTest {
 		assertThat(memberActivity.getMemberType()).isEqualTo(MemberType.MAKERS);
 		assertThat(memberActivity.getJobFamily()).isEqualTo(JobFamily.FE);
 		assertThat(memberActivity.getRecruitTypeDetail()).isEqualTo(RecruitTypeDetail.REGULAR);
+		assertThat(memberActivity.getActivityStatus()).isEqualTo(ActivityStatus.ENDED);
 		assertThat(memberActivity.getCareerDetails()).isEqualTo(CareerDetails.EMPLOYEE);
 		assertThat(memberActivity.getExperiencePeriod()).isEqualTo(ExperiencePeriod.ONE_TO_TWO);
 		assertThat(memberActivity.getMemo()).isEqualTo("테스트 메모");
@@ -111,6 +116,36 @@ class MemberActivityTest {
 		assertThat(memberMakers.getCompany()).isEqualTo("JECT");
 		assertThat(memberMakers.getExpertTopics()).isEqualTo("백오피스");
 		assertThat(memberMakers.getActivityCertNumber()).isEqualTo("MK-001");
+	}
+
+	@Test
+	@DisplayName("일반 구성원에 맞지 않는 활동 상태로 생성하면 예외가 발생한다")
+	void 일반_구성원에_맞지_않는_활동_상태로_생성하면_예외가_발생한다() {
+		// when
+		Throwable throwable = catchThrowable(() -> semesterActivity()
+			.activityStatus(ActivityStatus.DROPOUT)
+			.build());
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.INVALID_ACTIVITY_STATUS);
+	}
+
+	@Test
+	@DisplayName("메이커스팀에 맞지 않는 활동 상태로 생성하면 예외가 발생한다")
+	void 메이커스팀에_맞지_않는_활동_상태로_생성하면_예외가_발생한다() {
+		// when
+		Throwable throwable = catchThrowable(() -> makersActivity()
+			.activityStatus(ActivityStatus.COMPLETED)
+			.build());
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.INVALID_ACTIVITY_STATUS);
 	}
 
 	@Test

--- a/src/test/java/org/ject/support/domain/member/fixture/MakersActivityFixture.java
+++ b/src/test/java/org/ject/support/domain/member/fixture/MakersActivityFixture.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.member.fixture;
 
 import org.ject.support.domain.member.Availability;
+import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.CareerLevel;
 import org.ject.support.domain.member.ExperiencePeriod;
@@ -14,6 +15,7 @@ public final class MakersActivityFixture {
     private Long memberId = 1L;
     private JobFamily jobFamily = JobFamily.FE;
     private MakersTeam makersTeam = MakersTeam.TEAM_1;
+    private ActivityStatus activityStatus = ActivityStatus.ACTIVE;
     private boolean deleted = false;
 
     private MakersActivityFixture() {
@@ -38,6 +40,11 @@ public final class MakersActivityFixture {
         return this;
     }
 
+    public MakersActivityFixture activityStatus(ActivityStatus activityStatus) {
+        this.activityStatus = activityStatus;
+        return this;
+    }
+
     public MakersActivityFixture deleted() {
         this.deleted = true;
         return this;
@@ -48,6 +55,7 @@ public final class MakersActivityFixture {
             memberId,
             jobFamily,
             RecruitTypeDetail.REGULAR,
+            activityStatus,
             CareerDetails.EMPLOYEE,
             ExperiencePeriod.ONE_TO_TWO,
             "테스트 메모",

--- a/src/test/java/org/ject/support/domain/member/fixture/SemesterActivityFixture.java
+++ b/src/test/java/org/ject/support/domain/member/fixture/SemesterActivityFixture.java
@@ -82,13 +82,13 @@ public final class SemesterActivityFixture {
             memberId,
             jobFamily,
             recruitTypeDetail,
+            activityStatus,
             careerDetails,
             experiencePeriod,
             memo,
             semesterId,
             teamId
         );
-        memberActivity.updateActivityStatus(activityStatus);
         if (deleted) {
             memberActivity.delete();
         }

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -134,6 +134,7 @@ class MemberActivityRepositoryTest {
             memberId,
             JobFamily.FE,
             RecruitTypeDetail.REGULAR,
+            activityStatus,
             CareerDetails.EMPLOYEE,
             ExperiencePeriod.ONE_TO_TWO,
             "테스트 메모",
@@ -147,7 +148,6 @@ class MemberActivityRepositoryTest {
             "백오피스",
             "MK-001"
         );
-        memberActivity.updateActivityStatus(activityStatus);
         return memberActivity;
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #609

## 📝 작업 내용

- 일반 구성원과 메이커스팀 구성원 추가 요청에서 누락된 `activityStatus` 필드를 추가했습니다.
- 항상 ACTIVE 상태인 구성원만 추가하도록 제한된 기존 로직을 요청받은 활동 상태로 저장하도록 수정했습니다.
- 구성원 유형별로 허용되는 활동 상태인지 도메인에서 검증하도록 보강했습니다.
- 메이커스팀도 운영서포터즈와 마찬가지로 ACTIVE 상태로 추가할 때만 기존 ACTIVE 활동 중복을 검증하여, ENDED, DROPOUT 상태의 과거 활동 정보는 추가할 수 있도록 변경했습니다.
- 관련 테스트를 보강했습니다.

## ✅ 테스트

- `./gradlew cleanTest test`
- 전체 테스트 및 JaCoCo 커버리지 검증 통과

## 🙏 리뷰 요구사항 (선택)

- 일반 구성원은 동일 기수 활동의 상태와 관계없이 중복 생성을 막고, 메이커스팀은 ACTIVE 활동만 중복을 막는 정책이 적절한지 확인 부탁드립니다.