### PR TITLE
feat: 선정 결과 축 도입 및 선정 결과 세팅

### DIFF
--- a/src/main/java/org/ject/support/admin/apply/controller/AdminApplyApiSpec.java
+++ b/src/main/java/org/ject/support/admin/apply/controller/AdminApplyApiSpec.java
@@ -1,0 +1,63 @@
+package org.ject.support.admin.apply.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.ject.support.admin.apply.dto.AdminApplyDetailResponse;
+import org.ject.support.admin.apply.dto.AdminApplyResponse;
+import org.ject.support.admin.apply.dto.SelectionResultUpdateRequest;
+import org.ject.support.admin.apply.dto.SubmittedApplyBulkDeleteRequest;
+import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
+import org.ject.support.domain.apply.domain.ApplyStatus;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.RecruitType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Admin Apply", description = "[관리자] 지원서 관리 API")
+public interface AdminApplyApiSpec {
+
+    @Operation(
+            summary = "지원서 목록 조회",
+            description = "지원서들의 목록을 조회합니다. 모집 공고, 모집 유형, 모집 사유, 기수, 직군, 지원 상태로 필터링할 수 있습니다.")
+    Page<AdminApplyResponse> findApplies(@RequestParam(required = false) ApplyStatus applyStatus,
+                                         @RequestParam(required = false) Long semesterId,
+                                         @RequestParam(required = false) JobFamily jobFamily,
+                                         @RequestParam(required = false) RecruitType recruitType,
+                                         @RequestParam(required = false) RecruitTypeDetail recruitTypeDetail,
+                                         @RequestParam(required = false) Long recruitId,
+                                         @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable);
+
+    @Operation(
+            summary = "지원서 상세 조회",
+            description = "전달한 ID에 해당하는 지원서의 상세 정보를 조회합니다.")
+    AdminApplyDetailResponse findApply(@PathVariable Long applyId,
+                                       @RequestParam(required = false) ApplyStatus applyStatus);
+
+    @Operation(
+            summary = "제출된 지원서 수정",
+            description = "전달한 ID에 해당하는 제출된 지원서의 정보를 수정합니다.")
+    void editSubmittedApply(@PathVariable Long applyId,
+                            @RequestBody @Valid SubmittedApplyEditRequest request);
+
+    @Operation(
+            summary = "지원자 선정 결과 일괄 변경",
+            description = "제출 완료된 지원자들의 선정 결과와 예비 번호를 일괄 변경합니다.")
+    int updateSelectionResults(@RequestBody @Valid SelectionResultUpdateRequest request);
+
+    @Operation(
+            summary = "지원서 삭제",
+            description = "전달한 ID에 해당하는 지원서를 삭제합니다.")
+    void deleteApply(@PathVariable Long applyId);
+
+    @Operation(
+            summary = "지원서 다수 삭제",
+            description = "선택한 다수의 지원서들을 삭제합니다. 삭제한 수를 반환합니다.")
+    int deleteSubmittedApplies(@RequestBody @Valid SubmittedApplyBulkDeleteRequest request);
+}

--- a/src/main/java/org/ject/support/admin/apply/controller/AdminApplyController.java
+++ b/src/main/java/org/ject/support/admin/apply/controller/AdminApplyController.java
@@ -1,7 +1,5 @@
 package org.ject.support.admin.apply.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.apply.dto.AdminApplyDetailResponse;
@@ -32,15 +30,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin/applies")
-@Tag(name = "Admin Apply", description = "[관리자] 지원서 관리 API")
-public class AdminApplyController {
+public class AdminApplyController implements AdminApplyApiSpec {
 
     private final AdminApplyService adminApplyService;
 
+    @Override
     @GetMapping
-    @Operation(
-            summary = "지원서 목록 조회",
-            description = "지원서들의 목록을 조회합니다. 모집 공고, 모집 유형, 모집 사유, 기수, 직군, 지원 상태로 필터링할 수 있습니다.")
     public Page<AdminApplyResponse> findApplies(@RequestParam(required = false) final ApplyStatus applyStatus,
                                                 @RequestParam(required = false) final Long semesterId,
                                                 @RequestParam(required = false) final JobFamily jobFamily,
@@ -53,44 +48,34 @@ public class AdminApplyController {
         return adminApplyService.findApplies(condition, pageable);
     }
 
+    @Override
     @GetMapping("/{applyId}")
-    @Operation(
-            summary = "지원서 상세 조회",
-            description = "전달한 ID에 해당하는 지원서의 상세 정보를 조회합니다.")
     public AdminApplyDetailResponse findApply(@PathVariable final Long applyId,
                                               @RequestParam(required = false) final ApplyStatus applyStatus) {
         return adminApplyService.findApply(applyId, applyStatus);
     }
 
+    @Override
     @PutMapping("/{applyId}")
-    @Operation(
-            summary = "제출된 지원서 수정",
-            description = "전달한 ID에 해당하는 제출된 지원서의 정보를 수정 합니다.")
     public void editSubmittedApply(@PathVariable("applyId") final Long applyId,
                                    @RequestBody @Valid final SubmittedApplyEditRequest request) {
         adminApplyService.updateSubmittedApply(applyId, request);
     }
 
+    @Override
     @PatchMapping("/selection-results")
-    @Operation(
-            summary = "지원자 선정 결과 일괄 변경",
-            description = "제출 완료된 지원자들의 선정 결과와 예비 번호를 일괄 변경합니다.")
     public int updateSelectionResults(@RequestBody @Valid final SelectionResultUpdateRequest request) {
         return adminApplyService.updateSelectionResults(request);
     }
 
+    @Override
     @DeleteMapping("/{applyId}")
-    @Operation(
-            summary = "지원서 삭제",
-            description = "전달한 ID에 해당하는 지원서를 삭제합니다.")
     public void deleteApply(@PathVariable final Long applyId) {
         adminApplyService.deleteApply(applyId);
     }
 
+    @Override
     @DeleteMapping
-    @Operation(
-            summary = "지원서 다수 삭제",
-            description = "선택한 다수의 지원서들을 삭제합니다. 삭제한 수를 반환합니다.")
     public int deleteSubmittedApplies(@RequestBody @Valid final SubmittedApplyBulkDeleteRequest request) {
         return adminApplyService.deleteApplies(request.applyIds());
     }

--- a/src/main/java/org/ject/support/admin/apply/controller/AdminApplyController.java
+++ b/src/main/java/org/ject/support/admin/apply/controller/AdminApplyController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.apply.dto.AdminApplyDetailResponse;
 import org.ject.support.admin.apply.dto.AdminApplyResponse;
 import org.ject.support.admin.apply.dto.AdminApplySearchCondition;
+import org.ject.support.admin.apply.dto.SelectionResultUpdateRequest;
 import org.ject.support.admin.apply.dto.SubmittedApplyBulkDeleteRequest;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.service.AdminApplyService;
@@ -21,6 +22,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -67,6 +69,14 @@ public class AdminApplyController {
     public void editSubmittedApply(@PathVariable("applyId") final Long applyId,
                                    @RequestBody @Valid final SubmittedApplyEditRequest request) {
         adminApplyService.updateSubmittedApply(applyId, request);
+    }
+
+    @PatchMapping("/selection-results")
+    @Operation(
+            summary = "지원자 선정 결과 일괄 변경",
+            description = "제출 완료된 지원자들의 선정 결과와 예비 번호를 일괄 변경합니다.")
+    public int updateSelectionResults(@RequestBody @Valid final SelectionResultUpdateRequest request) {
+        return adminApplyService.updateSelectionResults(request);
     }
 
     @DeleteMapping("/{applyId}")

--- a/src/main/java/org/ject/support/admin/apply/dto/SelectionResultUpdateRequest.java
+++ b/src/main/java/org/ject/support/admin/apply/dto/SelectionResultUpdateRequest.java
@@ -1,0 +1,28 @@
+package org.ject.support.admin.apply.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import org.ject.support.domain.apply.domain.SelectionResult;
+
+@Schema(description = "지원서 선정 결과 일괄 변경 요청")
+public record SelectionResultUpdateRequest(
+        @Schema(description = "모집 공고 ID", example = "1")
+        @NotNull @Positive Long recruitId,
+        @Schema(description = "지원서별 선정 결과")
+        @NotEmpty List<@NotNull @Valid SelectionResultItem> selectionResults
+) {
+
+    public record SelectionResultItem(
+            @Schema(description = "지원서 ID", example = "1")
+            @NotNull @Positive Long applyId,
+            @Schema(description = "선정 결과", example = "PASSED")
+            @NotNull SelectionResult selectionResult,
+            @Schema(description = "예비 번호. 예비 합격일 때만 입력", example = "1", nullable = true)
+            @Positive Integer waitlistNumber
+    ) {
+    }
+}

--- a/src/main/java/org/ject/support/admin/apply/repository/AdminApplyRepository.java
+++ b/src/main/java/org/ject/support/admin/apply/repository/AdminApplyRepository.java
@@ -17,8 +17,13 @@ public interface AdminApplyRepository extends JpaRepository<Apply, Long>, AdminA
     @Query("SELECT a FROM Apply a JOIN FETCH a.applicant LEFT JOIN FETCH a.applicationForm WHERE a.id IN :ids")
     List<Apply> findAllByIdWithApplicant(@Param("ids") List<Long> ids);
 
+    @Query("SELECT a FROM Apply a JOIN FETCH a.applicant JOIN FETCH a.recruit LEFT JOIN FETCH a.applicationForm "
+            + "WHERE a.recruit.id = :recruitId AND a.id IN :applyIds")
+    List<Apply> findAllByRecruitIdAndIdInWithApplicant(@Param("recruitId") Long recruitId,
+                                                       @Param("applyIds") List<Long> applyIds);
+
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Apply a SET a.isDeleted = true WHERE a.id IN :ids")
+    @Query("UPDATE Apply a SET a.isDeleted = true, a.waitlistNumber = null WHERE a.id IN :ids")
     void deleteAllByIds(@Param("ids") Iterable<Long> ids);
 
     @Query("select a from Apply a join fetch a.applicant m where a.id = :applyId and a.status = :status")

--- a/src/main/java/org/ject/support/admin/apply/repository/AdminApplyRepository.java
+++ b/src/main/java/org/ject/support/admin/apply/repository/AdminApplyRepository.java
@@ -23,7 +23,9 @@ public interface AdminApplyRepository extends JpaRepository<Apply, Long>, AdminA
                                                        @Param("applyIds") List<Long> applyIds);
 
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Apply a SET a.isDeleted = true, a.waitlistNumber = null WHERE a.id IN :ids")
+    @Query("UPDATE Apply a SET a.isDeleted = true, "
+            + "a.selectionResult = org.ject.support.domain.apply.domain.SelectionResult.UNDECIDED, "
+            + "a.waitlistNumber = null WHERE a.id IN :ids")
     void deleteAllByIds(@Param("ids") Iterable<Long> ids);
 
     @Query("select a from Apply a join fetch a.applicant m where a.id = :applyId and a.status = :status")

--- a/src/main/java/org/ject/support/admin/apply/repository/AdminApplyRepository.java
+++ b/src/main/java/org/ject/support/admin/apply/repository/AdminApplyRepository.java
@@ -23,7 +23,7 @@ public interface AdminApplyRepository extends JpaRepository<Apply, Long>, AdminA
                                                        @Param("applyIds") List<Long> applyIds);
 
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Apply a SET a.isDeleted = true, "
+    @Query("UPDATE VERSIONED Apply a SET a.isDeleted = true, "
             + "a.selectionResult = org.ject.support.domain.apply.domain.SelectionResult.UNDECIDED, "
             + "a.waitlistNumber = null WHERE a.id IN :ids")
     void deleteAllByIds(@Param("ids") Iterable<Long> ids);

--- a/src/main/java/org/ject/support/admin/apply/service/AdminApplyService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/AdminApplyService.java
@@ -2,10 +2,13 @@ package org.ject.support.admin.apply.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.apply.dto.AdminApplyDetailResponse;
 import org.ject.support.admin.apply.dto.AdminApplyResponse;
 import org.ject.support.admin.apply.dto.AdminApplySearchCondition;
+import org.ject.support.admin.apply.dto.SelectionResultUpdateRequest;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.repository.AdminApplyRepository;
 import org.ject.support.common.data.PageResponse;
@@ -24,6 +27,7 @@ import org.ject.support.domain.recruit.exception.QuestionErrorCode;
 import org.ject.support.domain.recruit.exception.QuestionException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -96,6 +100,80 @@ public class AdminApplyService {
         return applyIds.size();
     }
 
+    @Transactional
+    public int updateSelectionResults(final SelectionResultUpdateRequest request) {
+        List<SelectionResultUpdateRequest.SelectionResultItem> items = request.selectionResults();
+        validateDuplicateApplyIds(items);
+        validateSelectionResults(items);
+
+        List<Long> applyIds = items.stream()
+                .map(SelectionResultUpdateRequest.SelectionResultItem::applyId)
+                .toList();
+        List<Apply> applies = adminApplyRepository.findAllByRecruitIdAndIdInWithApplicant(
+                request.recruitId(), applyIds);
+        if (applies.size() != applyIds.size()) {
+            throw new ApplyException(ApplyErrorCode.NOT_FOUND_APPLY);
+        }
+
+        Map<Long, SelectionResultUpdateRequest.SelectionResultItem> itemsByApplyId = items.stream()
+                .collect(Collectors.toMap(
+                        SelectionResultUpdateRequest.SelectionResultItem::applyId,
+                        Function.identity()));
+        applies.forEach(apply -> {
+            SelectionResultUpdateRequest.SelectionResultItem item = itemsByApplyId.get(apply.getId());
+            apply.validateSelectionResult(item.selectionResult(), item.waitlistNumber());
+        });
+        applies.forEach(Apply::clearWaitlistNumber);
+        adminApplyRepository.flush();
+
+        applies.forEach(apply -> {
+            SelectionResultUpdateRequest.SelectionResultItem item = itemsByApplyId.get(apply.getId());
+            apply.decideSelectionResult(item.selectionResult(), item.waitlistNumber());
+        });
+
+        try {
+            adminApplyRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new ApplyException(ApplyErrorCode.DUPLICATE_WAITLIST_NUMBER);
+        }
+        return applies.size();
+    }
+
+    private void validateSelectionResults(List<SelectionResultUpdateRequest.SelectionResultItem> items) {
+        items.forEach(item -> {
+            if (item.selectionResult().isWaitlisted() && item.waitlistNumber() == null) {
+                throw new ApplyException(ApplyErrorCode.WAITLIST_NUMBER_REQUIRED);
+            }
+            if (item.selectionResult().isWaitlisted() && item.waitlistNumber() <= 0) {
+                throw new ApplyException(ApplyErrorCode.INVALID_WAITLIST_NUMBER);
+            }
+            if (!item.selectionResult().isWaitlisted() && item.waitlistNumber() != null) {
+                throw new ApplyException(ApplyErrorCode.WAITLIST_NUMBER_NOT_ALLOWED);
+            }
+        });
+
+        long waitlistedCount = items.stream()
+                .filter(item -> item.selectionResult().isWaitlisted())
+                .count();
+        long distinctWaitlistNumberCount = items.stream()
+                .filter(item -> item.selectionResult().isWaitlisted())
+                .map(SelectionResultUpdateRequest.SelectionResultItem::waitlistNumber)
+                .distinct()
+                .count();
+        if (waitlistedCount != distinctWaitlistNumberCount) {
+            throw new ApplyException(ApplyErrorCode.DUPLICATE_WAITLIST_NUMBER);
+        }
+    }
+
+    private void validateDuplicateApplyIds(List<SelectionResultUpdateRequest.SelectionResultItem> items) {
+        long distinctApplyIdCount = items.stream()
+                .map(SelectionResultUpdateRequest.SelectionResultItem::applyId)
+                .distinct()
+                .count();
+        if (items.size() != distinctApplyIdCount) {
+            throw new ApplyException(ApplyErrorCode.DUPLICATE_APPLY_ID);
+        }
+    }
 
     private void validateQuestions(final Map<String, String> answers, final Recruit recruit) {
         answers.keySet().stream()

--- a/src/main/java/org/ject/support/admin/apply/service/ApplyPassService.java
+++ b/src/main/java/org/ject/support/admin/apply/service/ApplyPassService.java
@@ -3,6 +3,7 @@ package org.ject.support.admin.apply.service;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.domain.applicant.entity.Applicant;
 import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.SelectionResult;
 import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.domain.apply.repository.ApplyRepository;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,8 @@ public class ApplyPassService {
             if (apply.isNotSubmitted()) {
                 throw new ApplyException(NOT_SUBMITTED);
             }
+
+            apply.decideSelectionResult(SelectionResult.PASSED, null);
 
             // 지원자 role 승격
             Applicant applicant = apply.getApplicant();

--- a/src/main/java/org/ject/support/admin/mail/controller/AdminMailTargetApiSpec.java
+++ b/src/main/java/org/ject/support/admin/mail/controller/AdminMailTargetApiSpec.java
@@ -1,0 +1,16 @@
+package org.ject.support.admin.mail.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.admin.mail.dto.MailTargetSearchRequest;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@Tag(name = "AdminMailTarget", description = "메일 발송 대상자 조회 API (어드민 전용)")
+public interface AdminMailTargetApiSpec {
+
+    @Operation(summary = "메일 발송 대상자 조회", description = "모집 공고와 선정 결과로 메일 발송 대상자를 조회합니다.")
+    List<MailTargetResponse> searchTargets(@ModelAttribute @Valid MailTargetSearchRequest request);
+}

--- a/src/main/java/org/ject/support/admin/mail/controller/AdminMailTargetController.java
+++ b/src/main/java/org/ject/support/admin/mail/controller/AdminMailTargetController.java
@@ -1,0 +1,32 @@
+package org.ject.support.admin.mail.controller;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.admin.mail.dto.MailTargetSearchRequest;
+import org.ject.support.admin.mail.service.MailTargetService;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/mails/targets")
+public class AdminMailTargetController implements AdminMailTargetApiSpec {
+
+    private final MailTargetService mailTargetService;
+
+    @Override
+    @GetMapping
+    public List<MailTargetResponse> searchTargets(
+            @ParameterObject @ModelAttribute @Valid MailTargetSearchRequest request) {
+        SelectionResult result = request.selectionResult() == null
+                ? null
+                : request.selectionResult().toSelectionResult();
+        return mailTargetService.searchTargets(request.recruitId(), result);
+    }
+}

--- a/src/main/java/org/ject/support/admin/mail/dto/MailTargetResponse.java
+++ b/src/main/java/org/ject/support/admin/mail/dto/MailTargetResponse.java
@@ -1,0 +1,18 @@
+package org.ject.support.admin.mail.dto;
+
+import org.ject.support.domain.apply.domain.SelectionResult;
+
+public record MailTargetResponse(
+        Long applyId,
+        String name,
+        String phoneNumber,
+        String email,
+        SelectionResult selectionResult,
+        Integer waitlistNumber
+) {
+    public MailTargetResponse {
+        if (selectionResult != SelectionResult.WAITLISTED) {
+            waitlistNumber = null;
+        }
+    }
+}

--- a/src/main/java/org/ject/support/admin/mail/dto/MailTargetSearchRequest.java
+++ b/src/main/java/org/ject/support/admin/mail/dto/MailTargetSearchRequest.java
@@ -1,0 +1,13 @@
+package org.ject.support.admin.mail.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record MailTargetSearchRequest(
+        @Schema(description = "모집 공고 ID", example = "1")
+        @NotNull @Positive Long recruitId,
+        @Schema(description = "선정 결과 필터", example = "PASSED", nullable = true)
+        MailTargetSelectionResult selectionResult
+) {
+}

--- a/src/main/java/org/ject/support/admin/mail/dto/MailTargetSelectionResult.java
+++ b/src/main/java/org/ject/support/admin/mail/dto/MailTargetSelectionResult.java
@@ -1,0 +1,11 @@
+package org.ject.support.admin.mail.dto;
+
+import org.ject.support.domain.apply.domain.SelectionResult;
+
+public enum MailTargetSelectionResult {
+    PASSED, WAITLISTED, FAILED;
+
+    public SelectionResult toSelectionResult() {
+        return SelectionResult.valueOf(name());
+    }
+}

--- a/src/main/java/org/ject/support/admin/mail/repository/MailTargetQueryRepository.java
+++ b/src/main/java/org/ject/support/admin/mail/repository/MailTargetQueryRepository.java
@@ -1,0 +1,52 @@
+package org.ject.support.admin.mail.repository;
+
+import static org.ject.support.domain.apply.domain.QApplicationForm.applicationForm;
+import static org.ject.support.domain.apply.domain.QApply.apply;
+import static org.ject.support.domain.applicant.entity.QApplicant.applicant;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.domain.apply.domain.ApplyStatus;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MailTargetQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<MailTargetResponse> findTargets(Long recruitId, SelectionResult selectionResult) {
+        return queryFactory
+                .select(Projections.constructor(
+                        MailTargetResponse.class,
+                        apply.id,
+                        applicant.name,
+                        applicant.phoneNumber,
+                        applicant.email,
+                        apply.selectionResult,
+                        apply.waitlistNumber))
+                .from(apply)
+                .join(apply.applicant, applicant)
+                .join(apply.applicationForm, applicationForm)
+                .where(
+                        apply.recruit.id.eq(recruitId),
+                        apply.status.eq(ApplyStatus.SUBMITTED),
+                        apply.isDeleted.eq(false),
+                        applicant.isDeleted.eq(false),
+                        eqSelectionResult(selectionResult))
+                .orderBy(apply.submittedAt.desc(), apply.id.desc())
+                .fetch();
+    }
+
+    private BooleanExpression eqSelectionResult(SelectionResult selectionResult) {
+        return Optional.ofNullable(selectionResult)
+                .map(apply.selectionResult::eq)
+                .orElse(null);
+    }
+}

--- a/src/main/java/org/ject/support/admin/mail/service/MailTargetService.java
+++ b/src/main/java/org/ject/support/admin/mail/service/MailTargetService.java
@@ -1,0 +1,28 @@
+package org.ject.support.admin.mail.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.admin.mail.repository.MailTargetQueryRepository;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MailTargetService {
+
+    private final RecruitRepository recruitRepository;
+    private final MailTargetQueryRepository mailTargetQueryRepository;
+
+    public List<MailTargetResponse> searchTargets(Long recruitId, SelectionResult selectionResult) {
+        if (!recruitRepository.existsById(recruitId)) {
+            throw new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT);
+        }
+        return mailTargetQueryRepository.findTargets(recruitId, selectionResult);
+    }
+}

--- a/src/main/java/org/ject/support/domain/apply/domain/Apply.java
+++ b/src/main/java/org/ject/support/domain/apply/domain/Apply.java
@@ -28,6 +28,8 @@ import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.domain.base.BaseTimeEntity;
 import org.ject.support.domain.recruit.domain.Recruit;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -60,6 +62,9 @@ public class Apply extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(50)", nullable = false)
     private ApplyStatus status;
+
+    @Column(name = "submitted_at")
+    private LocalDateTime submittedAt;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "selection_result", columnDefinition = "varchar(50)", nullable = false)
@@ -94,10 +99,12 @@ public class Apply extends BaseTimeEntity {
 
     public void saveTemporarily() {
         this.status = ApplyStatus.TEMP_SAVED;
+        this.submittedAt = null;
     }
 
     public void resetToJoined() {
         this.status = ApplyStatus.JOINED;
+        this.submittedAt = null;
     }
 
     public boolean isNotTempSaved() {
@@ -122,6 +129,7 @@ public class Apply extends BaseTimeEntity {
     public void reject() {
         this.applicationForm = null;
         this.status = ApplyStatus.REJECTED;
+        this.submittedAt = null;
         this.selectionResult = SelectionResult.UNDECIDED;
         this.waitlistNumber = null;
     }
@@ -177,6 +185,7 @@ public class Apply extends BaseTimeEntity {
 
         this.applicationForm = applicationForm;
         this.status = ApplyStatus.SUBMITTED;
+        this.submittedAt = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/org/ject/support/domain/apply/domain/Apply.java
+++ b/src/main/java/org/ject/support/domain/apply/domain/Apply.java
@@ -12,6 +12,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -29,7 +31,11 @@ import org.ject.support.domain.recruit.domain.Recruit;
 @Entity
 @Getter
 @Builder
-@SQLDelete(sql = "UPDATE apply SET is_deleted = true, version = version + 1 WHERE id = ? AND version = ?")
+@Table(name = "apply", uniqueConstraints = @UniqueConstraint(
+        name = "uk_apply_recruit_waitlist_number",
+        columnNames = {"recruit_id", "waitlist_number"}))
+@SQLDelete(sql = "UPDATE apply SET is_deleted = true, waitlist_number = NULL, version = version + 1 "
+        + "WHERE id = ? AND version = ?")
 @SQLRestriction("is_deleted = false")
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -53,6 +59,14 @@ public class Apply extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(50)", nullable = false)
     private ApplyStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "selection_result", columnDefinition = "varchar(50)", nullable = false)
+    @Builder.Default
+    private SelectionResult selectionResult = SelectionResult.UNDECIDED;
+
+    @Column(name = "waitlist_number")
+    private Integer waitlistNumber;
 
     @Column(columnDefinition = "varchar(500) default ''", nullable = false)
     @Builder.Default
@@ -90,6 +104,7 @@ public class Apply extends BaseTimeEntity {
     public boolean isNotSubmitted() {
         return status.equals(ApplyStatus.JOINED)
                 || status.equals(ApplyStatus.TEMP_SAVED)
+                || status.equals(ApplyStatus.REJECTED)
                 || (status.equals(ApplyStatus.SUBMITTED) && applicationForm == null);
     }
 
@@ -102,6 +117,8 @@ public class Apply extends BaseTimeEntity {
     public void reject() {
         this.applicationForm = null;
         this.status = ApplyStatus.REJECTED;
+        this.selectionResult = SelectionResult.UNDECIDED;
+        this.waitlistNumber = null;
     }
 
     public boolean isTempSaved() {
@@ -110,6 +127,38 @@ public class Apply extends BaseTimeEntity {
 
     public boolean isSubmitted() {
         return status.equals(ApplyStatus.SUBMITTED);
+    }
+
+    /**
+     * 선정 결과를 정한다. 지원 상태와는 별도의 축이므로 상태나 지원서는 건드리지 않는다.
+     */
+    public void decideSelectionResult(SelectionResult selectionResult, Integer waitlistNumber) {
+        validateSelectionResult(selectionResult, waitlistNumber);
+
+        this.selectionResult = selectionResult;
+        this.waitlistNumber = waitlistNumber;
+    }
+
+    public void validateSelectionResult(SelectionResult selectionResult, Integer waitlistNumber) {
+        if (isNotSubmitted()) {
+            throw new ApplyException(ApplyErrorCode.NOT_SUBMITTED);
+        }
+
+        if (selectionResult.isWaitlisted() && waitlistNumber == null) {
+            throw new ApplyException(ApplyErrorCode.WAITLIST_NUMBER_REQUIRED);
+        }
+
+        if (selectionResult.isWaitlisted() && waitlistNumber <= 0) {
+            throw new ApplyException(ApplyErrorCode.INVALID_WAITLIST_NUMBER);
+        }
+
+        if (!selectionResult.isWaitlisted() && waitlistNumber != null) {
+            throw new ApplyException(ApplyErrorCode.WAITLIST_NUMBER_NOT_ALLOWED);
+        }
+    }
+
+    public void clearWaitlistNumber() {
+        this.waitlistNumber = null;
     }
 
     public void submit(ApplicationForm applicationForm) {

--- a/src/main/java/org/ject/support/domain/apply/domain/Apply.java
+++ b/src/main/java/org/ject/support/domain/apply/domain/Apply.java
@@ -34,7 +34,8 @@ import org.ject.support.domain.recruit.domain.Recruit;
 @Table(name = "apply", uniqueConstraints = @UniqueConstraint(
         name = "uk_apply_recruit_waitlist_number",
         columnNames = {"recruit_id", "waitlist_number"}))
-@SQLDelete(sql = "UPDATE apply SET is_deleted = true, waitlist_number = NULL, version = version + 1 "
+@SQLDelete(sql = "UPDATE apply SET is_deleted = true, selection_result = 'UNDECIDED', waitlist_number = NULL, "
+        + "version = version + 1 "
         + "WHERE id = ? AND version = ?")
 @SQLRestriction("is_deleted = false")
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/org/ject/support/domain/apply/domain/Apply.java
+++ b/src/main/java/org/ject/support/domain/apply/domain/Apply.java
@@ -92,8 +92,12 @@ public class Apply extends BaseTimeEntity {
         this.applicationForm = newApplicationForm;
     }
 
-    public void updateStatus(ApplyStatus status) {
-        this.status = status;
+    public void saveTemporarily() {
+        this.status = ApplyStatus.TEMP_SAVED;
+    }
+
+    public void resetToJoined() {
+        this.status = ApplyStatus.JOINED;
     }
 
     public boolean isNotTempSaved() {

--- a/src/main/java/org/ject/support/domain/apply/domain/SelectionResult.java
+++ b/src/main/java/org/ject/support/domain/apply/domain/SelectionResult.java
@@ -1,0 +1,16 @@
+package org.ject.support.domain.apply.domain;
+
+/**
+ * 제출된 지원을 운영팀이 평가한 결과. 지원 상태(ApplyStatus)와는 독립적인 축이다.
+ */
+public enum SelectionResult {
+    UNDECIDED, PASSED, WAITLISTED, FAILED;
+
+    public boolean isWaitlisted() {
+        return this == WAITLISTED;
+    }
+
+    public boolean isPassed() {
+        return this == PASSED;
+    }
+}

--- a/src/main/java/org/ject/support/domain/apply/exception/ApplyErrorCode.java
+++ b/src/main/java/org/ject/support/domain/apply/exception/ApplyErrorCode.java
@@ -17,7 +17,12 @@ public enum ApplyErrorCode implements ErrorCode {
     NOT_FOUND_TEMP_APPLICATION_FORM(NOT_FOUND, "APPLY-3", "임시 저장한 지원서가 존재하지 않습니다."),
     NOT_FOUND_SUBMITTED_APPLICATION_FORM(NOT_FOUND, "APPLY-4", "제출된 지원서가 존재하지 않습니다."),
     NOT_SUBMITTED(CONFLICT, "APPLY-5", "제출 완료된 지원서가 아닙니다."),
-    PORTFOLIO_REQUIRED(BAD_REQUEST, "APPLY-6", "포트폴리오를 필수로 제출해야 합니다.")
+    PORTFOLIO_REQUIRED(BAD_REQUEST, "APPLY-6", "포트폴리오를 필수로 제출해야 합니다."),
+    WAITLIST_NUMBER_REQUIRED(BAD_REQUEST, "APPLY-7", "예비 합격은 예비 번호를 함께 지정해야 합니다."),
+    WAITLIST_NUMBER_NOT_ALLOWED(BAD_REQUEST, "APPLY-8", "예비 합격이 아닌 선정 결과에는 예비 번호를 지정할 수 없습니다."),
+    DUPLICATE_WAITLIST_NUMBER(CONFLICT, "APPLY-9", "같은 모집 공고 안에서 예비 번호는 중복될 수 없습니다."),
+    DUPLICATE_APPLY_ID(BAD_REQUEST, "APPLY-10", "하나의 요청에 같은 지원을 두 번 담을 수 없습니다."),
+    INVALID_WAITLIST_NUMBER(BAD_REQUEST, "APPLY-11", "예비 번호는 1 이상의 정수여야 합니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -39,7 +39,6 @@ import java.util.Optional;
 
 import static org.ject.support.domain.apply.domain.ApplyStatus.JOINED;
 import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
-import static org.ject.support.domain.apply.domain.ApplyStatus.TEMP_SAVED;
 import static org.ject.support.domain.apply.exception.ApplyErrorCode.ALREADY_SUBMITTED;
 import static org.ject.support.domain.apply.exception.ApplyErrorCode.NOT_FOUND_APPLY;
 
@@ -108,7 +107,7 @@ public class ApplyService implements ApplyUsecase {
             applicationFormRepository.save(applicationForm);
 
             apply.updateApplicationForm(applicationForm);
-            apply.updateStatus(TEMP_SAVED);
+            apply.saveTemporarily();
             return;
         }
 
@@ -132,7 +131,7 @@ public class ApplyService implements ApplyUsecase {
 
         // 임시 저장한 지원서 제거 및 상태 변경
         apply.deleteApplicationForm();
-        apply.updateStatus(JOINED);
+        apply.resetToJoined();
 
         // 프로필 제거
         Applicant applicant = apply.getApplicant();

--- a/src/main/resources/db/migration/V37__add_selection_result_to_apply.sql
+++ b/src/main/resources/db/migration/V37__add_selection_result_to_apply.sql
@@ -1,0 +1,4 @@
+ALTER TABLE apply
+    ADD COLUMN selection_result VARCHAR(50) NOT NULL DEFAULT 'UNDECIDED',
+    ADD COLUMN waitlist_number INT NULL,
+    ADD CONSTRAINT uk_apply_recruit_waitlist_number UNIQUE (recruit_id, waitlist_number);

--- a/src/main/resources/db/migration/V38__add_submitted_at_to_apply.sql
+++ b/src/main/resources/db/migration/V38__add_submitted_at_to_apply.sql
@@ -1,0 +1,7 @@
+ALTER TABLE apply
+    ADD COLUMN submitted_at datetime(6) NULL;
+
+-- 기존 제출 완료 지원서는 제출 시각이 없어 created_at을 임시 기준으로 백필한다.
+UPDATE apply
+SET submitted_at = created_at
+WHERE status = 'SUBMITTED';

--- a/src/test/java/org/ject/support/admin/apply/controller/AdminApplyControllerTest.java
+++ b/src/test/java/org/ject/support/admin/apply/controller/AdminApplyControllerTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -71,5 +73,27 @@ class AdminApplyControllerTest extends UnitTestSupport {
                 .andExpect(status().isOk());
 
         verify(adminApplyService).findApplies(eq(condition), any(Pageable.class));
+    }
+
+    @Test
+    void 선정_결과_일괄_변경_요청을_처리한다() throws Exception {
+        // given
+        given(adminApplyService.updateSelectionResults(any())).willReturn(1);
+
+        // when, then
+        mockMvc.perform(patch("/admin/applies/selection-results")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "recruitId": 1,
+                                  "selectionResults": [
+                                    {"applyId": 1, "selectionResult": "PASSED", "waitlistNumber": null}
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(content().string("1"));
+
+        verify(adminApplyService).updateSelectionResults(any());
     }
 }

--- a/src/test/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryTest.java
@@ -1,6 +1,7 @@
 package org.ject.support.admin.apply.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
 import static org.ject.support.domain.apply.domain.ApplyStatus.TEMP_SAVED;
 import static org.ject.support.domain.member.JobFamily.BE;
@@ -8,12 +9,14 @@ import static org.ject.support.domain.member.JobFamily.FE;
 import static org.ject.support.domain.member.JobFamily.PM;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
+import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.ject.support.admin.apply.dto.AdminApplySearchCondition;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.ApplyStatus;
+import org.ject.support.domain.apply.domain.SelectionResult;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Role;
@@ -34,6 +37,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @Import({QueryDslTestConfig.class, AdminApplyQueryRepositoryImpl.class})
 @DataJpaTest
@@ -53,6 +57,9 @@ class AdminApplyQueryRepositoryTest {
 
     @Autowired
     org.ject.support.domain.apply.repository.ApplyRepository applyRepository;
+
+    @Autowired
+    EntityManager entityManager;
 
     Semester semester;
     Recruit beRecruit;
@@ -381,6 +388,48 @@ class AdminApplyQueryRepositoryTest {
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().getFirst().getRecruit()).isEqualTo(beRecruit);
+    }
+
+    @Test
+    void 모집_공고와_지원ID로_지원서를_조회한다() {
+        // given
+        Applicant applicant = createApplicant("selection@test.com", BE);
+        applicantRepository.save(applicant);
+        Apply savedApply = applyRepository.save(getApply(applicant, beRecruit, SUBMITTED));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<Apply> result = adminApplyRepository.findAllByRecruitIdAndIdInWithApplicant(
+                beRecruit.getId(), List.of(savedApply.getId()));
+
+        // then
+        assertThat(result).singleElement()
+                .satisfies(apply -> {
+                    assertThat(apply.getId()).isEqualTo(savedApply.getId());
+                    assertThat(apply.getApplicant().getId()).isEqualTo(applicant.getId());
+                    assertThat(apply.getRecruit().getId()).isEqualTo(beRecruit.getId());
+                });
+    }
+
+    @Test
+    void 같은_모집_공고에서_예비_번호_중복을_DB가_막는다() {
+        // given
+        Applicant applicant1 = createApplicant("duplicate-selection-1@test.com", BE);
+        Applicant applicant2 = createApplicant("duplicate-selection-2@test.com", BE);
+        applicantRepository.saveAll(List.of(applicant1, applicant2));
+
+        Apply apply1 = getApply(applicant1, beRecruit, SUBMITTED);
+        Apply apply2 = getApply(applicant2, beRecruit, SUBMITTED);
+        apply1.decideSelectionResult(SelectionResult.WAITLISTED, 1);
+        apply2.decideSelectionResult(SelectionResult.WAITLISTED, 1);
+
+        // when, then
+        assertThatThrownBy(() -> {
+            applyRepository.saveAll(List.of(apply1, apply2));
+            entityManager.flush();
+        })
+                .isInstanceOf(DataIntegrityViolationException.class);
     }
 
     private Recruit getRecruit(JobFamily jobFamily) {

--- a/src/test/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryTest.java
@@ -10,6 +10,8 @@ import static org.ject.support.domain.member.JobFamily.PM;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.OptimisticLockException;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.ject.support.admin.apply.dto.AdminApplySearchCondition;
@@ -38,6 +40,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Import({QueryDslTestConfig.class, AdminApplyQueryRepositoryImpl.class})
 @DataJpaTest
@@ -60,6 +66,12 @@ class AdminApplyQueryRepositoryTest {
 
     @Autowired
     EntityManager entityManager;
+
+    @Autowired
+    EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    PlatformTransactionManager transactionManager;
 
     Semester semester;
     Recruit beRecruit;
@@ -441,6 +453,10 @@ class AdminApplyQueryRepositoryTest {
         apply.decideSelectionResult(SelectionResult.WAITLISTED, 1);
         Apply savedApply = applyRepository.save(apply);
         entityManager.flush();
+        long versionBeforeDelete = ((Number) entityManager.createNativeQuery(
+                        "SELECT version FROM apply WHERE id = :id")
+                .setParameter("id", savedApply.getId())
+                .getSingleResult()).longValue();
 
         // when
         adminApplyRepository.deleteAllByIds(List.of(savedApply.getId()));
@@ -448,12 +464,47 @@ class AdminApplyQueryRepositoryTest {
 
         // then
         Object[] state = (Object[]) entityManager.createNativeQuery(
-                        "SELECT selection_result, waitlist_number FROM apply WHERE id = :id")
+                        "SELECT selection_result, waitlist_number, version FROM apply WHERE id = :id")
                 .setParameter("id", savedApply.getId())
                 .getSingleResult();
         assertThat(state[0]).isEqualTo("UNDECIDED");
         assertThat(state[1]).isNull();
+        assertThat(((Number) state[2]).longValue()).isEqualTo(versionBeforeDelete + 1);
         assertThat(adminApplyRepository.findById(savedApply.getId())).isEmpty();
+    }
+
+    @Test
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+    void 다건_삭제와_동시에_수정하면_낙관적_락_예외가_발생한다() {
+        // given
+        Applicant applicant = createApplicant("bulk-delete-lock@test.com", BE);
+        applicantRepository.save(applicant);
+        Apply savedApply = applyRepository.save(getApply(applicant, beRecruit, SUBMITTED));
+        entityManager.flush();
+        Long applyId = savedApply.getId();
+
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        EntityManager staleEntityManager = entityManagerFactory.createEntityManager();
+        try {
+            staleEntityManager.getTransaction().begin();
+            Apply staleApply = staleEntityManager.find(Apply.class, applyId);
+
+            new TransactionTemplate(transactionManager).executeWithoutResult(transactionStatus ->
+                    adminApplyRepository.deleteAllByIds(List.of(applyId)));
+
+            // when, then
+            staleApply.saveTemporarily();
+            assertThatThrownBy(staleEntityManager::flush)
+                    .isInstanceOf(OptimisticLockException.class);
+        } finally {
+            if (staleEntityManager.getTransaction().isActive()) {
+                staleEntityManager.getTransaction().rollback();
+            }
+            staleEntityManager.close();
+            TestTransaction.start();
+        }
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/admin/apply/repository/AdminApplyQueryRepositoryTest.java
@@ -432,6 +432,54 @@ class AdminApplyQueryRepositoryTest {
                 .isInstanceOf(DataIntegrityViolationException.class);
     }
 
+    @Test
+    void 다건_삭제하면_선정_결과와_예비_번호를_초기화한다() {
+        // given
+        Applicant applicant = createApplicant("bulk-delete@test.com", BE);
+        applicantRepository.save(applicant);
+        Apply apply = getApply(applicant, beRecruit, SUBMITTED);
+        apply.decideSelectionResult(SelectionResult.WAITLISTED, 1);
+        Apply savedApply = applyRepository.save(apply);
+        entityManager.flush();
+
+        // when
+        adminApplyRepository.deleteAllByIds(List.of(savedApply.getId()));
+        entityManager.flush();
+
+        // then
+        Object[] state = (Object[]) entityManager.createNativeQuery(
+                        "SELECT selection_result, waitlist_number FROM apply WHERE id = :id")
+                .setParameter("id", savedApply.getId())
+                .getSingleResult();
+        assertThat(state[0]).isEqualTo("UNDECIDED");
+        assertThat(state[1]).isNull();
+        assertThat(adminApplyRepository.findById(savedApply.getId())).isEmpty();
+    }
+
+    @Test
+    void 단건_삭제하면_선정_결과와_예비_번호를_초기화한다() {
+        // given
+        Applicant applicant = createApplicant("single-delete@test.com", BE);
+        applicantRepository.save(applicant);
+        Apply apply = getApply(applicant, beRecruit, SUBMITTED);
+        apply.decideSelectionResult(SelectionResult.WAITLISTED, 1);
+        Apply savedApply = applyRepository.save(apply);
+        entityManager.flush();
+
+        // when
+        adminApplyRepository.delete(savedApply);
+        entityManager.flush();
+
+        // then
+        Object[] state = (Object[]) entityManager.createNativeQuery(
+                        "SELECT selection_result, waitlist_number FROM apply WHERE id = :id")
+                .setParameter("id", savedApply.getId())
+                .getSingleResult();
+        assertThat(state[0]).isEqualTo("UNDECIDED");
+        assertThat(state[1]).isNull();
+        assertThat(adminApplyRepository.findById(savedApply.getId())).isEmpty();
+    }
+
     private Recruit getRecruit(JobFamily jobFamily) {
         return Recruit.builder()
                 .semester(semester)

--- a/src/test/java/org/ject/support/admin/apply/service/AdminApplyServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/AdminApplyServiceTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.List;
 import java.util.Map;
@@ -12,6 +15,7 @@ import java.util.Optional;
 import org.ject.support.admin.apply.dto.AdminApplyDetailResponse;
 import org.ject.support.admin.apply.dto.AdminApplyResponse;
 import org.ject.support.admin.apply.dto.AdminApplySearchCondition;
+import org.ject.support.admin.apply.dto.SelectionResultUpdateRequest;
 import org.ject.support.admin.apply.dto.SubmittedApplyEditRequest;
 import org.ject.support.admin.apply.repository.AdminApplyRepository;
 import org.ject.support.base.UnitTestSupport;
@@ -19,6 +23,7 @@ import org.ject.support.common.util.Map2JsonSerializer;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.ApplyStatus;
+import org.ject.support.domain.apply.domain.SelectionResult;
 import org.ject.support.domain.apply.dto.ApplyPortfolioDto;
 import org.ject.support.domain.apply.exception.ApplyErrorCode;
 import org.ject.support.domain.apply.exception.ApplyException;
@@ -82,6 +87,7 @@ class AdminApplyServiceTest extends UnitTestSupport {
                 .build();
 
         var recruit = Recruit.builder()
+                .id(1L)
                 .semester(semester)
                 .questions(List.of(question1, question2))
                 .recruitType(org.ject.support.domain.recruit.domain.RecruitType.REGULAR)
@@ -95,6 +101,150 @@ class AdminApplyServiceTest extends UnitTestSupport {
                 .note("Test note")
                 .applicationForm(ApplicationForm.builder().build())
                 .build();
+    }
+
+    @Test
+    void 제출된_지원들의_선정_결과를_일괄_변경한다() {
+        // given
+        var secondApply = Apply.builder()
+                .id(2L)
+                .applicant(Applicant.builder().name("김젝트2").build())
+                .recruit(submittedApply.getRecruit())
+                .status(ApplyStatus.SUBMITTED)
+                .applicationForm(ApplicationForm.builder().build())
+                .build();
+        var request = new SelectionResultUpdateRequest(
+                1L,
+                List.of(
+                        new SelectionResultUpdateRequest.SelectionResultItem(1L, SelectionResult.WAITLISTED, 1),
+                        new SelectionResultUpdateRequest.SelectionResultItem(2L, SelectionResult.PASSED, null)
+                )
+        );
+        given(adminApplyRepository.findAllByRecruitIdAndIdInWithApplicant(1L, List.of(1L, 2L)))
+                .willReturn(List.of(submittedApply, secondApply));
+
+        // when
+        int updatedCount = adminApplyService.updateSelectionResults(request);
+
+        // then
+        assertThat(updatedCount).isEqualTo(2);
+        assertThat(submittedApply.getSelectionResult()).isEqualTo(SelectionResult.WAITLISTED);
+        assertThat(submittedApply.getWaitlistNumber()).isEqualTo(1);
+        assertThat(secondApply.getSelectionResult()).isEqualTo(SelectionResult.PASSED);
+        assertThat(secondApply.getWaitlistNumber()).isNull();
+        verify(adminApplyRepository, times(2)).flush();
+    }
+
+    @Test
+    void 기존_예비_번호를_서로_교체할_수_있다() {
+        // given
+        var secondApply = Apply.builder()
+                .id(2L)
+                .applicant(Applicant.builder().name("김젝트2").build())
+                .recruit(submittedApply.getRecruit())
+                .status(ApplyStatus.SUBMITTED)
+                .applicationForm(ApplicationForm.builder().build())
+                .build();
+        submittedApply.decideSelectionResult(SelectionResult.WAITLISTED, 1);
+        secondApply.decideSelectionResult(SelectionResult.WAITLISTED, 2);
+        var request = new SelectionResultUpdateRequest(
+                1L,
+                List.of(
+                        new SelectionResultUpdateRequest.SelectionResultItem(1L, SelectionResult.WAITLISTED, 2),
+                        new SelectionResultUpdateRequest.SelectionResultItem(2L, SelectionResult.WAITLISTED, 1)
+                )
+        );
+        given(adminApplyRepository.findAllByRecruitIdAndIdInWithApplicant(1L, List.of(1L, 2L)))
+                .willReturn(List.of(submittedApply, secondApply));
+
+        // when
+        adminApplyService.updateSelectionResults(request);
+
+        // then
+        assertThat(submittedApply.getWaitlistNumber()).isEqualTo(2);
+        assertThat(secondApply.getWaitlistNumber()).isEqualTo(1);
+        verify(adminApplyRepository, times(2)).flush();
+    }
+
+    @Test
+    void 모집_공고가_다르거나_존재하지_않는_지원이_포함되면_일괄_변경하지_않는다() {
+        // given
+        var request = new SelectionResultUpdateRequest(
+                1L,
+                List.of(new SelectionResultUpdateRequest.SelectionResultItem(999L, SelectionResult.PASSED, null))
+        );
+        given(adminApplyRepository.findAllByRecruitIdAndIdInWithApplicant(1L, List.of(999L)))
+                .willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> adminApplyService.updateSelectionResults(request))
+                .isInstanceOf(ApplyException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_FOUND_APPLY);
+        assertThat(submittedApply.getSelectionResult()).isEqualTo(SelectionResult.UNDECIDED);
+    }
+
+    @Test
+    void 요청에_같은_지원이_중복되면_일괄_변경하지_않는다() {
+        // given
+        var request = new SelectionResultUpdateRequest(
+                1L,
+                List.of(
+                        new SelectionResultUpdateRequest.SelectionResultItem(1L, SelectionResult.PASSED, null),
+                        new SelectionResultUpdateRequest.SelectionResultItem(1L, SelectionResult.FAILED, null)
+                )
+        );
+
+        // when & then
+        assertThatThrownBy(() -> adminApplyService.updateSelectionResults(request))
+                .isInstanceOf(ApplyException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.DUPLICATE_APPLY_ID);
+        verifyNoInteractions(adminApplyRepository);
+    }
+
+    @Test
+    void 같은_모집_공고에서_예비_번호가_중복되면_일괄_변경하지_않는다() {
+        // given
+        var request = new SelectionResultUpdateRequest(
+                1L,
+                List.of(
+                        new SelectionResultUpdateRequest.SelectionResultItem(1L, SelectionResult.WAITLISTED, 1),
+                        new SelectionResultUpdateRequest.SelectionResultItem(2L, SelectionResult.WAITLISTED, 1)
+                )
+        );
+
+        // when & then
+        assertThatThrownBy(() -> adminApplyService.updateSelectionResults(request))
+                .isInstanceOf(ApplyException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.DUPLICATE_WAITLIST_NUMBER);
+        verifyNoInteractions(adminApplyRepository);
+    }
+
+    @Test
+    void 제출되지_않은_지원이_하나라도_있으면_일괄_변경하지_않는다() {
+        // given
+        var tempApply = Apply.builder()
+                .id(2L)
+                .applicant(Applicant.builder().name("김젝트2").build())
+                .recruit(submittedApply.getRecruit())
+                .status(ApplyStatus.TEMP_SAVED)
+                .applicationForm(ApplicationForm.builder().build())
+                .build();
+        var request = new SelectionResultUpdateRequest(
+                1L,
+                List.of(
+                        new SelectionResultUpdateRequest.SelectionResultItem(1L, SelectionResult.PASSED, null),
+                        new SelectionResultUpdateRequest.SelectionResultItem(2L, SelectionResult.PASSED, null)
+                )
+        );
+        given(adminApplyRepository.findAllByRecruitIdAndIdInWithApplicant(1L, List.of(1L, 2L)))
+                .willReturn(List.of(submittedApply, tempApply));
+
+        // when & then
+        assertThatThrownBy(() -> adminApplyService.updateSelectionResults(request))
+                .isInstanceOf(ApplyException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ApplyErrorCode.NOT_SUBMITTED);
+        assertThat(submittedApply.getSelectionResult()).isEqualTo(SelectionResult.UNDECIDED);
+        verify(adminApplyRepository, never()).flush();
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/apply/service/ApplyPassServiceTest.java
+++ b/src/test/java/org/ject/support/admin/apply/service/ApplyPassServiceTest.java
@@ -4,6 +4,7 @@ import org.ject.support.base.UnitTestSupport;
 import org.ject.support.domain.apply.domain.ApplicationForm;
 import org.ject.support.domain.apply.domain.Apply;
 import org.ject.support.domain.apply.domain.ApplyStatus;
+import org.ject.support.domain.apply.domain.SelectionResult;
 import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.domain.apply.repository.ApplyRepository;
 import org.ject.support.domain.member.JobFamily;
@@ -60,6 +61,9 @@ class ApplyPassServiceTest extends UnitTestSupport {
         assertThat(applicant1.getMemberType()).isEqualTo(MemberType.SEMESTER);
         assertThat(applicant2.getMemberType()).isEqualTo(MemberType.SEMESTER);
         assertThat(applicant3.getMemberType()).isEqualTo(MemberType.SEMESTER);
+        assertThat(apply1.getSelectionResult()).isEqualTo(SelectionResult.PASSED);
+        assertThat(apply2.getSelectionResult()).isEqualTo(SelectionResult.PASSED);
+        assertThat(apply3.getSelectionResult()).isEqualTo(SelectionResult.PASSED);
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/mail/controller/AdminMailTargetControllerTest.java
+++ b/src/test/java/org/ject/support/admin/mail/controller/AdminMailTargetControllerTest.java
@@ -1,0 +1,108 @@
+package org.ject.support.admin.mail.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.admin.mail.dto.MailTargetSelectionResult;
+import org.ject.support.admin.mail.service.MailTargetService;
+import org.ject.support.common.exception.GlobalExceptionHandler;
+import org.ject.support.common.response.ResponseWrapper;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.OptionalValidatorFactoryBean;
+
+@ExtendWith(MockitoExtension.class)
+class AdminMailTargetControllerTest {
+
+    private MockMvc mockMvc;
+
+    private final OptionalValidatorFactoryBean validator = new OptionalValidatorFactoryBean();
+
+    @Mock
+    private MailTargetService mailTargetService;
+
+    @InjectMocks
+    private AdminMailTargetController adminMailTargetController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(adminMailTargetController)
+                .setControllerAdvice(new GlobalExceptionHandler(), new ResponseWrapper())
+                .setValidator(validator)
+                .build();
+    }
+
+    @Test
+    void 선정_결과를_지정해_메일_발송_대상을_조회한다() throws Exception {
+        // given
+        MailTargetResponse response = new MailTargetResponse(
+                10L, "홍길동", "01012345678", "test@test.com", SelectionResult.WAITLISTED, 2);
+        given(mailTargetService.searchTargets(1L, SelectionResult.WAITLISTED)).willReturn(List.of(response));
+
+        // when & then
+        mockMvc.perform(get("/admin/mails/targets")
+                        .param("recruitId", "1")
+                        .param("selectionResult", "WAITLISTED"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].applyId").value(10))
+                .andExpect(jsonPath("$.data[0].name").value("홍길동"))
+                .andExpect(jsonPath("$.data[0].phoneNumber").value("01012345678"))
+                .andExpect(jsonPath("$.data[0].email").value("test@test.com"))
+                .andExpect(jsonPath("$.data[0].selectionResult").value("WAITLISTED"))
+                .andExpect(jsonPath("$.data[0].waitlistNumber").value(2));
+        then(mailTargetService).should().searchTargets(1L, SelectionResult.WAITLISTED);
+    }
+
+    @Test
+    void 선정_결과_없이_전체_메일_발송_대상을_조회한다() throws Exception {
+        // given
+        given(mailTargetService.searchTargets(1L, null)).willReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get("/admin/mails/targets").param("recruitId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isEmpty());
+        then(mailTargetService).should().searchTargets(1L, null);
+    }
+
+    @Test
+    void 미지원_선정_결과는_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/admin/mails/targets")
+                        .param("recruitId", "1")
+                        .param("selectionResult", "UNDECIDED"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 존재하지_않는_모집_공고면_404를_반환한다() throws Exception {
+        // given
+        given(mailTargetService.searchTargets(999L, null))
+                .willThrow(new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
+
+        // when & then
+        mockMvc.perform(get("/admin/mails/targets").param("recruitId", "999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value("RECRUIT-1"));
+    }
+
+    @Test
+    void 모집_공고_ID가_양수가_아니면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/admin/mails/targets").param("recruitId", "0"))
+                .andExpect(status().isBadRequest());
+        then(mailTargetService).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/org/ject/support/admin/mail/controller/AdminMailTargetSecurityTest.java
+++ b/src/test/java/org/ject/support/admin/mail/controller/AdminMailTargetSecurityTest.java
@@ -1,0 +1,54 @@
+package org.ject.support.admin.mail.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.admin.mail.service.MailTargetService;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.ject.support.testconfig.ApplicationPeriodTest;
+import org.ject.support.testconfig.AuthenticatedUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
+class AdminMailTargetSecurityTest extends ApplicationPeriodTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MailTargetService mailTargetService;
+
+    @Test
+    void 인증되지_않은_사용자는_메일_발송_대상을_조회할_수_없다() throws Exception {
+        mockMvc.perform(get("/admin/mails/targets").param("recruitId", "1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @AuthenticatedUser(isAdmin = false)
+    void 일반_사용자는_메일_발송_대상을_조회할_수_없다() throws Exception {
+        mockMvc.perform(get("/admin/mails/targets").param("recruitId", "1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @AuthenticatedUser(isAdmin = true)
+    void 관리자는_메일_발송_대상을_조회할_수_있다() throws Exception {
+        given(mailTargetService.searchTargets(1L, null)).willReturn(List.of(
+                new MailTargetResponse(1L, "홍길동", "01012345678", "test@test.com", SelectionResult.PASSED, null)));
+
+        mockMvc.perform(get("/admin/mails/targets").param("recruitId", "1"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/org/ject/support/admin/mail/repository/MailTargetQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/admin/mail/repository/MailTargetQueryRepositoryTest.java
@@ -1,0 +1,161 @@
+package org.ject.support.admin.mail.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
+import static org.ject.support.domain.member.JobFamily.BE;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.domain.applicant.entity.Applicant;
+import org.ject.support.domain.applicant.repository.ApplicantRepository;
+import org.ject.support.domain.apply.domain.ApplicationForm;
+import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.ject.support.domain.apply.repository.ApplyRepository;
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.Semester;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.ject.support.domain.recruit.repository.SemesterRepository;
+import org.ject.support.testconfig.QueryDslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@Import({QueryDslTestConfig.class, MailTargetQueryRepository.class})
+@DataJpaTest
+class MailTargetQueryRepositoryTest {
+
+    @Autowired
+    private MailTargetQueryRepository mailTargetQueryRepository;
+
+    @Autowired
+    private SemesterRepository semesterRepository;
+
+    @Autowired
+    private RecruitRepository recruitRepository;
+
+    @Autowired
+    private ApplicantRepository applicantRepository;
+
+    @Autowired
+    private ApplyRepository applyRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Recruit recruit;
+
+    @BeforeEach
+    void setUp() {
+        Semester semester = semesterRepository.save(Semester.builder()
+                .name("1기")
+                .isRecruiting(true)
+                .build());
+        recruit = recruitRepository.save(Recruit.builder()
+                .semester(semester)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .jobFamily(BE)
+                .build());
+    }
+
+    @Test
+    void 제출_완료되고_지원서가_있는_대상만_제출_시각과_ID_내림차순으로_조회한다() {
+        // given
+        LocalDateTime latest = LocalDateTime.of(2025, 1, 3, 10, 0);
+        LocalDateTime sameSubmittedAt = LocalDateTime.of(2025, 1, 2, 10, 0);
+        Apply latestApply = saveTarget("latest@test.com", latest, SelectionResult.PASSED, 99);
+        Apply firstTieApply = saveTarget("first-tie@test.com", sameSubmittedAt, SelectionResult.FAILED);
+        Apply secondTieApply = saveTarget("second-tie@test.com", sameSubmittedAt, SelectionResult.WAITLISTED, 2);
+        saveApplyWithoutForm("without-form@test.com", SUBMITTED);
+        saveApplyWithoutForm("temp@test.com", ApplyStatus.TEMP_SAVED);
+        Apply deletedApply = saveTarget("deleted@test.com", latest, SelectionResult.PASSED);
+        applyRepository.delete(deletedApply);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<MailTargetResponse> result = mailTargetQueryRepository.findTargets(recruit.getId(), null);
+
+        // then
+        assertThat(result)
+                .extracting(MailTargetResponse::applyId)
+                .containsExactly(latestApply.getId(), secondTieApply.getId(), firstTieApply.getId());
+        assertThat(result.getFirst().waitlistNumber()).isNull();
+    }
+
+    @Test
+    void 선정_결과로_메일_발송_대상을_필터링한다() {
+        // given
+        saveTarget("passed@test.com", LocalDateTime.now(), SelectionResult.PASSED);
+        Apply waitlistedApply = saveTarget("waitlisted@test.com", LocalDateTime.now(), SelectionResult.WAITLISTED, 1);
+        saveTarget("failed@test.com", LocalDateTime.now(), SelectionResult.FAILED);
+
+        // when
+        List<MailTargetResponse> result = mailTargetQueryRepository.findTargets(
+                recruit.getId(), SelectionResult.WAITLISTED);
+
+        // then
+        assertThat(result).singleElement().satisfies(target -> {
+            assertThat(target.applyId()).isEqualTo(waitlistedApply.getId());
+            assertThat(target.email()).isEqualTo("waitlisted@test.com");
+            assertThat(target.selectionResult()).isEqualTo(SelectionResult.WAITLISTED);
+            assertThat(target.waitlistNumber()).isEqualTo(1);
+        });
+    }
+
+    private Apply saveTarget(String email, LocalDateTime submittedAt, SelectionResult selectionResult) {
+        return saveTarget(email, submittedAt, selectionResult, null);
+    }
+
+    private Apply saveTarget(String email,
+                             LocalDateTime submittedAt,
+                             SelectionResult selectionResult,
+                             Integer waitlistNumber) {
+        Applicant applicant = applicantRepository.save(Applicant.builder()
+                .email(email)
+                .name("테스트 사용자")
+                .phoneNumber("01012345678")
+                .jobFamily(BE)
+                .semesterId(1L)
+                .role(Role.APPLY)
+                .status(MemberStatus.ACTIVE)
+                .pin("123456")
+                .build());
+        Apply apply = Apply.builder()
+                .applicant(applicant)
+                .recruit(recruit)
+                .status(SUBMITTED)
+                .selectionResult(selectionResult)
+                .waitlistNumber(waitlistNumber)
+                .submittedAt(submittedAt)
+                .build();
+        apply.updateApplicationForm(ApplicationForm.builder().apply(apply).build());
+        return applyRepository.save(apply);
+    }
+
+    private Apply saveApplyWithoutForm(String email, ApplyStatus status) {
+        Applicant applicant = applicantRepository.save(Applicant.builder()
+                .email(email)
+                .name("테스트 사용자")
+                .phoneNumber("01012345678")
+                .jobFamily(BE)
+                .semesterId(1L)
+                .role(Role.APPLY)
+                .status(MemberStatus.ACTIVE)
+                .pin("123456")
+                .build());
+        return applyRepository.save(Apply.builder()
+                .applicant(applicant)
+                .recruit(recruit)
+                .status(status)
+                .build());
+    }
+}

--- a/src/test/java/org/ject/support/admin/mail/service/MailTargetServiceTest.java
+++ b/src/test/java/org/ject/support/admin/mail/service/MailTargetServiceTest.java
@@ -1,0 +1,63 @@
+package org.ject.support.admin.mail.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.admin.mail.repository.MailTargetQueryRepository;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MailTargetServiceTest {
+
+    @InjectMocks
+    private MailTargetService mailTargetService;
+
+    @Mock
+    private RecruitRepository recruitRepository;
+
+    @Mock
+    private MailTargetQueryRepository mailTargetQueryRepository;
+
+    @Test
+    void 모집_공고와_선정_결과로_메일_발송_대상을_조회한다() {
+        // given
+        Long recruitId = 1L;
+        MailTargetResponse response = new MailTargetResponse(
+                10L, "홍길동", "01012345678", "test@test.com", SelectionResult.PASSED, null);
+        given(recruitRepository.existsById(recruitId)).willReturn(true);
+        given(mailTargetQueryRepository.findTargets(recruitId, SelectionResult.PASSED))
+                .willReturn(List.of(response));
+
+        // when
+        List<MailTargetResponse> result = mailTargetService.searchTargets(recruitId, SelectionResult.PASSED);
+
+        // then
+        assertThat(result).containsExactly(response);
+    }
+
+    @Test
+    void 존재하지_않는_모집_공고면_예외가_발생한다() {
+        // given
+        Long recruitId = 999L;
+        given(recruitRepository.existsById(recruitId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> mailTargetService.searchTargets(recruitId, null))
+                .isInstanceOf(RecruitException.class)
+                .extracting("errorCode")
+                .isEqualTo(RecruitErrorCode.NOT_FOUND_RECRUIT);
+        then(mailTargetQueryRepository).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/org/ject/support/domain/apply/domain/ApplyTest.java
+++ b/src/test/java/org/ject/support/domain/apply/domain/ApplyTest.java
@@ -34,6 +34,20 @@ class ApplyTest extends TestSupport {
     }
 
     @Test
+    void 제출하면_제출_시각을_기록한다() {
+        // given
+        Apply apply = Apply.createApply(Applicant.builder().build(), Recruit.builder()
+                .jobFamily(JobFamily.BE)
+                .build());
+
+        // when
+        apply.submit(ApplicationForm.builder().build());
+
+        // then
+        assertThat(apply.getSubmittedAt()).isNotNull();
+    }
+
+    @Test
     void 포트폴리오가_필수인_직군은_포트폴리오가_있으면_제출할_수_있다() {
         // given
         Recruit recruit = Recruit.builder()
@@ -212,6 +226,18 @@ class ApplyTest extends TestSupport {
         // then
         assertThat(apply.getSelectionResult()).isEqualTo(SelectionResult.UNDECIDED);
         assertThat(apply.getWaitlistNumber()).isNull();
+    }
+
+    @Test
+    void 반려하면_제출_시각을_초기화한다() {
+        // given
+        Apply apply = submittedApply();
+
+        // when
+        apply.reject();
+
+        // then
+        assertThat(apply.getSubmittedAt()).isNull();
     }
 
     @Test

--- a/src/test/java/org/ject/support/domain/apply/domain/ApplyTest.java
+++ b/src/test/java/org/ject/support/domain/apply/domain/ApplyTest.java
@@ -176,6 +176,18 @@ class ApplyTest extends TestSupport {
     }
 
     @Test
+    void 음수_예비_번호는_허용하지_않는다() {
+        // given
+        Apply apply = submittedApply();
+
+        // when & then
+        assertThatThrownBy(() -> apply.decideSelectionResult(SelectionResult.WAITLISTED, -1))
+                .isInstanceOf(ApplyException.class)
+                .extracting("errorCode")
+                .isEqualTo(ApplyErrorCode.INVALID_WAITLIST_NUMBER);
+    }
+
+    @Test
     void 반려된_지원은_선정_결과를_정할_수_없다() {
         // given
         Apply apply = submittedApply();

--- a/src/test/java/org/ject/support/domain/apply/domain/ApplyTest.java
+++ b/src/test/java/org/ject/support/domain/apply/domain/ApplyTest.java
@@ -245,7 +245,7 @@ class ApplyTest extends TestSupport {
                 .jobFamily(JobFamily.BE)
                 .build();
         Apply apply = Apply.createApply(Applicant.builder().build(), recruit);
-        apply.updateStatus(SUBMITTED); // 이미 제출된 상태
+        apply.submit(ApplicationForm.builder().build()); // 이미 제출된 상태
 
         ApplicationForm form = ApplicationForm.builder().build();
 

--- a/src/test/java/org/ject/support/domain/apply/domain/ApplyTest.java
+++ b/src/test/java/org/ject/support/domain/apply/domain/ApplyTest.java
@@ -71,6 +71,162 @@ class ApplyTest extends TestSupport {
     }
 
     @Test
+    void 지원은_기본적으로_선정_결과가_미정이다() {
+        // given
+        Recruit recruit = Recruit.builder()
+                .jobFamily(JobFamily.BE)
+                .build();
+
+        // when
+        Apply apply = Apply.createApply(Applicant.builder().build(), recruit);
+
+        // then
+        assertThat(apply.getSelectionResult()).isEqualTo(SelectionResult.UNDECIDED);
+        assertThat(apply.getWaitlistNumber()).isNull();
+    }
+
+    @Test
+    void 제출된_지원의_선정_결과를_합격으로_정할_수_있다() {
+        // given
+        Apply apply = submittedApply();
+
+        // when
+        apply.decideSelectionResult(SelectionResult.PASSED, null);
+
+        // then
+        assertThat(apply.getSelectionResult()).isEqualTo(SelectionResult.PASSED);
+        assertThat(apply.getWaitlistNumber()).isNull();
+    }
+
+    @Test
+    void 선정_결과를_불합격으로_정해도_지원_상태와_지원서는_그대로_유지된다() {
+        // given
+        Apply apply = submittedApply();
+        ApplicationForm form = apply.getApplicationForm();
+
+        // when
+        apply.decideSelectionResult(SelectionResult.FAILED, null);
+
+        // then
+        assertThat(apply.getSelectionResult()).isEqualTo(SelectionResult.FAILED);
+        assertThat(apply.getStatus()).isEqualTo(SUBMITTED);
+        assertThat(apply.getApplicationForm()).isEqualTo(form);
+    }
+
+    @Test
+    void 예비_합격으로_정하면_예비_번호를_함께_가진다() {
+        // given
+        Apply apply = submittedApply();
+
+        // when
+        apply.decideSelectionResult(SelectionResult.WAITLISTED, 3);
+
+        // then
+        assertThat(apply.getSelectionResult()).isEqualTo(SelectionResult.WAITLISTED);
+        assertThat(apply.getWaitlistNumber()).isEqualTo(3);
+    }
+
+    @Test
+    void 예비_합격이_아닌_선정_결과로_바꾸면_예비_번호가_사라진다() {
+        // given
+        Apply apply = submittedApply();
+        apply.decideSelectionResult(SelectionResult.WAITLISTED, 3);
+
+        // when
+        apply.decideSelectionResult(SelectionResult.PASSED, null);
+
+        // then
+        assertThat(apply.getWaitlistNumber()).isNull();
+    }
+
+    @Test
+    void 예비_번호_없이_예비_합격으로_정하면_예외가_발생한다() {
+        // given
+        Apply apply = submittedApply();
+
+        // when & then
+        assertThatThrownBy(() -> apply.decideSelectionResult(SelectionResult.WAITLISTED, null))
+                .isInstanceOf(ApplyException.class)
+                .extracting("errorCode")
+                .isEqualTo(ApplyErrorCode.WAITLIST_NUMBER_REQUIRED);
+    }
+
+    @Test
+    void 예비_합격이_아닌데_예비_번호를_지정하면_예외가_발생한다() {
+        // given
+        Apply apply = submittedApply();
+
+        // when & then
+        assertThatThrownBy(() -> apply.decideSelectionResult(SelectionResult.PASSED, 1))
+                .isInstanceOf(ApplyException.class)
+                .extracting("errorCode")
+                .isEqualTo(ApplyErrorCode.WAITLIST_NUMBER_NOT_ALLOWED);
+    }
+
+    @Test
+    void 예비_번호는_양수여야_한다() {
+        // given
+        Apply apply = submittedApply();
+
+        // when & then
+        assertThatThrownBy(() -> apply.decideSelectionResult(SelectionResult.WAITLISTED, 0))
+                .isInstanceOf(ApplyException.class)
+                .extracting("errorCode")
+                .isEqualTo(ApplyErrorCode.INVALID_WAITLIST_NUMBER);
+    }
+
+    @Test
+    void 반려된_지원은_선정_결과를_정할_수_없다() {
+        // given
+        Apply apply = submittedApply();
+        apply.reject();
+
+        // when & then
+        assertThatThrownBy(() -> apply.decideSelectionResult(SelectionResult.PASSED, null))
+                .isInstanceOf(ApplyException.class)
+                .extracting("errorCode")
+                .isEqualTo(ApplyErrorCode.NOT_SUBMITTED);
+    }
+
+    @Test
+    void 지원을_반려하면_선정_결과와_예비_번호를_초기화한다() {
+        // given
+        Apply apply = submittedApply();
+        apply.decideSelectionResult(SelectionResult.WAITLISTED, 3);
+
+        // when
+        apply.reject();
+
+        // then
+        assertThat(apply.getSelectionResult()).isEqualTo(SelectionResult.UNDECIDED);
+        assertThat(apply.getWaitlistNumber()).isNull();
+    }
+
+    @Test
+    void 제출되지_않은_지원은_선정_결과를_정할_수_없다() {
+        // given
+        Recruit recruit = Recruit.builder()
+                .jobFamily(JobFamily.BE)
+                .build();
+        Apply apply = Apply.createApply(Applicant.builder().build(), recruit);
+
+        // when & then
+        assertThatThrownBy(() -> apply.decideSelectionResult(SelectionResult.PASSED, null))
+                .isInstanceOf(ApplyException.class)
+                .extracting("errorCode")
+                .isEqualTo(ApplyErrorCode.NOT_SUBMITTED);
+    }
+
+    private Apply submittedApply() {
+        Recruit recruit = Recruit.builder()
+                .jobFamily(JobFamily.BE)
+                .build();
+        Apply apply = Apply.createApply(Applicant.builder().build(), recruit);
+        apply.submit(ApplicationForm.builder().build());
+        return apply;
+    }
+
+    @Test
     void 이미_제출된_지원서는_다시_제출할_수_없다() {
         // given
         Recruit recruit = Recruit.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈

#625

## 📝 작업 내용

- `ApplyStatus`와 분리된 `SelectionResult` 축 추가
- `UNDECIDED`, `PASSED`, `WAITLISTED`, `FAILED` 결과 및 제출 상태 기반 도메인 검증 추가
- 예비 번호 필수·양수·중복 검증과 모집 공고별 DB 유일성 제약 추가
- `/admin/applies/selection-results` 일괄 변경 API 추가
- 기존 `ApplyPassService` 합격 처리에 `PASSED` 기록 연계
- 기존 지원 데이터의 `UNDECIDED` 초기화를 위한 Flyway `V37` 추가
- 도메인·서비스·컨트롤러·QueryDSL 저장소 테스트 추가

## 🙏 리뷰 요구사항 (선택)

- 일괄 변경 시 전체 검증 후 반영되는지, 예비 번호 교체와 동시성 제약 처리가 의도에 맞는지 확인 부탁드립니다.
- 기존 합격 처리 API의 승격 동작과 `PASSED` 기록 연계가 기존 계약을 유지하는지 확인 부탁드립니다.

## 검증

- `git diff --cached --check` 통과
- Java 21 기준 변경 관련 단위 테스트 통과
- Java 21 기준 `AdminApplyQueryRepositoryTest` 통과
- 전체 `./gradlew test`는 로컬 `RedisTestContainersConfig`의 `DockerClientProviderStrategy` 초기화 실패로 545개 중 51개 실패


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 제출 완료 지원자의 합격·예비 합격·불합격 결과를 일괄 변경할 수 있습니다.
  * 예비 합격자에게 예비 번호를 지정하고 관리할 수 있습니다.
  * 선정 결과별 메일 발송 대상자를 조회할 수 있습니다.

* **개선 사항**
  * 결과 변경 시 지원서 및 예비 번호의 중복·유효성을 검증합니다.
  * 합격 처리 시 선정 결과가 자동으로 반영됩니다.
  * 지원서 삭제 또는 반려 시 예비 번호와 선정 결과가 초기화됩니다.
  * 제출 시각이 기록되어 대상자 정렬과 관리가 개선됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->