### PR TITLE
[FEAT] 기수별 행사 목록 조회 및 편집(추가&수정) API 개발

### DIFF
--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersController.java
@@ -6,6 +6,7 @@ import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
 import org.ject.support.admin.member.service.AdminMemberMakersUseCase;
 import org.ject.support.common.response.CursorPageResponse;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,7 +36,7 @@ public class AdminMemberMakersController implements AdminMemberMakersApiSpec{
 	@Override
 	@GetMapping
 	public CursorPageResponse<MemberMakersListResponse> getAdminMemberMakersList(
-		@ModelAttribute @Valid MemberMakersListRequest request) {
+		@ParameterObject @ModelAttribute @Valid MemberMakersListRequest request) {
 		return adminMemberMakersUseCase.getMemberMakersList(request);
 	}
 

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberSemesterController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberSemesterController.java
@@ -5,6 +5,7 @@ import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
 import org.ject.support.admin.member.dto.response.SearchMemberSemesterResponse;
 import org.ject.support.admin.member.service.AdminMemberSemesterUseCase;
 import org.ject.support.common.response.CursorPageResponse;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,7 +35,7 @@ public class AdminMemberSemesterController implements AdminMemberSemesterApiSpec
 	@Override
 	@GetMapping
 	public CursorPageResponse<SearchMemberSemesterResponse> searchAdminMemberSemesterList(
-		@ModelAttribute @Valid MemberSemesterSearchCondition request) {
+		@ParameterObject @ModelAttribute @Valid MemberSemesterSearchCondition request) {
 		return adminMemberUsecase.searchMemberSemester(request);
 	}
 }

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersController.java
@@ -6,6 +6,7 @@ import org.ject.support.admin.member.dto.response.MemberSupportersDetailResponse
 import org.ject.support.admin.member.dto.response.MemberSupportersListResponse;
 import org.ject.support.admin.member.service.AdminMemberSupportersUseCase;
 import org.ject.support.common.response.CursorPageResponse;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,7 +36,7 @@ public class AdminMemberSupportersController implements AdminMemberSupportersApi
 	@Override
 	@GetMapping
 	public CursorPageResponse<MemberSupportersListResponse> getAdminMemberSupportersList(
-		@ModelAttribute @Valid MemberSupportersListRequest request) {
+		@ParameterObject  @ModelAttribute @Valid MemberSupportersListRequest request) {
 		return adminMemberSupportersUseCase.getMemberSupportersList(request);
 	}
 

--- a/src/main/java/org/ject/support/admin/semester/controller/AdminSemesterEventApiSpec.java
+++ b/src/main/java/org/ject/support/admin/semester/controller/AdminSemesterEventApiSpec.java
@@ -1,0 +1,21 @@
+package org.ject.support.admin.semester.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.ject.support.admin.semester.dto.SemesterEventsResponse;
+import org.ject.support.domain.recruit.domain.SemesterEventType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "AdminSemesterEvent", description = "기수별 행사 관리 API")
+public interface AdminSemesterEventApiSpec {
+
+    @Operation(
+            summary = "기수별 행사 목록 조회",
+            description = "선택한 기수와 행사 타입의 행사 목록을 조회합니다.")
+    SemesterEventsResponse getEvents(
+            @PathVariable Long semesterId,
+            @RequestParam SemesterEventType type
+    );
+
+}

--- a/src/main/java/org/ject/support/admin/semester/controller/AdminSemesterEventApiSpec.java
+++ b/src/main/java/org/ject/support/admin/semester/controller/AdminSemesterEventApiSpec.java
@@ -2,9 +2,12 @@ package org.ject.support.admin.semester.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.ject.support.admin.semester.dto.EditSemesterEventsRequest;
 import org.ject.support.admin.semester.dto.SemesterEventsResponse;
 import org.ject.support.domain.recruit.domain.SemesterEventType;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "AdminSemesterEvent", description = "기수별 행사 관리 API")
@@ -18,4 +21,11 @@ public interface AdminSemesterEventApiSpec {
             @RequestParam SemesterEventType type
     );
 
+    @Operation(
+            summary = "기수별 행사 일괄 편집",
+            description = "선택한 기수의 행사 추가와 이름 수정을 원자적으로 처리합니다.")
+    void editEvents(
+            @PathVariable Long semesterId,
+            @RequestBody @Valid EditSemesterEventsRequest request
+    );
 }

--- a/src/main/java/org/ject/support/admin/semester/controller/AdminSemesterEventController.java
+++ b/src/main/java/org/ject/support/admin/semester/controller/AdminSemesterEventController.java
@@ -1,11 +1,15 @@
 package org.ject.support.admin.semester.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.semester.dto.EditSemesterEventsRequest;
 import org.ject.support.admin.semester.dto.SemesterEventsResponse;
 import org.ject.support.admin.semester.service.AdminSemesterEventService;
 import org.ject.support.domain.recruit.domain.SemesterEventType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,4 +31,13 @@ public class AdminSemesterEventController implements AdminSemesterEventApiSpec {
         return adminSemesterEventService.getEvents(semesterId, type);
     }
 
+    // 선택한 기수의 행사 추가 및 이름 수정
+    @Override
+    @PostMapping
+    public void editEvents(
+            @PathVariable Long semesterId,
+            @RequestBody @Valid EditSemesterEventsRequest request
+    ) {
+        adminSemesterEventService.editEvents(semesterId, request);
+    }
 }

--- a/src/main/java/org/ject/support/admin/semester/controller/AdminSemesterEventController.java
+++ b/src/main/java/org/ject/support/admin/semester/controller/AdminSemesterEventController.java
@@ -1,0 +1,30 @@
+package org.ject.support.admin.semester.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.semester.dto.SemesterEventsResponse;
+import org.ject.support.admin.semester.service.AdminSemesterEventService;
+import org.ject.support.domain.recruit.domain.SemesterEventType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/semesters/{semesterId}/events")
+public class AdminSemesterEventController implements AdminSemesterEventApiSpec {
+
+    private final AdminSemesterEventService adminSemesterEventService;
+
+    // 선택한 기수의 행사 목록 조회
+    @Override
+    @GetMapping
+    public SemesterEventsResponse getEvents(
+            @PathVariable Long semesterId,
+            @RequestParam SemesterEventType type
+    ) {
+        return adminSemesterEventService.getEvents(semesterId, type);
+    }
+
+}

--- a/src/main/java/org/ject/support/admin/semester/dto/CreateSemesterEventRequest.java
+++ b/src/main/java/org/ject/support/admin/semester/dto/CreateSemesterEventRequest.java
@@ -1,0 +1,11 @@
+package org.ject.support.admin.semester.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateSemesterEventRequest(
+        @NotBlank(message = "행사 이름을 입력해주세요.")
+        @Size(max = 25, message = "행사 이름은 25자 이하여야 합니다.")
+        String name
+) {
+}

--- a/src/main/java/org/ject/support/admin/semester/dto/EditSemesterEventsRequest.java
+++ b/src/main/java/org/ject/support/admin/semester/dto/EditSemesterEventsRequest.java
@@ -1,0 +1,38 @@
+package org.ject.support.admin.semester.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import org.ject.support.domain.recruit.domain.SemesterEventType;
+
+public record EditSemesterEventsRequest(
+        @NotNull(message = "행사 타입을 입력해주세요.")
+        SemesterEventType type,
+
+        @Size(min = 1, message = "추가 행사 목록은 비어 있을 수 없습니다.")
+        List<@NotNull(message = "추가 행사 항목은 null일 수 없습니다.") @Valid CreateSemesterEventRequest> created,
+
+        @Size(min = 1, message = "수정 행사 목록은 비어 있을 수 없습니다.")
+        List<@NotNull(message = "수정 행사 항목은 null일 수 없습니다.") @Valid UpdateSemesterEventRequest> updated
+) {
+
+    // 추가 또는 수정 요청이 하나 이상 존재하는지 검증
+    @JsonIgnore
+    @AssertTrue(message = "추가 또는 수정 행사 목록 중 하나는 반드시 입력해야 합니다.")
+    public boolean isChanged() {
+        return created != null || updated != null;
+    }
+
+    // 서비스에서 사용할 추가 행사 목록 반환
+    public List<CreateSemesterEventRequest> createdOrEmpty() {
+        return created == null ? List.of() : created;
+    }
+
+    // 서비스에서 사용할 수정 행사 목록 반환
+    public List<UpdateSemesterEventRequest> updatedOrEmpty() {
+        return updated == null ? List.of() : updated;
+    }
+}

--- a/src/main/java/org/ject/support/admin/semester/dto/SemesterEventResponse.java
+++ b/src/main/java/org/ject/support/admin/semester/dto/SemesterEventResponse.java
@@ -1,0 +1,13 @@
+package org.ject.support.admin.semester.dto;
+
+import org.ject.support.domain.recruit.domain.SemesterEvent;
+
+public record SemesterEventResponse(
+        Long id,
+        String name
+) {
+
+    public static SemesterEventResponse from(SemesterEvent semesterEvent) {
+        return new SemesterEventResponse(semesterEvent.getId(), semesterEvent.getName());
+    }
+}

--- a/src/main/java/org/ject/support/admin/semester/dto/SemesterEventsResponse.java
+++ b/src/main/java/org/ject/support/admin/semester/dto/SemesterEventsResponse.java
@@ -1,0 +1,21 @@
+package org.ject.support.admin.semester.dto;
+
+import java.util.List;
+import org.ject.support.domain.recruit.domain.SemesterEvent;
+import org.ject.support.domain.recruit.domain.SemesterEventType;
+
+public record SemesterEventsResponse(
+        SemesterEventType type,
+        List<SemesterEventResponse> events
+) {
+
+    public static SemesterEventsResponse from(
+            SemesterEventType type,
+            List<SemesterEvent> semesterEvents
+    ) {
+        List<SemesterEventResponse> events = semesterEvents.stream()
+                .map(SemesterEventResponse::from)
+                .toList();
+        return new SemesterEventsResponse(type, events);
+    }
+}

--- a/src/main/java/org/ject/support/admin/semester/dto/UpdateSemesterEventRequest.java
+++ b/src/main/java/org/ject/support/admin/semester/dto/UpdateSemesterEventRequest.java
@@ -1,0 +1,15 @@
+package org.ject.support.admin.semester.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateSemesterEventRequest(
+        @NotNull(message = "행사 ID를 입력해주세요.")
+        Long id,
+
+        @NotBlank(message = "행사 이름을 입력해주세요.")
+        @Size(max = 25, message = "행사 이름은 25자 이하여야 합니다.")
+        String name
+) {
+}

--- a/src/main/java/org/ject/support/admin/semester/service/AdminSemesterEventService.java
+++ b/src/main/java/org/ject/support/admin/semester/service/AdminSemesterEventService.java
@@ -1,10 +1,19 @@
 package org.ject.support.admin.semester.service;
 
+import static org.ject.support.domain.recruit.exception.SemesterErrorCode.DUPLICATED_SEMESTER_EVENT_ID;
+import static org.ject.support.domain.recruit.exception.SemesterErrorCode.EXCEEDED_SEMESTER_EVENT_LIMIT;
 import static org.ject.support.domain.recruit.exception.SemesterErrorCode.NOT_FOUND_SEMESTER;
+import static org.ject.support.domain.recruit.exception.SemesterErrorCode.NOT_FOUND_SEMESTER_EVENT;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.semester.dto.CreateSemesterEventRequest;
+import org.ject.support.admin.semester.dto.EditSemesterEventsRequest;
 import org.ject.support.admin.semester.dto.SemesterEventsResponse;
+import org.ject.support.admin.semester.dto.UpdateSemesterEventRequest;
 import org.ject.support.domain.recruit.domain.SemesterEvent;
 import org.ject.support.domain.recruit.domain.SemesterEventType;
 import org.ject.support.domain.recruit.exception.SemesterException;
@@ -16,6 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class AdminSemesterEventService {
+
+    private static final int MAX_EVENT_COUNT_PER_TYPE = 10;
 
     private final SemesterRepository semesterRepository;
     private final SemesterEventRepository semesterEventRepository;
@@ -30,6 +41,36 @@ public class AdminSemesterEventService {
         return SemesterEventsResponse.from(type, events);
     }
 
+    // 기수별 행사 추가와 수정
+    @Transactional
+    public void editEvents(Long semesterId, EditSemesterEventsRequest request) {
+        List<CreateSemesterEventRequest> created = request.createdOrEmpty();
+        List<UpdateSemesterEventRequest> updated = request.updatedOrEmpty();
+
+        // 기수 및 타입별 생성 가능 개수 검증
+        validateSemester(semesterId);
+        validateEventLimit(semesterId, request.type(), created.size());
+
+        // 수정 요청의 중복과 대상 범위 검증
+        validateDuplicatedIds(updated);
+        Map<Long, SemesterEvent> eventsById =
+                findUpdateEvents(semesterId, request.type(), updated);
+
+        // 신규 행사 생성 및 저장
+        List<SemesterEvent> createdEvents = created
+                .stream()
+                .map(createRequest ->
+                        SemesterEvent.create(semesterId, request.type(), createRequest.name()))
+                .toList();
+
+        semesterEventRepository.saveAll(createdEvents);
+
+        // 기존 행사 이름 변경
+        updated.forEach(updateRequest ->
+                eventsById.get(updateRequest.id()).updateName(updateRequest.name()));
+
+    }
+
     // 존재하는 기수인지 검증
     private void validateSemester(Long semesterId) {
         if (!semesterRepository.existsById(semesterId)) {
@@ -37,4 +78,48 @@ public class AdminSemesterEventService {
         }
     }
 
+    // 동일 행사에 대한 중복 수정 방지
+    private void validateDuplicatedIds(List<UpdateSemesterEventRequest> updated) {
+        long distinctIdCount = updated.stream()
+                .map(UpdateSemesterEventRequest::id)
+                .distinct()
+                .count();
+
+        if (distinctIdCount != updated.size()) {
+            throw new SemesterException(DUPLICATED_SEMESTER_EVENT_ID);
+        }
+    }
+
+    // 요청한 기수에 속한 수정 대상 행사 일괄 조회
+    private Map<Long, SemesterEvent> findUpdateEvents(Long semesterId, SemesterEventType type, List<UpdateSemesterEventRequest> updated) {
+        if (updated.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Long> eventIds = updated.stream()
+                .map(UpdateSemesterEventRequest::id)
+                .toList();
+        List<SemesterEvent> events = semesterEventRepository
+                .findAllByIdInAndSemesterIdAndType(eventIds, semesterId, type);
+
+        if (events.size() != eventIds.size()) {
+            throw new SemesterException(NOT_FOUND_SEMESTER_EVENT);
+        }
+
+        return events.stream()
+                .collect(Collectors.toMap(SemesterEvent::getId, Function.identity()));
+    }
+
+    // 기수와 행사 타입별 최대 등록 개수 검증
+    private void validateEventLimit(Long semesterId, SemesterEventType type, int createdCount) {
+        if (createdCount == 0) {
+            return;
+        }
+
+        long currentCount = semesterEventRepository.countBySemesterIdAndType(semesterId, type);
+
+        if (currentCount + createdCount > MAX_EVENT_COUNT_PER_TYPE) {
+            throw new SemesterException(EXCEEDED_SEMESTER_EVENT_LIMIT);
+        }
+    }
 }

--- a/src/main/java/org/ject/support/admin/semester/service/AdminSemesterEventService.java
+++ b/src/main/java/org/ject/support/admin/semester/service/AdminSemesterEventService.java
@@ -1,0 +1,40 @@
+package org.ject.support.admin.semester.service;
+
+import static org.ject.support.domain.recruit.exception.SemesterErrorCode.NOT_FOUND_SEMESTER;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.semester.dto.SemesterEventsResponse;
+import org.ject.support.domain.recruit.domain.SemesterEvent;
+import org.ject.support.domain.recruit.domain.SemesterEventType;
+import org.ject.support.domain.recruit.exception.SemesterException;
+import org.ject.support.domain.recruit.repository.SemesterEventRepository;
+import org.ject.support.domain.recruit.repository.SemesterRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminSemesterEventService {
+
+    private final SemesterRepository semesterRepository;
+    private final SemesterEventRepository semesterEventRepository;
+
+    // 선택한 기수의 행사 목록 조회
+    @Transactional(readOnly = true)
+    public SemesterEventsResponse getEvents(Long semesterId, SemesterEventType type) {
+        validateSemester(semesterId);
+
+        List<SemesterEvent> events =
+                semesterEventRepository.findAllBySemesterIdAndTypeOrderByIdAsc(semesterId, type);
+        return SemesterEventsResponse.from(type, events);
+    }
+
+    // 존재하는 기수인지 검증
+    private void validateSemester(Long semesterId) {
+        if (!semesterRepository.existsById(semesterId)) {
+            throw new SemesterException(NOT_FOUND_SEMESTER);
+        }
+    }
+
+}

--- a/src/main/java/org/ject/support/common/springdoc/SpringdocConfig.java
+++ b/src/main/java/org/ject/support/common/springdoc/SpringdocConfig.java
@@ -10,10 +10,16 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.core.jackson.ModelResolver;
 
 @Configuration
 @RequiredArgsConstructor
 public class SpringdocConfig {
+
+    static {
+        // 모든 enum을 공통 Schema로 등록
+        ModelResolver.enumsAsRef = true;
+    }
 
     private final SuccessResponseCustomizer successResponseCustomizer;
     private final ErrorResponseCustomizer errorResponseCustomizer;

--- a/src/main/java/org/ject/support/domain/recruit/domain/SemesterEvent.java
+++ b/src/main/java/org/ject/support/domain/recruit/domain/SemesterEvent.java
@@ -17,7 +17,7 @@ import org.ject.support.domain.base.BaseTimeEntity;
 
 @Entity
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @Table(name = "semester_event")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -40,4 +40,22 @@ public class SemesterEvent extends BaseTimeEntity {
     @Column(nullable = false)
     @Builder.Default
     private Boolean isRequired = true;
+
+    // 기수별 행사 생성
+    public static SemesterEvent create(
+            Long semesterId,
+            SemesterEventType type,
+            String name
+    ) {
+        return SemesterEvent.builder()
+                .semesterId(semesterId)
+                .type(type)
+                .name(name)
+                .build();
+    }
+
+    // 기수별 행사 이름 변경
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/org/ject/support/domain/recruit/domain/SemesterEvent.java
+++ b/src/main/java/org/ject/support/domain/recruit/domain/SemesterEvent.java
@@ -34,7 +34,7 @@ public class SemesterEvent extends BaseTimeEntity {
     @Column(columnDefinition = "varchar(45)", nullable = false)
     private SemesterEventType type;
 
-    @Column(length = 100, nullable = false)
+    @Column(length = 25, nullable = false)
     private String name;
 
     @Column(nullable = false)

--- a/src/main/java/org/ject/support/domain/recruit/exception/SemesterErrorCode.java
+++ b/src/main/java/org/ject/support/domain/recruit/exception/SemesterErrorCode.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import org.ject.support.common.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
@@ -12,6 +13,9 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 public enum SemesterErrorCode implements ErrorCode {
     NOT_FOUND_RECRUITING_SEMESTER(NOT_FOUND, "SEMESTER-1", "현재 모집중인 기수가 존재하지 않습니다."),
     NOT_FOUND_SEMESTER(NOT_FOUND, "SEMESTER-2", "기수가 존재하지 않습니다."),
+    NOT_FOUND_SEMESTER_EVENT(NOT_FOUND, "SEMESTER-3", "기수의 행사를 찾을 수 없습니다."),
+    DUPLICATED_SEMESTER_EVENT_ID(BAD_REQUEST, "SEMESTER-4", "중복된 행사 ID가 존재합니다."),
+    EXCEEDED_SEMESTER_EVENT_LIMIT(BAD_REQUEST, "SEMESTER-5", "기수별 행사 유형은 최대 10개까지 등록할 수 있습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/ject/support/domain/recruit/repository/SemesterEventRepository.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/SemesterEventRepository.java
@@ -1,0 +1,15 @@
+package org.ject.support.domain.recruit.repository;
+
+import java.util.List;
+import org.ject.support.domain.recruit.domain.SemesterEvent;
+import org.ject.support.domain.recruit.domain.SemesterEventType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SemesterEventRepository extends JpaRepository<SemesterEvent, Long> {
+
+    List<SemesterEvent> findAllBySemesterIdAndTypeOrderByIdAsc(
+            Long semesterId,
+            SemesterEventType type
+    );
+
+}

--- a/src/main/java/org/ject/support/domain/recruit/repository/SemesterEventRepository.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/SemesterEventRepository.java
@@ -1,5 +1,6 @@
 package org.ject.support.domain.recruit.repository;
 
+import java.util.Collection;
 import java.util.List;
 import org.ject.support.domain.recruit.domain.SemesterEvent;
 import org.ject.support.domain.recruit.domain.SemesterEventType;
@@ -12,4 +13,11 @@ public interface SemesterEventRepository extends JpaRepository<SemesterEvent, Lo
             SemesterEventType type
     );
 
+    List<SemesterEvent> findAllByIdInAndSemesterIdAndType(
+            Collection<Long> ids,
+            Long semesterId,
+            SemesterEventType type
+    );
+
+    long countBySemesterIdAndType(Long semesterId, SemesterEventType type);
 }

--- a/src/main/resources/db/migration/V36__shorten_semester_event_name.sql
+++ b/src/main/resources/db/migration/V36__shorten_semester_event_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE semester_event
+    MODIFY COLUMN name VARCHAR(25) NOT NULL;

--- a/src/test/java/org/ject/support/admin/semester/controller/AdminSemesterEventControllerTest.java
+++ b/src/test/java/org/ject/support/admin/semester/controller/AdminSemesterEventControllerTest.java
@@ -1,0 +1,74 @@
+package org.ject.support.admin.semester.controller;
+
+import static org.ject.support.domain.recruit.domain.SemesterEventType.EVENT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.ject.support.admin.semester.dto.SemesterEventResponse;
+import org.ject.support.admin.semester.dto.SemesterEventsResponse;
+import org.ject.support.admin.semester.service.AdminSemesterEventService;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.common.exception.GlobalExceptionHandler;
+import org.ject.support.common.response.ResponseWrapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class AdminSemesterEventControllerTest extends UnitTestSupport {
+
+    @Mock
+    private AdminSemesterEventService adminSemesterEventService;
+
+    @InjectMocks
+    private AdminSemesterEventController adminSemesterEventController;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        mockMvc = MockMvcBuilders.standaloneSetup(adminSemesterEventController)
+                .setControllerAdvice(new GlobalExceptionHandler(), new ResponseWrapper())
+                .build();
+    }
+
+    @Test
+    @DisplayName("기수와 행사 유형으로 행사 목록을 조회한다")
+    void 기수와_행사_유형으로_행사_목록을_조회한다() throws Exception {
+        // given
+        SemesterEventsResponse response = new SemesterEventsResponse(EVENT, List.of(new SemesterEventResponse(1L, "오리엔테이션")));
+        given(adminSemesterEventService.getEvents(4L, EVENT)).willReturn(response);
+
+        // when, then
+        mockMvc.perform(get("/admin/semesters/{semesterId}/events", 4L)
+                        .param("type", "EVENT"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.type").value("EVENT"))
+                .andExpect(jsonPath("$.data.events[0].id").value(1L))
+                .andExpect(jsonPath("$.data.events[0].name").value("오리엔테이션"));
+    }
+
+    @Test
+    @DisplayName("행사 유형이 없으면 행사 목록을 조회하지 않는다")
+    void 행사_유형이_없으면_행사_목록을_조회하지_않는다() throws Exception {
+        // when, then
+        mockMvc.perform(get("/admin/semesters/{semesterId}/events", 4L))
+                .andExpect(status().isBadRequest());
+
+        verify(adminSemesterEventService, never()).getEvents(any(), any());
+    }
+
+}

--- a/src/test/java/org/ject/support/admin/semester/controller/AdminSemesterEventControllerTest.java
+++ b/src/test/java/org/ject/support/admin/semester/controller/AdminSemesterEventControllerTest.java
@@ -1,18 +1,24 @@
 package org.ject.support.admin.semester.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.ject.support.domain.recruit.domain.SemesterEventType.EVENT;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import org.ject.support.admin.semester.dto.CreateSemesterEventRequest;
+import org.ject.support.admin.semester.dto.EditSemesterEventsRequest;
 import org.ject.support.admin.semester.dto.SemesterEventResponse;
 import org.ject.support.admin.semester.dto.SemesterEventsResponse;
+import org.ject.support.admin.semester.dto.UpdateSemesterEventRequest;
 import org.ject.support.admin.semester.service.AdminSemesterEventService;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.common.exception.GlobalExceptionHandler;
@@ -20,9 +26,11 @@ import org.ject.support.common.response.ResponseWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class AdminSemesterEventControllerTest extends UnitTestSupport {
@@ -71,4 +79,72 @@ class AdminSemesterEventControllerTest extends UnitTestSupport {
         verify(adminSemesterEventService, never()).getEvents(any(), any());
     }
 
+    @Test
+    @DisplayName("기수 행사의 추가와 수정을 함께 요청한다")
+    void 기수_행사의_추가와_수정을_함께_요청한다() throws Exception {
+        // given
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(
+                EVENT,
+                List.of(new CreateSemesterEventRequest("최종 발표")),
+                List.of(new UpdateSemesterEventRequest(1L, "사전 오리엔테이션"))
+        );
+
+        // when, then
+        mockMvc.perform(post("/admin/semesters/{semesterId}/events", 4L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+
+        ArgumentCaptor<EditSemesterEventsRequest> captor = ArgumentCaptor.forClass(EditSemesterEventsRequest.class);
+        verify(adminSemesterEventService).editEvents(eq(4L), captor.capture());
+        assertThat(captor.getValue().type()).isEqualTo(EVENT);
+        assertThat(captor.getValue().created().getFirst().name()).isEqualTo("최종 발표");
+        assertThat(captor.getValue().updated().getFirst().name()).isEqualTo("사전 오리엔테이션");
+    }
+
+    @Test
+    @DisplayName("추가와 수정 목록이 모두 없으면 기수 행사를 변경하지 않는다")
+    void 추가와_수정_목록이_모두_없으면_기수_행사를_변경하지_않는다() throws Exception {
+        // given
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(EVENT, null, null);
+
+        // when, then
+        mockMvc.perform(post("/admin/semesters/{semesterId}/events", 4L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+        verify(adminSemesterEventService, never()).editEvents(any(), any());
+    }
+
+    @Test
+    @DisplayName("변경 목록이 비어 있으면 기수 행사를 변경하지 않는다")
+    void 변경_목록이_비어_있으면_기수_행사를_변경하지_않는다() throws Exception {
+        // given
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(EVENT, List.of(), null);
+
+        // when, then
+        mockMvc.perform(post("/admin/semesters/{semesterId}/events", 4L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+        verify(adminSemesterEventService, never()).editEvents(any(), any());
+    }
+
+    @Test
+    @DisplayName("필수값이 없으면 기수 행사를 변경하지 않는다")
+    void 필수값이_없으면_기수_행사를_변경하지_않는다() throws Exception {
+        // given
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(EVENT, List.of(new CreateSemesterEventRequest(" ")), null);
+
+        // when, then
+        mockMvc.perform(post("/admin/semesters/{semesterId}/events", 4L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+        verify(adminSemesterEventService, never()).editEvents(any(), any());
+    }
 }

--- a/src/test/java/org/ject/support/admin/semester/service/AdminSemesterEventServiceTest.java
+++ b/src/test/java/org/ject/support/admin/semester/service/AdminSemesterEventServiceTest.java
@@ -1,0 +1,96 @@
+package org.ject.support.admin.semester.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.ject.support.domain.recruit.domain.SemesterEventType.EVENT;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import org.ject.support.admin.semester.dto.SemesterEventsResponse;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.domain.recruit.domain.SemesterEvent;
+import org.ject.support.domain.recruit.exception.SemesterErrorCode;
+import org.ject.support.domain.recruit.exception.SemesterException;
+import org.ject.support.domain.recruit.repository.SemesterEventRepository;
+import org.ject.support.domain.recruit.repository.SemesterRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class AdminSemesterEventServiceTest extends UnitTestSupport {
+
+    @Mock
+    private SemesterRepository semesterRepository;
+
+    @Mock
+    private SemesterEventRepository semesterEventRepository;
+
+    @InjectMocks
+    private AdminSemesterEventService adminSemesterEventService;
+
+    @BeforeEach
+    void setUp() {
+        given(semesterRepository.existsById(anyLong())).willReturn(true);
+    }
+
+    @Test
+    @DisplayName("선택한 기수와 행사 유형의 행사 목록을 조회한다")
+    void 선택한_기수와_행사_유형의_행사_목록을_조회한다() {
+        // given
+        SemesterEvent semesterEvent = semesterEvent(1L, 4L, "오리엔테이션");
+        given(semesterEventRepository.findAllBySemesterIdAndTypeOrderByIdAsc(4L, EVENT)).willReturn(List.of(semesterEvent));
+
+        // when
+        SemesterEventsResponse response = adminSemesterEventService.getEvents(4L, EVENT);
+
+        // then
+        assertThat(response.type()).isEqualTo(EVENT);
+        assertThat(response.events()).hasSize(1);
+        assertThat(response.events().getFirst().id()).isEqualTo(1L);
+        assertThat(response.events().getFirst().name()).isEqualTo("오리엔테이션");
+    }
+
+    @Test
+    @DisplayName("조회 결과가 없으면 빈 행사 목록을 반환한다")
+    void 조회_결과가_없으면_빈_행사_목록을_반환한다() {
+        // given
+        given(semesterEventRepository.findAllBySemesterIdAndTypeOrderByIdAsc(4L, EVENT)).willReturn(List.of());
+
+        // when
+        SemesterEventsResponse response = adminSemesterEventService.getEvents(4L, EVENT);
+
+        // then
+        assertThat(response.type()).isEqualTo(EVENT);
+        assertThat(response.events()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 기수의 행사 목록을 조회하면 예외가 발생한다")
+    void 존재하지_않는_기수의_행사_목록을_조회하면_예외가_발생한다() {
+        // given
+        given(semesterRepository.existsById(4L)).willReturn(false);
+
+        // when
+        Throwable throwable = catchThrowable(() -> adminSemesterEventService.getEvents(4L, EVENT));
+
+        // then
+        assertSemesterError(throwable, SemesterErrorCode.NOT_FOUND_SEMESTER);
+    }
+
+    private SemesterEvent semesterEvent(Long id, Long semesterId, String name) {
+        SemesterEvent semesterEvent = SemesterEvent.create(semesterId, EVENT, name);
+        ReflectionTestUtils.setField(semesterEvent, "id", id);
+        return semesterEvent;
+    }
+
+    private void assertSemesterError(Throwable throwable, SemesterErrorCode errorCode) {
+        assertThat(throwable)
+                .isInstanceOf(SemesterException.class)
+                .extracting("errorCode")
+                .isEqualTo(errorCode);
+    }
+}

--- a/src/test/java/org/ject/support/admin/semester/service/AdminSemesterEventServiceTest.java
+++ b/src/test/java/org/ject/support/admin/semester/service/AdminSemesterEventServiceTest.java
@@ -152,8 +152,8 @@ class AdminSemesterEventServiceTest extends UnitTestSupport {
     }
 
     @Test
-    @DisplayName("행사가 최대 개수만큼 등록되어 있어도 기존 행사 이름을 수정한다")
-    void 행사가_최대_개수만큼_등록되어_있어도_기존_행사_이름을_수정한다() {
+    @DisplayName("기존 행사 이름만 수정하면 등록 개수를 조회하지 않는다")
+    void 기존_행사_이름만_수정하면_등록_개수를_조회하지_않는다() {
         // given
         SemesterEvent semesterEvent = semesterEvent(1L, 4L, "오리엔테이션");
         given(semesterEventRepository.findAllByIdInAndSemesterIdAndType(List.of(1L), 4L, EVENT)).willReturn(List.of(semesterEvent));

--- a/src/test/java/org/ject/support/admin/semester/service/AdminSemesterEventServiceTest.java
+++ b/src/test/java/org/ject/support/admin/semester/service/AdminSemesterEventServiceTest.java
@@ -3,11 +3,17 @@ package org.ject.support.admin.semester.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.ject.support.domain.recruit.domain.SemesterEventType.EVENT;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
+import org.ject.support.admin.semester.dto.CreateSemesterEventRequest;
+import org.ject.support.admin.semester.dto.EditSemesterEventsRequest;
 import org.ject.support.admin.semester.dto.SemesterEventsResponse;
+import org.ject.support.admin.semester.dto.UpdateSemesterEventRequest;
 import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.recruit.domain.SemesterEvent;
 import org.ject.support.domain.recruit.exception.SemesterErrorCode;
@@ -17,11 +23,14 @@ import org.ject.support.domain.recruit.repository.SemesterRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class AdminSemesterEventServiceTest extends UnitTestSupport {
+
+    private static final long MAX_EVENT_COUNT = 10L;
 
     @Mock
     private SemesterRepository semesterRepository;
@@ -81,10 +90,215 @@ class AdminSemesterEventServiceTest extends UnitTestSupport {
         assertSemesterError(throwable, SemesterErrorCode.NOT_FOUND_SEMESTER);
     }
 
+    @Test
+    @DisplayName("선택한 행사 유형으로 신규 행사를 추가한다")
+    void 선택한_행사_유형으로_신규_행사를_추가한다() {
+        // given
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(EVENT, List.of(new CreateSemesterEventRequest("오리엔테이션")), null);
+
+        // when
+        adminSemesterEventService.editEvents(4L, request);
+
+        // then
+        SemesterEvent savedEvent = captureSavedEvents().getFirst();
+        assertThat(savedEvent.getSemesterId()).isEqualTo(4L);
+        assertThat(savedEvent.getType()).isEqualTo(EVENT);
+        assertThat(savedEvent.getName()).isEqualTo("오리엔테이션");
+        assertThat(savedEvent.getIsRequired()).isTrue();
+    }
+
+    @Test
+    @DisplayName("행사는 유형별 등록 가능한 최대 개수까지 추가한다")
+    void 행사는_유형별_등록_가능한_최대_개수까지_추가한다() {
+        // given
+        given(semesterEventRepository.countBySemesterIdAndType(4L, EVENT)).willReturn(MAX_EVENT_COUNT - 1);
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(EVENT, List.of(new CreateSemesterEventRequest("최종 발표")), null);
+
+        // when
+        adminSemesterEventService.editEvents(4L, request);
+
+        // then
+        assertThat(captureSavedEvents()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("행사가 유형별 등록 가능한 최대 개수를 초과하면 예외가 발생한다")
+    void 행사가_유형별_등록_가능한_최대_개수를_초과하면_예외가_발생한다() {
+        // given
+        given(semesterEventRepository.countBySemesterIdAndType(4L, EVENT)).willReturn(MAX_EVENT_COUNT);
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(EVENT, List.of(new CreateSemesterEventRequest("최종 발표")), null);
+
+        // when
+        Throwable throwable = catchThrowable(() -> adminSemesterEventService.editEvents(4L, request));
+
+        // then
+        assertSemesterError(throwable, SemesterErrorCode.EXCEEDED_SEMESTER_EVENT_LIMIT);
+        verify(semesterEventRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("기존 기수 행사 이름을 수정한다")
+    void 기존_기수_행사_이름을_수정한다() {
+        // given
+        SemesterEvent semesterEvent = semesterEvent(1L, 4L, "오리엔테이션");
+        given(semesterEventRepository.findAllByIdInAndSemesterIdAndType(List.of(1L), 4L, EVENT)).willReturn(List.of(semesterEvent));
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(EVENT, null, List.of(new UpdateSemesterEventRequest(1L, "사전 오리엔테이션")));
+
+        // when
+        adminSemesterEventService.editEvents(4L, request);
+
+        // then
+        assertThat(semesterEvent.getName()).isEqualTo("사전 오리엔테이션");
+    }
+
+    @Test
+    @DisplayName("행사가 최대 개수만큼 등록되어 있어도 기존 행사 이름을 수정한다")
+    void 행사가_최대_개수만큼_등록되어_있어도_기존_행사_이름을_수정한다() {
+        // given
+        SemesterEvent semesterEvent = semesterEvent(1L, 4L, "오리엔테이션");
+        given(semesterEventRepository.findAllByIdInAndSemesterIdAndType(List.of(1L), 4L, EVENT)).willReturn(List.of(semesterEvent));
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(EVENT, null, List.of(new UpdateSemesterEventRequest(1L, "사전 오리엔테이션")));
+
+        // when
+        adminSemesterEventService.editEvents(4L, request);
+
+        // then
+        assertThat(semesterEvent.getName()).isEqualTo("사전 오리엔테이션");
+        verify(semesterEventRepository, never()).countBySemesterIdAndType(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("같은 행사를 두 번 수정하면 예외가 발생한다")
+    void 같은_행사를_두_번_수정하면_예외가_발생한다() {
+        // given
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(
+                EVENT,
+                null,
+                List.of(
+                        new UpdateSemesterEventRequest(1L, "사전 오리엔테이션"),
+                        new UpdateSemesterEventRequest(1L, "최종 오리엔테이션")
+                )
+        );
+
+        // when
+        Throwable throwable = catchThrowable(() -> adminSemesterEventService.editEvents(4L, request));
+
+        // then
+        assertSemesterError(throwable, SemesterErrorCode.DUPLICATED_SEMESTER_EVENT_ID);
+    }
+
+    @Test
+    @DisplayName("선택한 기수와 행사 유형에 없는 행사를 수정하면 예외가 발생한다")
+    void 선택한_기수와_행사_유형에_없는_행사를_수정하면_예외가_발생한다() {
+        // given
+        given(semesterEventRepository.findAllByIdInAndSemesterIdAndType(List.of(1L), 4L, EVENT)).willReturn(List.of());
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(EVENT, null, List.of(new UpdateSemesterEventRequest(1L, "사전 오리엔테이션")));
+
+        // when
+        Throwable throwable = catchThrowable(() -> adminSemesterEventService.editEvents(4L, request));
+
+        // then
+        assertSemesterError(throwable, SemesterErrorCode.NOT_FOUND_SEMESTER_EVENT);
+    }
+
+    @Test
+    @DisplayName("신규 행사 추가와 기존 행사 이름 수정을 함께 반영한다")
+    void 신규_행사_추가와_기존_행사_이름_수정을_함께_반영한다() {
+        // given
+        SemesterEvent semesterEvent = semesterEvent(1L, 4L, "오리엔테이션");
+        given(semesterEventRepository.findAllByIdInAndSemesterIdAndType(List.of(1L), 4L, EVENT)).willReturn(List.of(semesterEvent));
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(
+                EVENT,
+                List.of(new CreateSemesterEventRequest("최종 발표")),
+                List.of(new UpdateSemesterEventRequest(1L, "사전 오리엔테이션"))
+        );
+
+        // when
+        adminSemesterEventService.editEvents(4L, request);
+
+        // then
+        assertThat(captureSavedEvents().getFirst().getName()).isEqualTo("최종 발표");
+        assertThat(semesterEvent.getName()).isEqualTo("사전 오리엔테이션");
+    }
+
+    @Test
+    @DisplayName("추가 가능한 개수를 초과하면 함께 요청한 이름 수정도 반영하지 않는다")
+    void 추가_가능한_개수를_초과하면_함께_요청한_이름_수정도_반영하지_않는다() {
+        // given
+        SemesterEvent semesterEvent = semesterEvent(1L, 4L, "오리엔테이션");
+        given(semesterEventRepository.countBySemesterIdAndType(4L, EVENT))
+                .willReturn(MAX_EVENT_COUNT);
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(
+                EVENT,
+                List.of(new CreateSemesterEventRequest("최종 발표")),
+                List.of(new UpdateSemesterEventRequest(1L, "사전 오리엔테이션"))
+        );
+
+        // when
+        Throwable throwable = catchThrowable(() -> adminSemesterEventService.editEvents(4L, request));
+
+        // then
+        assertSemesterError(throwable, SemesterErrorCode.EXCEEDED_SEMESTER_EVENT_LIMIT);
+        assertThat(semesterEvent.getName()).isEqualTo("오리엔테이션");
+        verify(semesterEventRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("잘못된 수정 대상이 포함되면 어떤 행사도 변경하지 않는다")
+    void 잘못된_수정_대상이_포함되면_어떤_행사도_변경하지_않는다() {
+        // given
+        SemesterEvent semesterEvent = semesterEvent(1L, 4L, "오리엔테이션");
+        given(semesterEventRepository.findAllByIdInAndSemesterIdAndType(
+                List.of(1L, 2L), 4L, EVENT))
+                .willReturn(List.of(semesterEvent));
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(
+                EVENT,
+                List.of(new CreateSemesterEventRequest("최종 발표")),
+                List.of(
+                        new UpdateSemesterEventRequest(1L, "사전 오리엔테이션"),
+                        new UpdateSemesterEventRequest(2L, "존재하지 않는 행사")
+                )
+        );
+
+        // when
+        Throwable throwable = catchThrowable(() -> adminSemesterEventService.editEvents(4L, request));
+
+        // then
+        assertSemesterError(throwable, SemesterErrorCode.NOT_FOUND_SEMESTER_EVENT);
+        assertThat(semesterEvent.getName()).isEqualTo("오리엔테이션");
+        verify(semesterEventRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 기수에 행사를 추가하거나 수정하면 예외가 발생한다")
+    void 존재하지_않는_기수에_행사를_추가하거나_수정하면_예외가_발생한다() {
+        // given
+        given(semesterRepository.existsById(4L)).willReturn(false);
+        EditSemesterEventsRequest request = new EditSemesterEventsRequest(
+                EVENT,
+                List.of(new CreateSemesterEventRequest("최종 발표")),
+                List.of(new UpdateSemesterEventRequest(1L, "사전 오리엔테이션"))
+        );
+
+        // when
+        Throwable throwable = catchThrowable(() -> adminSemesterEventService.editEvents(4L, request));
+
+        // then
+        assertSemesterError(throwable, SemesterErrorCode.NOT_FOUND_SEMESTER);
+        verify(semesterEventRepository, never()).saveAll(any());
+    }
+
     private SemesterEvent semesterEvent(Long id, Long semesterId, String name) {
         SemesterEvent semesterEvent = SemesterEvent.create(semesterId, EVENT, name);
         ReflectionTestUtils.setField(semesterEvent, "id", id);
         return semesterEvent;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private List<SemesterEvent> captureSavedEvents() {
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(semesterEventRepository).saveAll(captor.capture());
+        return captor.getValue();
     }
 
     private void assertSemesterError(Throwable throwable, SemesterErrorCode errorCode) {

--- a/src/test/java/org/ject/support/domain/recruit/domain/SemesterEventTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/domain/SemesterEventTest.java
@@ -1,0 +1,51 @@
+package org.ject.support.domain.recruit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.recruit.domain.SemesterEventType.EVENT;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SemesterEventTest {
+
+    @Test
+    @DisplayName("기수 행사를 생성한다")
+    void 기수_행사를_생성한다() {
+        // given
+        Long semesterId = 4L;
+        String name = "오리엔테이션";
+
+        // when
+        SemesterEvent semesterEvent = SemesterEvent.create(semesterId, EVENT, name);
+
+        // then
+        assertThat(semesterEvent.getSemesterId()).isEqualTo(semesterId);
+        assertThat(semesterEvent.getType()).isEqualTo(EVENT);
+        assertThat(semesterEvent.getName()).isEqualTo(name);
+    }
+
+    @Test
+    @DisplayName("기수 행사를 생성하면 필수 행사로 설정된다")
+    void 기수_행사를_생성하면_필수_행사로_설정된다() {
+        // when
+        SemesterEvent semesterEvent = SemesterEvent.create(4L, EVENT, "오리엔테이션");
+
+        // then
+        assertThat(semesterEvent.getIsRequired()).isTrue();
+    }
+
+    @Test
+    @DisplayName("기수 행사 이름을 수정한다")
+    void 기수_행사_이름을_수정한다() {
+        // given
+        SemesterEvent semesterEvent = SemesterEvent.create(4L, EVENT, "오리엔테이션");
+
+        // when
+        semesterEvent.updateName("사전 오리엔테이션");
+
+        // then
+        assertThat(semesterEvent.getName()).isEqualTo("사전 오리엔테이션");
+        assertThat(semesterEvent.getSemesterId()).isEqualTo(4L);
+        assertThat(semesterEvent.getType()).isEqualTo(EVENT);
+    }
+}

--- a/src/test/java/org/ject/support/domain/recruit/repository/SemesterEventRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/repository/SemesterEventRepositoryTest.java
@@ -1,0 +1,39 @@
+package org.ject.support.domain.recruit.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.recruit.domain.SemesterEventType.EVENT;
+import static org.ject.support.domain.recruit.domain.SemesterEventType.SURVEY;
+
+import java.util.List;
+import org.ject.support.domain.recruit.domain.SemesterEvent;
+import org.ject.support.testconfig.QueryDslTestConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@Import(QueryDslTestConfig.class)
+@DataJpaTest
+class SemesterEventRepositoryTest {
+
+    @Autowired
+    private SemesterEventRepository semesterEventRepository;
+
+    @Test
+    @DisplayName("기수와 행사 유형으로 행사 목록을 등록 순서대로 조회한다")
+    void 기수와_행사_유형으로_행사_목록을_등록_순서대로_조회한다() {
+        // given
+        SemesterEvent first = semesterEventRepository.save(SemesterEvent.create(4L, EVENT, "오리엔테이션"));
+        SemesterEvent second = semesterEventRepository.save(SemesterEvent.create(4L, EVENT, "중간 발표"));
+        semesterEventRepository.save(SemesterEvent.create(4L, SURVEY, "만족도 조사"));
+        semesterEventRepository.save(SemesterEvent.create(5L, EVENT, "다른 기수 행사"));
+
+        // when
+        List<SemesterEvent> result = semesterEventRepository.findAllBySemesterIdAndTypeOrderByIdAsc(4L, EVENT);
+
+        // then
+        assertThat(result).containsExactly(first, second);
+    }
+
+}

--- a/src/test/java/org/ject/support/domain/recruit/repository/SemesterEventRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/repository/SemesterEventRepositoryTest.java
@@ -36,4 +36,34 @@ class SemesterEventRepositoryTest {
         assertThat(result).containsExactly(first, second);
     }
 
+    @Test
+    @DisplayName("다른 기수나 행사 유형의 행사는 수정 대상에서 제외한다")
+    void 다른_기수나_행사_유형의_행사는_수정_대상에서_제외한다() {
+        // given
+        SemesterEvent target = semesterEventRepository.save(SemesterEvent.create(4L, EVENT, "오리엔테이션"));
+        SemesterEvent otherType = semesterEventRepository.save(SemesterEvent.create(4L, SURVEY, "만족도 조사"));
+        SemesterEvent otherSemester = semesterEventRepository.save(SemesterEvent.create(5L, EVENT, "다른 기수 행사"));
+
+        // when
+        List<SemesterEvent> result = semesterEventRepository.findAllByIdInAndSemesterIdAndType(List.of(target.getId(), otherType.getId(), otherSemester.getId()), 4L, EVENT);
+
+        // then
+        assertThat(result).containsExactly(target);
+    }
+
+    @Test
+    @DisplayName("기수와 행사 유형별 행사 개수를 조회한다")
+    void 기수와_행사_유형별_행사_개수를_조회한다() {
+        // given
+        semesterEventRepository.save(SemesterEvent.create(4L, EVENT, "오리엔테이션"));
+        semesterEventRepository.save(SemesterEvent.create(4L, EVENT, "중간 발표"));
+        semesterEventRepository.save(SemesterEvent.create(4L, SURVEY, "만족도 조사"));
+        semesterEventRepository.save(SemesterEvent.create(5L, EVENT, "다른 기수 행사"));
+
+        // when
+        long count = semesterEventRepository.countBySemesterIdAndType(4L, EVENT);
+
+        // then
+        assertThat(count).isEqualTo(2L);
+    }
 }


### PR DESCRIPTION
FE측에서 참고할 수 있게 BE에서 사용중인 Enum을 하단에 dto와 함께 보여주도록 Swagger관련 설정 추가도 함께 진행했습니다. 우선 작업해뒀지만 불필요하거나 우려가 있다면 제거 후 병합하겠습니다 :)

여러 이슈를 함께 작업하게 되어 죄송합니다!

## #️⃣연관된 이슈

close #582
close #615 
close #619 

## 📝 작업 내용
- 기수와 행사 타입(`EVENT`, `SURVEY`)을 기준으로 행사 목록을 조회하는 API를 구현했습니다.
- 신규 행사 추가와 기존 행사 이름 수정을 하나의 요청에서 원자적으로 처리하는 API를 구현했습니다.
- 추가·수정 기능 호출시 아래와 같은 정책이 적용됩니다.
  - created, updated 둘중 하나는 존재 해야 함.
  - 각 배열은 비어있을 수 없음.
- 기수와 행사 타입별로 최대 10개까지 등록할 수 있도록 제한했습니다.
- `SemesterEvent` 생성을 도메인 함수로 내재화하고 생성 시 필수 행사로 설정되도록 구성했습니다.
- 행사 이름을 최대 25자로 제한하고 `semester_event.name` 컬럼 변경 마이그레이션을 추가했습니다.
- Entity, Repository, Service, Controller 테스트를 추가했습니다.

## ✅ 테스트

- `./gradlew test`
- 전체 테스트 및 JaCoCo 커버리지 검증 통과
- `git diff --check` 통과

## 🙏 리뷰 요구사항 (선택)

- 추가와 수정을 하나의 트랜잭션에서 처리하는 검증 순서와 원자성 보장이 적절한지 확인 부탁드립니다.
- 기수·행사 타입별 최대 10개 제한과 요청 목록 검증 정책이 프론트 편집 흐름에 적합한지 확인 부탁드립니다.