### PR TITLE
[FEAT] 운영 서포터즈 구성원 상세 조회 API 개발

### DIFF
--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersApiSpec.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersApiSpec.java
@@ -2,9 +2,11 @@ package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
 import org.ject.support.admin.member.dto.request.MemberSupportersListRequest;
+import org.ject.support.admin.member.dto.response.MemberSupportersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberSupportersListResponse;
 import org.ject.support.common.response.CursorPageResponse;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,4 +27,10 @@ public interface AdminMemberSupportersApiSpec {
 		description = "운영 서포터즈 구성원 목록을 조회합니다."
 	)
 	CursorPageResponse<MemberSupportersListResponse> getAdminMemberSupportersList(@ModelAttribute MemberSupportersListRequest request);
+
+	@Operation(
+		summary = "운영 서포터즈 구성원 상세 조회",
+		description = "운영 서포터즈 구성원을 상세 조회합니다."
+	)
+	MemberSupportersDetailResponse getAdminMemberSupportersDetail(@PathVariable Long memberActivityId);
 }

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersController.java
@@ -2,11 +2,13 @@ package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
 import org.ject.support.admin.member.dto.request.MemberSupportersListRequest;
+import org.ject.support.admin.member.dto.response.MemberSupportersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberSupportersListResponse;
 import org.ject.support.admin.member.service.AdminMemberSupportersUseCase;
 import org.ject.support.common.response.CursorPageResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,5 +37,11 @@ public class AdminMemberSupportersController implements AdminMemberSupportersApi
 	public CursorPageResponse<MemberSupportersListResponse> getAdminMemberSupportersList(
 		@ModelAttribute @Valid MemberSupportersListRequest request) {
 		return adminMemberSupportersUseCase.getMemberSupportersList(request);
+	}
+
+	@Override
+	@GetMapping("/{memberActivityId}")
+	public MemberSupportersDetailResponse getAdminMemberSupportersDetail(@PathVariable Long memberActivityId) {
+		return adminMemberSupportersUseCase.getMemberSupportersDetail(memberActivityId);
 	}
 }

--- a/src/main/java/org/ject/support/admin/member/dto/projection/MemberMakersDetailProjection.java
+++ b/src/main/java/org/ject/support/admin/member/dto/projection/MemberMakersDetailProjection.java
@@ -13,7 +13,7 @@ import org.ject.support.domain.member.Region;
 import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 
 public record MemberMakersDetailProjection(
-	Long id,
+	Long memberActivityId,
 
 	String name,
 

--- a/src/main/java/org/ject/support/admin/member/dto/projection/MemberSupportersDetailProjection.java
+++ b/src/main/java/org/ject/support/admin/member/dto/projection/MemberSupportersDetailProjection.java
@@ -1,0 +1,24 @@
+package org.ject.support.admin.member.dto.projection;
+
+import java.time.LocalDate;
+
+import org.ject.support.domain.member.ActivityStatus;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+
+public record MemberSupportersDetailProjection(
+	Long memberActivityId,
+	String name,
+	String phoneNumber,
+	String email,
+	MemberType memberType,
+	JobFamily jobFamily,
+	RecruitTypeDetail recruitTypeDetail,
+	ActivityStatus activityStatus,
+	LocalDate startDate,
+	LocalDate endDate,
+	String activityCertNumber,
+	String memo
+) {
+}

--- a/src/main/java/org/ject/support/admin/member/dto/request/MemberMakersListRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/MemberMakersListRequest.java
@@ -9,8 +9,8 @@ public record MemberMakersListRequest(
 	Long cursor,
 
 	// 정책 변경에 대비해 여유롭게 설정
-	@Min(1)
-	@Max(100)
+	@Min(value = 1, message = "조회 개수는 1개 이상이어야 합니다.")
+	@Max(value = 100, message = "조회 개수는 100개 이하여야 합니다.")
 	Integer size
 ) {
 	//size가 없으면 기본 30개

--- a/src/main/java/org/ject/support/admin/member/dto/request/MemberSemesterSearchCondition.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/MemberSemesterSearchCondition.java
@@ -18,8 +18,8 @@ public record MemberSemesterSearchCondition(
 	Long cursor,
 
 	// 정책 변경에 대비해 여유롭게 설정
-	@Min(1)
-	@Max(100)
+	@Min(value = 1, message = "조회 개수는 1개 이상이어야 합니다.")
+	@Max(value = 100, message = "조회 개수는 100개 이하여야 합니다.")
 	Integer size,
 
 	//-- 필터 --

--- a/src/main/java/org/ject/support/admin/member/dto/request/MemberSupportersListRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/MemberSupportersListRequest.java
@@ -9,8 +9,8 @@ public record MemberSupportersListRequest(
 	Long cursor,
 
 	// 정책 변경에 대비해 여유롭게 설정
-	@Min(1)
-	@Max(100)
+	@Min(value = 1, message = "조회 개수는 1개 이상이어야 합니다.")
+	@Max(value = 100, message = "조회 개수는 100개 이하여야 합니다.")
 	Integer size
 ) {
 	// size가 없으면 기본 30개

--- a/src/main/java/org/ject/support/admin/member/dto/response/MemberMakersDetailResponse.java
+++ b/src/main/java/org/ject/support/admin/member/dto/response/MemberMakersDetailResponse.java
@@ -14,7 +14,7 @@ import org.ject.support.domain.member.Region;
 import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 
 public record MemberMakersDetailResponse(
-	Long id,
+	Long memberActivityId,
 
 	String name,
 
@@ -59,7 +59,7 @@ public record MemberMakersDetailResponse(
 ) {
 	public static MemberMakersDetailResponse from(MemberMakersDetailProjection projection) {
 		return new MemberMakersDetailResponse(
-			projection.id(),
+			projection.memberActivityId(),
 			projection.name(),
 			projection.email(),
 			projection.phoneNumber(),

--- a/src/main/java/org/ject/support/admin/member/dto/response/MemberSupportersDetailResponse.java
+++ b/src/main/java/org/ject/support/admin/member/dto/response/MemberSupportersDetailResponse.java
@@ -1,0 +1,41 @@
+package org.ject.support.admin.member.dto.response;
+
+import java.time.LocalDate;
+
+import org.ject.support.admin.member.dto.projection.MemberSupportersDetailProjection;
+import org.ject.support.domain.member.ActivityStatus;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+
+public record MemberSupportersDetailResponse(
+	Long memberActivityId,
+	String name,
+	String phoneNumber,
+	String email,
+	MemberType memberType,
+	JobFamily jobFamily,
+	RecruitTypeDetail recruitTypeDetail,
+	ActivityStatus activityStatus,
+	LocalDate startDate,
+	LocalDate endDate,
+	String activityCertNumber,
+	String memo
+) {
+	public static MemberSupportersDetailResponse from(MemberSupportersDetailProjection projection) {
+		return new MemberSupportersDetailResponse(
+			projection.memberActivityId(),
+			projection.name(),
+			projection.phoneNumber(),
+			projection.email(),
+			projection.memberType(),
+			projection.jobFamily(),
+			projection.recruitTypeDetail(),
+			projection.activityStatus(),
+			projection.startDate(),
+			projection.endDate(),
+			projection.activityCertNumber(),
+			projection.memo()
+		);
+	}
+}

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
@@ -4,6 +4,7 @@ import static org.ject.support.domain.member.exception.MemberErrorCode.*;
 
 import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
+import org.ject.support.admin.member.dto.projection.MemberSupportersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberSupportersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
@@ -29,7 +30,6 @@ import java.util.List;
 public class AdminMemberActivityService {
 
 	private final MemberActivityRepository memberActivityRepository;
-
 
 	public void createMemberSemesterActivity(CreateMemberSemesterRequest request, Long memberId) {
 		// 추가하려는 대상이 같은 기수에 이미 등록되어있는지 중복 검증
@@ -136,6 +136,13 @@ public class AdminMemberActivityService {
 		return memberActivityRepository.findMemberMakersDetail(memberActivityId)
 			.orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 	}
+
+	// 운영 서포터즈 구성원 상세 조회
+	public MemberSupportersDetailProjection getMemberSupportersDetail(Long memberActivityId) {
+		return memberActivityRepository.findMemberSupportersDetail(memberActivityId)
+			.orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+	}
+
 	/*
 	유틸, 검증 함수
 	 */

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberSupportersUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberSupportersUseCase.java
@@ -1,8 +1,10 @@
 package org.ject.support.admin.member.service;
 
+import org.ject.support.admin.member.dto.projection.MemberSupportersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberSupportersListProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
 import org.ject.support.admin.member.dto.request.MemberSupportersListRequest;
+import org.ject.support.admin.member.dto.response.MemberSupportersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberSupportersListResponse;
 import org.ject.support.admin.member.dto.result.MemberPageResult;
 import org.ject.support.common.response.CursorPageResponse;
@@ -29,9 +31,9 @@ public class AdminMemberSupportersUseCase {
 		adminMemberActivityService.createMemberSupportersActivity(request, memberId);
 	}
 
+	// 운영 서포터즈 구성원 목록 조회(커서 기반 페이징)
 	@Transactional(readOnly = true)
 	public CursorPageResponse<MemberSupportersListResponse> getMemberSupportersList(MemberSupportersListRequest request) {
-		// 목록 조회
 		MemberPageResult<MemberSupportersListProjection> pageResult =
 			adminMemberActivityService.getMemberSupportersList(request);
 
@@ -40,5 +42,12 @@ public class AdminMemberSupportersUseCase {
 			MemberSupportersListResponse::from,
 			MemberSupportersListProjection::memberActivityId
 		);
+	}
+
+	// 운영 서포터즈 구성원 상세 조회
+	@Transactional(readOnly = true)
+	public MemberSupportersDetailResponse getMemberSupportersDetail(Long memberActivityId) {
+		MemberSupportersDetailProjection projection = adminMemberActivityService.getMemberSupportersDetail(memberActivityId);
+		return MemberSupportersDetailResponse.from(projection);
 	}
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
+import org.ject.support.admin.member.dto.projection.MemberSupportersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberSupportersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
@@ -29,4 +30,6 @@ public interface MemberActivityQueryRepository {
 	List<MemberSupportersListProjection> findMemberSupportersList(Long cursor, int limit);
 
 	long countMemberSupportersList();
+
+	Optional<MemberSupportersDetailProjection> findMemberSupportersDetail(Long memberActivityId);
 }

--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityQueryRepositoryImpl.java
@@ -4,12 +4,14 @@ import static org.ject.support.domain.member.entity.QMember.*;
 import static org.ject.support.domain.member.entity.QMemberActivity.*;
 import static org.ject.support.domain.member.entity.QMemberMakers.*;
 import static org.ject.support.domain.member.entity.QMemberSemester.*;
+import static org.ject.support.domain.member.entity.QMemberSupporters.*;
 
 import java.util.List;
 import java.util.Optional;
 
 import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
+import org.ject.support.admin.member.dto.projection.MemberSupportersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberSupportersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
@@ -34,9 +36,7 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 
 	private final JPAQueryFactory jpaQueryFactory;
 
-	// 단일 값 기준으로 일반 구성원 필터링
-	//id기준 내림차순 - 최신순
-	//size+1개 조회
+	// 일반 구성원 목록 조회(단일 값 동적 필터)
 	@Override
 	public List<SearchMemberSemesterProjection> searchMemberSemesters(MemberSemesterSearchCondition condition, int limit) {
 		return jpaQueryFactory.select(Projections.constructor(
@@ -68,6 +68,7 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 			.fetch();
 	}
 
+	// 일반 구성원 수 조회(필터 적용)
 	@Override
 	public long countMemberSemesters(MemberSemesterSearchCondition condition) {
 		Long count = jpaQueryFactory.select(memberActivity.id.count())
@@ -116,6 +117,7 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 		);
 	}
 
+	// 메이커스팀 구성원 목록 조회(커서 기반 페이징)
 	@Override
 	public List<MemberMakersListProjection> findMemberMakersList(Long cursor, Integer limit) {
 		return jpaQueryFactory.select(Projections.constructor(
@@ -144,6 +146,7 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 
 	}
 
+	// 메이커스팀 구성원 수 조회
 	@Override
 	public long countMemberMakersList() {
 		Long count = jpaQueryFactory.select(memberActivity.id.count())
@@ -159,6 +162,7 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 		return count == null ? 0L : count;
 	}
 
+	// 메이커스팀 구성원 상세 조회
 	@Override
 	public Optional<MemberMakersDetailProjection> findMemberMakersDetail(Long memberActivityId) {
 		return Optional.ofNullable(
@@ -200,6 +204,7 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 		);
 	}
 
+	// 운영 서포터즈 구성원 목록 조회(커서 기반 페이징)
 	@Override
 	public List<MemberSupportersListProjection> findMemberSupportersList(Long cursor, int limit) {
 		return jpaQueryFactory.select(Projections.constructor(
@@ -224,6 +229,7 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 			.fetch();
 	}
 
+	// 운영 서포터즈 수 조회
 	@Override
 	public long countMemberSupportersList() {
 		Long count = jpaQueryFactory.select(memberActivity.id.count())
@@ -236,6 +242,39 @@ public class MemberActivityQueryRepositoryImpl implements MemberActivityQueryRep
 			).fetchOne();
 
 		return count == null ? 0L : count;
+	}
+
+	// 운영 서포터즈 구성원 상세 조회
+	@Override
+	public Optional<MemberSupportersDetailProjection> findMemberSupportersDetail(Long memberActivityId) {
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.select(Projections.constructor(
+					MemberSupportersDetailProjection.class,
+					memberActivity.id,
+					member.name,
+					member.phoneNumber,
+					member.email,
+					memberActivity.memberType,
+					memberActivity.jobFamily,
+					memberActivity.recruitTypeDetail,
+					memberActivity.activityStatus,
+					memberActivity.startDate,
+					memberActivity.endDate,
+					memberSupporters.activityCertNumber,
+					memberActivity.memo
+				))
+				.from(memberActivity)
+				.join(member).on(member.id.eq(memberActivity.memberId))
+				.join(memberSupporters).on(memberActivity.id.eq(memberSupporters.id))
+				.where(
+					memberActivity.id.eq(memberActivityId),
+					member.isDeleted.isFalse(),
+					memberActivity.isDeleted.isFalse(),
+					memberActivity.memberType.eq(MemberType.SUPPORTERS)
+				)
+				.fetchOne()
+		);
 	}
 
 	// 조회 결과에서 지정 직군의 이름만 분리

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
@@ -241,7 +241,7 @@ class AdminMemberMakersControllerTest {
 		mockMvc.perform(get("/admin/members/makers/{memberActivityId}", memberActivity.getId()))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.status").value("SUCCESS"))
-			.andExpect(jsonPath("$.data.id").value(memberActivity.getId()))
+			.andExpect(jsonPath("$.data.memberActivityId").value(memberActivity.getId()))
 			.andExpect(jsonPath("$.data.name").value("김젝트"))
 			.andExpect(jsonPath("$.data.email").exists())
 			.andExpect(jsonPath("$.data.jobFamily").value(JobFamily.FE.name()))

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
@@ -207,7 +207,8 @@ class AdminMemberMakersControllerTest {
 		mockMvc.perform(get("/admin/members/makers")
 				.param("size", "0"))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"))
+			.andExpect(jsonPath("$.data[0]").value("조회 개수는 1개 이상이어야 합니다."));
 	}
 
 	@Test
@@ -217,7 +218,8 @@ class AdminMemberMakersControllerTest {
 		mockMvc.perform(get("/admin/members/makers")
 				.param("size", "101"))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"))
+			.andExpect(jsonPath("$.data[0]").value("조회 개수는 100개 이하여야 합니다."));
 	}
 
 	@Test

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
@@ -250,6 +250,28 @@ class AdminMemberSemesterControllerTest {
 	}
 
 	@Test
+	@DisplayName("조회 개수가 1개보다 작으면 일반 구성원 목록을 조회하지 않는다")
+	void 조회_개수가_1개보다_작으면_일반_구성원_목록을_조회하지_않는다() throws Exception {
+		// when & then
+		mockMvc.perform(get("/admin/members/semester")
+				.param("size", "0"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"))
+			.andExpect(jsonPath("$.data[0]").value("조회 개수는 1개 이상이어야 합니다."));
+	}
+
+	@Test
+	@DisplayName("조회 개수가 100개보다 크면 일반 구성원 목록을 조회하지 않는다")
+	void 조회_개수가_100개보다_크면_일반_구성원_목록을_조회하지_않는다() throws Exception {
+		// when & then
+		mockMvc.perform(get("/admin/members/semester")
+				.param("size", "101"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"))
+			.andExpect(jsonPath("$.data[0]").value("조회 개수는 100개 이하여야 합니다."));
+	}
+
+	@Test
 	@DisplayName("팀 필터만 있으면 일반 구성원 목록을 조회하지 않는다")
 	void 팀_필터만_있으면_일반_구성원_목록을_조회하지_않는다() throws Exception {
 		// when & then

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberSupportersControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberSupportersControllerTest.java
@@ -161,11 +161,13 @@ class AdminMemberSupportersControllerTest {
 	void 유효하지_않은_페이징_값이면_운영_서포터즈_목록을_조회하지_않는다() throws Exception {
 		mockMvc.perform(get("/admin/members/supporters").param("size", "0"))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"))
+			.andExpect(jsonPath("$.data[0]").value("조회 개수는 1개 이상이어야 합니다."));
 
 		mockMvc.perform(get("/admin/members/supporters").param("size", "101"))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"))
+			.andExpect(jsonPath("$.data[0]").value("조회 개수는 100개 이하여야 합니다."));
 
 		mockMvc.perform(get("/admin/members/supporters").param("cursor", "0"))
 			.andExpect(status().isBadRequest())

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberSupportersControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberSupportersControllerTest.java
@@ -172,6 +172,37 @@ class AdminMemberSupportersControllerTest {
 			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
 	}
 
+	@Test
+	@DisplayName("운영 서포터즈 구성원의 상세정보를 조회한다")
+	void 운영_서포터즈_구성원의_상세정보를_조회한다() throws Exception {
+		// given
+		MemberActivity memberActivity = saveSupportersActivity(uniqueEmail("detail"), ActivityStatus.ENDED);
+
+		// when & then
+		mockMvc.perform(get("/admin/members/supporters/{memberActivityId}", memberActivity.getId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("SUCCESS"))
+			.andExpect(jsonPath("$.data.memberActivityId").value(memberActivity.getId()))
+			.andExpect(jsonPath("$.data.name").value("김젝트"))
+			.andExpect(jsonPath("$.data.phoneNumber").value("01012345678"))
+			.andExpect(jsonPath("$.data.email").exists())
+			.andExpect(jsonPath("$.data.memberType").value(MemberType.SUPPORTERS.name()))
+			.andExpect(jsonPath("$.data.jobFamily").value(JobFamily.OPS.name()))
+			.andExpect(jsonPath("$.data.recruitTypeDetail").value(RecruitTypeDetail.REGULAR.name()))
+			.andExpect(jsonPath("$.data.activityStatus").value(ActivityStatus.ENDED.name()))
+			.andExpect(jsonPath("$.data.activityCertNumber").value("SP-001"))
+			.andExpect(jsonPath("$.data.memo").value("memo"));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 운영 서포터즈 구성원을 조회하면 404를 반환한다")
+	void 존재하지_않는_운영_서포터즈_구성원을_조회하면_404를_반환한다() throws Exception {
+		// when & then
+		mockMvc.perform(get("/admin/members/supporters/{memberActivityId}", 999999999L))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.status").value(MemberErrorCode.NOT_FOUND_MEMBER.getCode()));
+	}
+
 	private CreateMemberSupportersRequest createMemberSupportersRequest(String email, JobFamily jobFamily, String memo) {
 		return new CreateMemberSupportersRequest(
 			"김서포터",

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
+import org.ject.support.admin.member.dto.projection.MemberSupportersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberSupportersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
@@ -328,6 +329,44 @@ class AdminMemberActivityServiceTest {
         verify(memberActivityRepository).findMemberMakersDetail(memberActivityId);
     }
 
+    @Test
+    @DisplayName("운영 서포터즈 구성원의 상세정보를 조회한다")
+    void 운영_서포터즈_구성원의_상세정보를_조회한다() {
+        // given
+        Long memberActivityId = 1L;
+        MemberSupportersDetailProjection projection = memberSupportersDetailProjection(memberActivityId);
+        given(memberActivityRepository.findMemberSupportersDetail(memberActivityId))
+            .willReturn(Optional.of(projection));
+
+        // when
+        MemberSupportersDetailProjection result =
+            adminMemberActivityService.getMemberSupportersDetail(memberActivityId);
+
+        // then
+        assertThat(result).isEqualTo(projection);
+        verify(memberActivityRepository).findMemberSupportersDetail(memberActivityId);
+    }
+
+    @Test
+    @DisplayName("운영 서포터즈 구성원을 찾을 수 없으면 예외가 발생한다")
+    void 운영_서포터즈_구성원을_찾을_수_없으면_예외가_발생한다() {
+        // given
+        Long memberActivityId = 1L;
+        given(memberActivityRepository.findMemberSupportersDetail(memberActivityId))
+            .willReturn(Optional.empty());
+
+        // when
+        Throwable throwable =
+            catchThrowable(() -> adminMemberActivityService.getMemberSupportersDetail(memberActivityId));
+
+        // then
+        assertThat(throwable)
+            .isInstanceOf(MemberException.class)
+            .extracting("errorCode")
+            .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+        verify(memberActivityRepository).findMemberSupportersDetail(memberActivityId);
+    }
+
     private CreateMemberSemesterRequest createMemberSemesterRequest() {
         return new CreateMemberSemesterRequest(
             "김젝트",
@@ -413,6 +452,23 @@ class AdminMemberActivityServiceTest {
             "JECT",
             "백오피스",
             "MK-001",
+            "memo"
+        );
+    }
+
+    private MemberSupportersDetailProjection memberSupportersDetailProjection(Long memberActivityId) {
+        return new MemberSupportersDetailProjection(
+            memberActivityId,
+            "김서포터",
+            "01012341234",
+            "supporter@ject.kr",
+            MemberType.SUPPORTERS,
+            JobFamily.OPS,
+            RecruitTypeDetail.REGULAR,
+            ActivityStatus.ACTIVE,
+            java.time.LocalDate.of(2025, 5, 19),
+            java.time.LocalDate.of(2025, 12, 19),
+            "SP-001",
             "memo"
         );
     }

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberMakersUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberMakersUseCaseTest.java
@@ -107,7 +107,7 @@ class AdminMemberMakersUseCaseTest {
 		MemberMakersDetailResponse response = adminMemberMakersUseCase.getMemberMakersDetail(memberActivityId);
 
 		// then
-		assertThat(response.id()).isEqualTo(projection.id());
+		assertThat(response.memberActivityId()).isEqualTo(projection.memberActivityId());
 		assertThat(response.name()).isEqualTo(projection.name());
 		assertThat(response.email()).isEqualTo(projection.email());
 		assertThat(response.makersTeam()).isEqualTo(projection.makersTeam());

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberSupportersUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberSupportersUseCaseTest.java
@@ -6,13 +6,16 @@ import static org.mockito.BDDMockito.verify;
 
 import java.util.List;
 
+import org.ject.support.admin.member.dto.projection.MemberSupportersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberSupportersListProjection;
 import org.ject.support.admin.member.dto.request.MemberSupportersListRequest;
+import org.ject.support.admin.member.dto.response.MemberSupportersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberSupportersListResponse;
 import org.ject.support.admin.member.dto.result.MemberPageResult;
 import org.ject.support.common.response.CursorPageResponse;
 import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -87,6 +90,23 @@ class AdminMemberSupportersUseCaseTest {
 		assertThat(response.totalCount()).isEqualTo(2L);
 	}
 
+	@Test
+	@DisplayName("운영 서포터즈 구성원의 상세정보를 응답으로 변환한다")
+	void 운영_서포터즈_구성원의_상세정보를_응답으로_변환한다() {
+		// given
+		Long memberActivityId = 1L;
+		MemberSupportersDetailProjection projection = supportersDetailProjection(memberActivityId);
+		given(adminMemberActivityService.getMemberSupportersDetail(memberActivityId)).willReturn(projection);
+
+		// when
+		MemberSupportersDetailResponse response =
+			adminMemberSupportersUseCase.getMemberSupportersDetail(memberActivityId);
+
+		// then
+		assertThat(response).isEqualTo(MemberSupportersDetailResponse.from(projection));
+		verify(adminMemberActivityService).getMemberSupportersDetail(memberActivityId);
+	}
+
 	private MemberSupportersListProjection supportersProjection(Long memberActivityId, String name) {
 		return new MemberSupportersListProjection(
 			memberActivityId,
@@ -95,6 +115,23 @@ class AdminMemberSupportersUseCaseTest {
 			JobFamily.OPS,
 			RecruitTypeDetail.REGULAR,
 			ActivityStatus.ACTIVE,
+			"memo"
+		);
+	}
+
+	private MemberSupportersDetailProjection supportersDetailProjection(Long memberActivityId) {
+		return new MemberSupportersDetailProjection(
+			memberActivityId,
+			"김서포터",
+			"01012345678",
+			"supporters@ject.kr",
+			MemberType.SUPPORTERS,
+			JobFamily.OPS,
+			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ACTIVE,
+			java.time.LocalDate.of(2025, 5, 19),
+			java.time.LocalDate.of(2025, 12, 19),
+			"SP-001",
 			"memo"
 		);
 	}

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -1079,7 +1079,7 @@ class MemberActivityRepositoryTest {
             .orElseThrow();
 
         // then
-        assertThat(projection.id()).isEqualTo(memberActivity.getId());
+        assertThat(projection.memberActivityId()).isEqualTo(memberActivity.getId());
         assertThat(projection.name()).isEqualTo(member.getName());
         assertThat(projection.email()).isEqualTo(member.getEmail());
         assertThat(projection.jobFamily()).isEqualTo(memberActivity.getJobFamily());

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
+import org.ject.support.admin.member.dto.projection.MemberSupportersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberSupportersListProjection;
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
@@ -1125,5 +1126,87 @@ class MemberActivityRepositoryTest {
 
         // then
         assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("운영 서포터즈 구성원의 상세정보를 조회한다")
+    void 운영_서포터즈_구성원의_상세정보를_조회한다() {
+        // given
+        Member member = memberRepository.save(member()
+            .email("supporters-detail@test.com")
+            .build());
+        MemberActivity memberActivity = memberActivityRepository.saveAndFlush(
+            createSupportersActivity(member.getId(), ActivityStatus.ACTIVE));
+
+        // when
+        MemberSupportersDetailProjection projection =
+            memberActivityRepository.findMemberSupportersDetail(memberActivity.getId()).orElseThrow();
+
+        // then
+        assertThat(projection.memberActivityId()).isEqualTo(memberActivity.getId());
+        assertThat(projection.name()).isEqualTo(member.getName());
+        assertThat(projection.phoneNumber()).isEqualTo(member.getPhoneNumber());
+        assertThat(projection.email()).isEqualTo(member.getEmail());
+        assertThat(projection.memberType()).isEqualTo(MemberType.SUPPORTERS);
+        assertThat(projection.jobFamily()).isEqualTo(memberActivity.getJobFamily());
+        assertThat(projection.recruitTypeDetail()).isEqualTo(memberActivity.getRecruitTypeDetail());
+        assertThat(projection.activityStatus()).isEqualTo(memberActivity.getActivityStatus());
+        assertThat(projection.startDate()).isEqualTo(memberActivity.getStartDate());
+        assertThat(projection.endDate()).isEqualTo(memberActivity.getEndDate());
+        assertThat(projection.activityCertNumber())
+            .isEqualTo(memberActivity.getMemberSupporters().getActivityCertNumber());
+        assertThat(projection.memo()).isEqualTo(memberActivity.getMemo());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 활동 이력을 조회하면 빈 결과를 반환한다")
+    void 존재하지_않는_활동_이력을_조회하면_빈_결과를_반환한다() {
+        assertThat(memberActivityRepository.findMemberSupportersDetail(999999999L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("삭제된 구성원은 상세조회에서 제외한다")
+    void 삭제된_구성원은_상세조회에서_제외한다() {
+        // given
+        Member member = memberRepository.save(member()
+            .email("deleted-supporters@test.com")
+            .deleted()
+            .build());
+        MemberActivity memberActivity = memberActivityRepository.saveAndFlush(
+            createSupportersActivity(member.getId(), ActivityStatus.ACTIVE));
+
+        // when & then
+        assertThat(memberActivityRepository.findMemberSupportersDetail(memberActivity.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("삭제된 활동 이력은 상세조회에서 제외한다")
+    void 삭제된_활동_이력은_상세조회에서_제외한다() {
+        // given
+        Member member = memberRepository.save(member()
+            .email("deleted-activity@test.com")
+            .build());
+        MemberActivity memberActivity = memberActivityRepository.saveAndFlush(
+            createSupportersActivity(member.getId(), ActivityStatus.ACTIVE));
+        memberActivityRepository.delete(memberActivity);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when & then
+        assertThat(memberActivityRepository.findMemberSupportersDetail(memberActivity.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("다른 유형의 구성원은 운영 서포터즈 상세조회에서 제외한다")
+    void 다른_유형의_구성원은_운영_서포터즈_상세조회에서_제외한다() {
+        // given
+        Member member = memberRepository.save(member()
+            .email("makers-not-supporters@test.com")
+            .build());
+        MemberActivity memberActivity = memberActivityRepository.saveAndFlush(
+            makersActivity().memberId(member.getId()).build());
+
+        // when & then
+        assertThat(memberActivityRepository.findMemberSupportersDetail(memberActivity.getId())).isEmpty();
     }
 }


### PR DESCRIPTION
#614 PR과 동일합니다!
Squash Merge로 히스토리가 달라져 새로 분기 후 작업했던 커밋을 체리픽했습니다!
이미 승인받은 PR이라 바이패스로 병합합니다!

## #️⃣연관된 이슈

close #541

## 📝 작업 내용

- 운영 서포터즈 구성원 상세 조회 응답 DTO와 Projection을 추가했습니다.
- `GET /admin/members/supporters/{memberActivityId}` API를 연결했습니다.
- 구성원 기본 정보와 소속, 직군, 모집 유형, 활동 상태, 활동 기간, 활동증명서 번호 및 메모를 조회하도록 구현했습니다.
- 삭제된 구성원 및 활동과 운영 서포터즈가 아닌 활동은 상세 조회에서 제외했습니다.
- 존재하지 않는 운영 서포터즈 구성원 조회 시 404 응답을 반환하도록 구성했습니다.
- Repository, Service, UseCase, Controller 계층의 상세 조회 테스트를 보강했습니다.

## ✅ 테스트

- 운영 서포터즈 상세 조회 관련 테스트 61개 통과
- `git diff --check` 통과

## 🙏 리뷰 요구사항 (선택)

- 상세 조회 응답 필드가 운영 서포터즈 구성원 관리에 필요한 항목을 모두 포함하는지 확인 부탁드립니다.
- `Member`, `MemberActivity`, `MemberSupporters` 조인과 삭제 데이터 및 구성원 유형 제외 조건이 적절한지 확인 부탁드립니다.