### PR TITLE
feat: 메일 발송 대상자 조회 API 추가

### DIFF
--- a/src/main/java/org/ject/support/admin/mail/controller/AdminMailTargetApiSpec.java
+++ b/src/main/java/org/ject/support/admin/mail/controller/AdminMailTargetApiSpec.java
@@ -1,0 +1,16 @@
+package org.ject.support.admin.mail.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.admin.mail.dto.MailTargetSearchRequest;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@Tag(name = "AdminMailTarget", description = "메일 발송 대상자 조회 API (어드민 전용)")
+public interface AdminMailTargetApiSpec {
+
+    @Operation(summary = "메일 발송 대상자 조회", description = "모집 공고와 선정 결과로 메일 발송 대상자를 조회합니다.")
+    List<MailTargetResponse> searchTargets(@ModelAttribute @Valid MailTargetSearchRequest request);
+}

--- a/src/main/java/org/ject/support/admin/mail/controller/AdminMailTargetController.java
+++ b/src/main/java/org/ject/support/admin/mail/controller/AdminMailTargetController.java
@@ -1,0 +1,32 @@
+package org.ject.support.admin.mail.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.admin.mail.dto.MailTargetSelectionResult;
+import org.ject.support.admin.mail.service.MailTargetService;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/mails/targets")
+@Tag(name = "AdminMailTarget", description = "메일 발송 대상자 조회 API (어드민 전용)")
+public class AdminMailTargetController {
+
+    private final MailTargetService mailTargetService;
+
+    @GetMapping
+    @Operation(summary = "메일 발송 대상자 조회", description = "모집 공고와 선정 결과로 메일 발송 대상자를 조회합니다.")
+    public List<MailTargetResponse> getTargets(
+            @RequestParam("recruitId") Long recruitId,
+            @RequestParam(value = "selectionResult", required = false) MailTargetSelectionResult selectionResult) {
+        SelectionResult result = selectionResult == null ? null : selectionResult.toSelectionResult();
+        return mailTargetService.getTargets(recruitId, result);
+    }
+}

--- a/src/main/java/org/ject/support/admin/mail/controller/AdminMailTargetController.java
+++ b/src/main/java/org/ject/support/admin/mail/controller/AdminMailTargetController.java
@@ -1,32 +1,32 @@
 package org.ject.support.admin.mail.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.ject.support.admin.mail.dto.MailTargetResponse;
-import org.ject.support.admin.mail.dto.MailTargetSelectionResult;
+import org.ject.support.admin.mail.dto.MailTargetSearchRequest;
 import org.ject.support.admin.mail.service.MailTargetService;
 import org.ject.support.domain.apply.domain.SelectionResult;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin/mails/targets")
-@Tag(name = "AdminMailTarget", description = "메일 발송 대상자 조회 API (어드민 전용)")
-public class AdminMailTargetController {
+public class AdminMailTargetController implements AdminMailTargetApiSpec {
 
     private final MailTargetService mailTargetService;
 
+    @Override
     @GetMapping
-    @Operation(summary = "메일 발송 대상자 조회", description = "모집 공고와 선정 결과로 메일 발송 대상자를 조회합니다.")
-    public List<MailTargetResponse> getTargets(
-            @RequestParam("recruitId") Long recruitId,
-            @RequestParam(value = "selectionResult", required = false) MailTargetSelectionResult selectionResult) {
-        SelectionResult result = selectionResult == null ? null : selectionResult.toSelectionResult();
-        return mailTargetService.getTargets(recruitId, result);
+    public List<MailTargetResponse> searchTargets(
+            @ParameterObject @ModelAttribute @Valid MailTargetSearchRequest request) {
+        SelectionResult result = request.selectionResult() == null
+                ? null
+                : request.selectionResult().toSelectionResult();
+        return mailTargetService.searchTargets(request.recruitId(), result);
     }
 }

--- a/src/main/java/org/ject/support/admin/mail/dto/MailTargetResponse.java
+++ b/src/main/java/org/ject/support/admin/mail/dto/MailTargetResponse.java
@@ -1,0 +1,18 @@
+package org.ject.support.admin.mail.dto;
+
+import org.ject.support.domain.apply.domain.SelectionResult;
+
+public record MailTargetResponse(
+        Long applyId,
+        String name,
+        String phoneNumber,
+        String email,
+        SelectionResult selectionResult,
+        Integer waitlistNumber
+) {
+    public MailTargetResponse {
+        if (selectionResult != SelectionResult.WAITLISTED) {
+            waitlistNumber = null;
+        }
+    }
+}

--- a/src/main/java/org/ject/support/admin/mail/dto/MailTargetSearchRequest.java
+++ b/src/main/java/org/ject/support/admin/mail/dto/MailTargetSearchRequest.java
@@ -1,0 +1,13 @@
+package org.ject.support.admin.mail.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record MailTargetSearchRequest(
+        @Schema(description = "모집 공고 ID", example = "1")
+        @NotNull @Positive Long recruitId,
+        @Schema(description = "선정 결과 필터", example = "PASSED", nullable = true)
+        MailTargetSelectionResult selectionResult
+) {
+}

--- a/src/main/java/org/ject/support/admin/mail/dto/MailTargetSelectionResult.java
+++ b/src/main/java/org/ject/support/admin/mail/dto/MailTargetSelectionResult.java
@@ -1,0 +1,11 @@
+package org.ject.support.admin.mail.dto;
+
+import org.ject.support.domain.apply.domain.SelectionResult;
+
+public enum MailTargetSelectionResult {
+    PASSED, WAITLISTED, FAILED;
+
+    public SelectionResult toSelectionResult() {
+        return SelectionResult.valueOf(name());
+    }
+}

--- a/src/main/java/org/ject/support/admin/mail/repository/MailTargetQueryRepository.java
+++ b/src/main/java/org/ject/support/admin/mail/repository/MailTargetQueryRepository.java
@@ -1,0 +1,52 @@
+package org.ject.support.admin.mail.repository;
+
+import static org.ject.support.domain.apply.domain.QApplicationForm.applicationForm;
+import static org.ject.support.domain.apply.domain.QApply.apply;
+import static org.ject.support.domain.applicant.entity.QApplicant.applicant;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.domain.apply.domain.ApplyStatus;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MailTargetQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<MailTargetResponse> findTargets(Long recruitId, SelectionResult selectionResult) {
+        return queryFactory
+                .select(Projections.constructor(
+                        MailTargetResponse.class,
+                        apply.id,
+                        applicant.name,
+                        applicant.phoneNumber,
+                        applicant.email,
+                        apply.selectionResult,
+                        apply.waitlistNumber))
+                .from(apply)
+                .join(apply.applicant, applicant)
+                .join(apply.applicationForm, applicationForm)
+                .where(
+                        apply.recruit.id.eq(recruitId),
+                        apply.status.eq(ApplyStatus.SUBMITTED),
+                        apply.isDeleted.eq(false),
+                        applicant.isDeleted.eq(false),
+                        eqSelectionResult(selectionResult))
+                .orderBy(apply.submittedAt.desc(), apply.id.desc())
+                .fetch();
+    }
+
+    private BooleanExpression eqSelectionResult(SelectionResult selectionResult) {
+        return Optional.ofNullable(selectionResult)
+                .map(apply.selectionResult::eq)
+                .orElse(null);
+    }
+}

--- a/src/main/java/org/ject/support/admin/mail/service/MailTargetService.java
+++ b/src/main/java/org/ject/support/admin/mail/service/MailTargetService.java
@@ -19,7 +19,7 @@ public class MailTargetService {
     private final RecruitRepository recruitRepository;
     private final MailTargetQueryRepository mailTargetQueryRepository;
 
-    public List<MailTargetResponse> getTargets(Long recruitId, SelectionResult selectionResult) {
+    public List<MailTargetResponse> searchTargets(Long recruitId, SelectionResult selectionResult) {
         if (!recruitRepository.existsById(recruitId)) {
             throw new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT);
         }

--- a/src/main/java/org/ject/support/admin/mail/service/MailTargetService.java
+++ b/src/main/java/org/ject/support/admin/mail/service/MailTargetService.java
@@ -1,0 +1,28 @@
+package org.ject.support.admin.mail.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.admin.mail.repository.MailTargetQueryRepository;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MailTargetService {
+
+    private final RecruitRepository recruitRepository;
+    private final MailTargetQueryRepository mailTargetQueryRepository;
+
+    public List<MailTargetResponse> getTargets(Long recruitId, SelectionResult selectionResult) {
+        if (!recruitRepository.existsById(recruitId)) {
+            throw new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT);
+        }
+        return mailTargetQueryRepository.findTargets(recruitId, selectionResult);
+    }
+}

--- a/src/main/java/org/ject/support/domain/apply/domain/Apply.java
+++ b/src/main/java/org/ject/support/domain/apply/domain/Apply.java
@@ -28,6 +28,8 @@ import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.domain.base.BaseTimeEntity;
 import org.ject.support.domain.recruit.domain.Recruit;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -60,6 +62,9 @@ public class Apply extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(50)", nullable = false)
     private ApplyStatus status;
+
+    @Column(name = "submitted_at")
+    private LocalDateTime submittedAt;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "selection_result", columnDefinition = "varchar(50)", nullable = false)
@@ -94,6 +99,9 @@ public class Apply extends BaseTimeEntity {
 
     public void updateStatus(ApplyStatus status) {
         this.status = status;
+        if (!status.equals(ApplyStatus.SUBMITTED)) {
+            this.submittedAt = null;
+        }
     }
 
     public boolean isNotTempSaved() {
@@ -118,6 +126,7 @@ public class Apply extends BaseTimeEntity {
     public void reject() {
         this.applicationForm = null;
         this.status = ApplyStatus.REJECTED;
+        this.submittedAt = null;
         this.selectionResult = SelectionResult.UNDECIDED;
         this.waitlistNumber = null;
     }
@@ -173,6 +182,7 @@ public class Apply extends BaseTimeEntity {
 
         this.applicationForm = applicationForm;
         this.status = ApplyStatus.SUBMITTED;
+        this.submittedAt = LocalDateTime.now();
     }
 
 }

--- a/src/main/resources/db/migration/V38__add_submitted_at_to_apply.sql
+++ b/src/main/resources/db/migration/V38__add_submitted_at_to_apply.sql
@@ -1,0 +1,7 @@
+ALTER TABLE apply
+    ADD COLUMN submitted_at datetime(6) NULL;
+
+-- 기존 제출 완료 지원서는 제출 시각이 없어 created_at을 임시 기준으로 백필한다.
+UPDATE apply
+SET submitted_at = created_at
+WHERE status = 'SUBMITTED';

--- a/src/test/java/org/ject/support/admin/mail/controller/AdminMailTargetControllerTest.java
+++ b/src/test/java/org/ject/support/admin/mail/controller/AdminMailTargetControllerTest.java
@@ -23,11 +23,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.OptionalValidatorFactoryBean;
 
 @ExtendWith(MockitoExtension.class)
 class AdminMailTargetControllerTest {
 
     private MockMvc mockMvc;
+
+    private final OptionalValidatorFactoryBean validator = new OptionalValidatorFactoryBean();
 
     @Mock
     private MailTargetService mailTargetService;
@@ -39,6 +42,7 @@ class AdminMailTargetControllerTest {
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(adminMailTargetController)
                 .setControllerAdvice(new GlobalExceptionHandler(), new ResponseWrapper())
+                .setValidator(validator)
                 .build();
     }
 
@@ -47,7 +51,7 @@ class AdminMailTargetControllerTest {
         // given
         MailTargetResponse response = new MailTargetResponse(
                 10L, "홍길동", "01012345678", "test@test.com", SelectionResult.WAITLISTED, 2);
-        given(mailTargetService.getTargets(1L, SelectionResult.WAITLISTED)).willReturn(List.of(response));
+        given(mailTargetService.searchTargets(1L, SelectionResult.WAITLISTED)).willReturn(List.of(response));
 
         // when & then
         mockMvc.perform(get("/admin/mails/targets")
@@ -60,19 +64,19 @@ class AdminMailTargetControllerTest {
                 .andExpect(jsonPath("$.data[0].email").value("test@test.com"))
                 .andExpect(jsonPath("$.data[0].selectionResult").value("WAITLISTED"))
                 .andExpect(jsonPath("$.data[0].waitlistNumber").value(2));
-        then(mailTargetService).should().getTargets(1L, SelectionResult.WAITLISTED);
+        then(mailTargetService).should().searchTargets(1L, SelectionResult.WAITLISTED);
     }
 
     @Test
     void 선정_결과_없이_전체_메일_발송_대상을_조회한다() throws Exception {
         // given
-        given(mailTargetService.getTargets(1L, null)).willReturn(List.of());
+        given(mailTargetService.searchTargets(1L, null)).willReturn(List.of());
 
         // when & then
         mockMvc.perform(get("/admin/mails/targets").param("recruitId", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isEmpty());
-        then(mailTargetService).should().getTargets(1L, null);
+        then(mailTargetService).should().searchTargets(1L, null);
     }
 
     @Test
@@ -86,12 +90,19 @@ class AdminMailTargetControllerTest {
     @Test
     void 존재하지_않는_모집_공고면_404를_반환한다() throws Exception {
         // given
-        given(mailTargetService.getTargets(999L, null))
+        given(mailTargetService.searchTargets(999L, null))
                 .willThrow(new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
 
         // when & then
         mockMvc.perform(get("/admin/mails/targets").param("recruitId", "999"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value("RECRUIT-1"));
+    }
+
+    @Test
+    void 모집_공고_ID가_양수가_아니면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/admin/mails/targets").param("recruitId", "0"))
+                .andExpect(status().isBadRequest());
+        then(mailTargetService).shouldHaveNoInteractions();
     }
 }

--- a/src/test/java/org/ject/support/admin/mail/controller/AdminMailTargetControllerTest.java
+++ b/src/test/java/org/ject/support/admin/mail/controller/AdminMailTargetControllerTest.java
@@ -1,0 +1,97 @@
+package org.ject.support.admin.mail.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.admin.mail.dto.MailTargetSelectionResult;
+import org.ject.support.admin.mail.service.MailTargetService;
+import org.ject.support.common.exception.GlobalExceptionHandler;
+import org.ject.support.common.response.ResponseWrapper;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class AdminMailTargetControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private MailTargetService mailTargetService;
+
+    @InjectMocks
+    private AdminMailTargetController adminMailTargetController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(adminMailTargetController)
+                .setControllerAdvice(new GlobalExceptionHandler(), new ResponseWrapper())
+                .build();
+    }
+
+    @Test
+    void 선정_결과를_지정해_메일_발송_대상을_조회한다() throws Exception {
+        // given
+        MailTargetResponse response = new MailTargetResponse(
+                10L, "홍길동", "01012345678", "test@test.com", SelectionResult.WAITLISTED, 2);
+        given(mailTargetService.getTargets(1L, SelectionResult.WAITLISTED)).willReturn(List.of(response));
+
+        // when & then
+        mockMvc.perform(get("/admin/mails/targets")
+                        .param("recruitId", "1")
+                        .param("selectionResult", "WAITLISTED"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].applyId").value(10))
+                .andExpect(jsonPath("$.data[0].name").value("홍길동"))
+                .andExpect(jsonPath("$.data[0].phoneNumber").value("01012345678"))
+                .andExpect(jsonPath("$.data[0].email").value("test@test.com"))
+                .andExpect(jsonPath("$.data[0].selectionResult").value("WAITLISTED"))
+                .andExpect(jsonPath("$.data[0].waitlistNumber").value(2));
+        then(mailTargetService).should().getTargets(1L, SelectionResult.WAITLISTED);
+    }
+
+    @Test
+    void 선정_결과_없이_전체_메일_발송_대상을_조회한다() throws Exception {
+        // given
+        given(mailTargetService.getTargets(1L, null)).willReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get("/admin/mails/targets").param("recruitId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isEmpty());
+        then(mailTargetService).should().getTargets(1L, null);
+    }
+
+    @Test
+    void 미지원_선정_결과는_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/admin/mails/targets")
+                        .param("recruitId", "1")
+                        .param("selectionResult", "UNDECIDED"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 존재하지_않는_모집_공고면_404를_반환한다() throws Exception {
+        // given
+        given(mailTargetService.getTargets(999L, null))
+                .willThrow(new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
+
+        // when & then
+        mockMvc.perform(get("/admin/mails/targets").param("recruitId", "999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value("RECRUIT-1"));
+    }
+}

--- a/src/test/java/org/ject/support/admin/mail/controller/AdminMailTargetSecurityTest.java
+++ b/src/test/java/org/ject/support/admin/mail/controller/AdminMailTargetSecurityTest.java
@@ -45,7 +45,7 @@ class AdminMailTargetSecurityTest extends ApplicationPeriodTest {
     @Test
     @AuthenticatedUser(isAdmin = true)
     void 관리자는_메일_발송_대상을_조회할_수_있다() throws Exception {
-        given(mailTargetService.getTargets(1L, null)).willReturn(List.of(
+        given(mailTargetService.searchTargets(1L, null)).willReturn(List.of(
                 new MailTargetResponse(1L, "홍길동", "01012345678", "test@test.com", SelectionResult.PASSED, null)));
 
         mockMvc.perform(get("/admin/mails/targets").param("recruitId", "1"))

--- a/src/test/java/org/ject/support/admin/mail/controller/AdminMailTargetSecurityTest.java
+++ b/src/test/java/org/ject/support/admin/mail/controller/AdminMailTargetSecurityTest.java
@@ -1,0 +1,54 @@
+package org.ject.support.admin.mail.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.admin.mail.service.MailTargetService;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.ject.support.testconfig.ApplicationPeriodTest;
+import org.ject.support.testconfig.AuthenticatedUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
+class AdminMailTargetSecurityTest extends ApplicationPeriodTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MailTargetService mailTargetService;
+
+    @Test
+    void 인증되지_않은_사용자는_메일_발송_대상을_조회할_수_없다() throws Exception {
+        mockMvc.perform(get("/admin/mails/targets").param("recruitId", "1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @AuthenticatedUser(isAdmin = false)
+    void 일반_사용자는_메일_발송_대상을_조회할_수_없다() throws Exception {
+        mockMvc.perform(get("/admin/mails/targets").param("recruitId", "1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @AuthenticatedUser(isAdmin = true)
+    void 관리자는_메일_발송_대상을_조회할_수_있다() throws Exception {
+        given(mailTargetService.getTargets(1L, null)).willReturn(List.of(
+                new MailTargetResponse(1L, "홍길동", "01012345678", "test@test.com", SelectionResult.PASSED, null)));
+
+        mockMvc.perform(get("/admin/mails/targets").param("recruitId", "1"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/org/ject/support/admin/mail/repository/MailTargetQueryRepositoryTest.java
+++ b/src/test/java/org/ject/support/admin/mail/repository/MailTargetQueryRepositoryTest.java
@@ -1,0 +1,161 @@
+package org.ject.support.admin.mail.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ject.support.domain.apply.domain.ApplyStatus.SUBMITTED;
+import static org.ject.support.domain.member.JobFamily.BE;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.domain.applicant.entity.Applicant;
+import org.ject.support.domain.applicant.repository.ApplicantRepository;
+import org.ject.support.domain.apply.domain.ApplicationForm;
+import org.ject.support.domain.apply.domain.Apply;
+import org.ject.support.domain.apply.domain.ApplyStatus;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.ject.support.domain.apply.repository.ApplyRepository;
+import org.ject.support.domain.member.MemberStatus;
+import org.ject.support.domain.member.Role;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.Semester;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.ject.support.domain.recruit.repository.SemesterRepository;
+import org.ject.support.testconfig.QueryDslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@Import({QueryDslTestConfig.class, MailTargetQueryRepository.class})
+@DataJpaTest
+class MailTargetQueryRepositoryTest {
+
+    @Autowired
+    private MailTargetQueryRepository mailTargetQueryRepository;
+
+    @Autowired
+    private SemesterRepository semesterRepository;
+
+    @Autowired
+    private RecruitRepository recruitRepository;
+
+    @Autowired
+    private ApplicantRepository applicantRepository;
+
+    @Autowired
+    private ApplyRepository applyRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Recruit recruit;
+
+    @BeforeEach
+    void setUp() {
+        Semester semester = semesterRepository.save(Semester.builder()
+                .name("1기")
+                .isRecruiting(true)
+                .build());
+        recruit = recruitRepository.save(Recruit.builder()
+                .semester(semester)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .jobFamily(BE)
+                .build());
+    }
+
+    @Test
+    void 제출_완료되고_지원서가_있는_대상만_제출_시각과_ID_내림차순으로_조회한다() {
+        // given
+        LocalDateTime latest = LocalDateTime.of(2025, 1, 3, 10, 0);
+        LocalDateTime sameSubmittedAt = LocalDateTime.of(2025, 1, 2, 10, 0);
+        Apply latestApply = saveTarget("latest@test.com", latest, SelectionResult.PASSED, 99);
+        Apply firstTieApply = saveTarget("first-tie@test.com", sameSubmittedAt, SelectionResult.FAILED);
+        Apply secondTieApply = saveTarget("second-tie@test.com", sameSubmittedAt, SelectionResult.WAITLISTED, 2);
+        saveApplyWithoutForm("without-form@test.com", SUBMITTED);
+        saveApplyWithoutForm("temp@test.com", ApplyStatus.TEMP_SAVED);
+        Apply deletedApply = saveTarget("deleted@test.com", latest, SelectionResult.PASSED);
+        applyRepository.delete(deletedApply);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<MailTargetResponse> result = mailTargetQueryRepository.findTargets(recruit.getId(), null);
+
+        // then
+        assertThat(result)
+                .extracting(MailTargetResponse::applyId)
+                .containsExactly(latestApply.getId(), secondTieApply.getId(), firstTieApply.getId());
+        assertThat(result.getFirst().waitlistNumber()).isNull();
+    }
+
+    @Test
+    void 선정_결과로_메일_발송_대상을_필터링한다() {
+        // given
+        saveTarget("passed@test.com", LocalDateTime.now(), SelectionResult.PASSED);
+        Apply waitlistedApply = saveTarget("waitlisted@test.com", LocalDateTime.now(), SelectionResult.WAITLISTED, 1);
+        saveTarget("failed@test.com", LocalDateTime.now(), SelectionResult.FAILED);
+
+        // when
+        List<MailTargetResponse> result = mailTargetQueryRepository.findTargets(
+                recruit.getId(), SelectionResult.WAITLISTED);
+
+        // then
+        assertThat(result).singleElement().satisfies(target -> {
+            assertThat(target.applyId()).isEqualTo(waitlistedApply.getId());
+            assertThat(target.email()).isEqualTo("waitlisted@test.com");
+            assertThat(target.selectionResult()).isEqualTo(SelectionResult.WAITLISTED);
+            assertThat(target.waitlistNumber()).isEqualTo(1);
+        });
+    }
+
+    private Apply saveTarget(String email, LocalDateTime submittedAt, SelectionResult selectionResult) {
+        return saveTarget(email, submittedAt, selectionResult, null);
+    }
+
+    private Apply saveTarget(String email,
+                             LocalDateTime submittedAt,
+                             SelectionResult selectionResult,
+                             Integer waitlistNumber) {
+        Applicant applicant = applicantRepository.save(Applicant.builder()
+                .email(email)
+                .name("테스트 사용자")
+                .phoneNumber("01012345678")
+                .jobFamily(BE)
+                .semesterId(1L)
+                .role(Role.APPLY)
+                .status(MemberStatus.ACTIVE)
+                .pin("123456")
+                .build());
+        Apply apply = Apply.builder()
+                .applicant(applicant)
+                .recruit(recruit)
+                .status(SUBMITTED)
+                .selectionResult(selectionResult)
+                .waitlistNumber(waitlistNumber)
+                .submittedAt(submittedAt)
+                .build();
+        apply.updateApplicationForm(ApplicationForm.builder().apply(apply).build());
+        return applyRepository.save(apply);
+    }
+
+    private Apply saveApplyWithoutForm(String email, ApplyStatus status) {
+        Applicant applicant = applicantRepository.save(Applicant.builder()
+                .email(email)
+                .name("테스트 사용자")
+                .phoneNumber("01012345678")
+                .jobFamily(BE)
+                .semesterId(1L)
+                .role(Role.APPLY)
+                .status(MemberStatus.ACTIVE)
+                .pin("123456")
+                .build());
+        return applyRepository.save(Apply.builder()
+                .applicant(applicant)
+                .recruit(recruit)
+                .status(status)
+                .build());
+    }
+}

--- a/src/test/java/org/ject/support/admin/mail/service/MailTargetServiceTest.java
+++ b/src/test/java/org/ject/support/admin/mail/service/MailTargetServiceTest.java
@@ -41,7 +41,7 @@ class MailTargetServiceTest {
                 .willReturn(List.of(response));
 
         // when
-        List<MailTargetResponse> result = mailTargetService.getTargets(recruitId, SelectionResult.PASSED);
+        List<MailTargetResponse> result = mailTargetService.searchTargets(recruitId, SelectionResult.PASSED);
 
         // then
         assertThat(result).containsExactly(response);
@@ -54,7 +54,7 @@ class MailTargetServiceTest {
         given(recruitRepository.existsById(recruitId)).willReturn(false);
 
         // when & then
-        assertThatThrownBy(() -> mailTargetService.getTargets(recruitId, null))
+        assertThatThrownBy(() -> mailTargetService.searchTargets(recruitId, null))
                 .isInstanceOf(RecruitException.class)
                 .extracting("errorCode")
                 .isEqualTo(RecruitErrorCode.NOT_FOUND_RECRUIT);

--- a/src/test/java/org/ject/support/admin/mail/service/MailTargetServiceTest.java
+++ b/src/test/java/org/ject/support/admin/mail/service/MailTargetServiceTest.java
@@ -1,0 +1,63 @@
+package org.ject.support.admin.mail.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailTargetResponse;
+import org.ject.support.admin.mail.repository.MailTargetQueryRepository;
+import org.ject.support.domain.apply.domain.SelectionResult;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MailTargetServiceTest {
+
+    @InjectMocks
+    private MailTargetService mailTargetService;
+
+    @Mock
+    private RecruitRepository recruitRepository;
+
+    @Mock
+    private MailTargetQueryRepository mailTargetQueryRepository;
+
+    @Test
+    void 모집_공고와_선정_결과로_메일_발송_대상을_조회한다() {
+        // given
+        Long recruitId = 1L;
+        MailTargetResponse response = new MailTargetResponse(
+                10L, "홍길동", "01012345678", "test@test.com", SelectionResult.PASSED, null);
+        given(recruitRepository.existsById(recruitId)).willReturn(true);
+        given(mailTargetQueryRepository.findTargets(recruitId, SelectionResult.PASSED))
+                .willReturn(List.of(response));
+
+        // when
+        List<MailTargetResponse> result = mailTargetService.getTargets(recruitId, SelectionResult.PASSED);
+
+        // then
+        assertThat(result).containsExactly(response);
+    }
+
+    @Test
+    void 존재하지_않는_모집_공고면_예외가_발생한다() {
+        // given
+        Long recruitId = 999L;
+        given(recruitRepository.existsById(recruitId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> mailTargetService.getTargets(recruitId, null))
+                .isInstanceOf(RecruitException.class)
+                .extracting("errorCode")
+                .isEqualTo(RecruitErrorCode.NOT_FOUND_RECRUIT);
+        then(mailTargetQueryRepository).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/org/ject/support/domain/apply/domain/ApplyTest.java
+++ b/src/test/java/org/ject/support/domain/apply/domain/ApplyTest.java
@@ -34,6 +34,20 @@ class ApplyTest extends TestSupport {
     }
 
     @Test
+    void 제출하면_제출_시각을_기록한다() {
+        // given
+        Apply apply = Apply.createApply(Applicant.builder().build(), Recruit.builder()
+                .jobFamily(JobFamily.BE)
+                .build());
+
+        // when
+        apply.submit(ApplicationForm.builder().build());
+
+        // then
+        assertThat(apply.getSubmittedAt()).isNotNull();
+    }
+
+    @Test
     void 포트폴리오가_필수인_직군은_포트폴리오가_있으면_제출할_수_있다() {
         // given
         Recruit recruit = Recruit.builder()
@@ -212,6 +226,18 @@ class ApplyTest extends TestSupport {
         // then
         assertThat(apply.getSelectionResult()).isEqualTo(SelectionResult.UNDECIDED);
         assertThat(apply.getWaitlistNumber()).isNull();
+    }
+
+    @Test
+    void 반려하면_제출_시각을_초기화한다() {
+        // given
+        Apply apply = submittedApply();
+
+        // when
+        apply.reject();
+
+        // then
+        assertThat(apply.getSubmittedAt()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

#627

## 📝 작업 내용

- 모집 공고와 선정 결과로 메일 발송 대상자를 조회하는 `GET /admin/mails/targets` API를 추가했습니다.
- `SUBMITTED` 상태이면서 `ApplicationForm`이 존재하는 지원만 DTO projection으로 조회하고, `submittedAt DESC, applyId DESC`로 정렬합니다.
- `PASSED`, `WAITLISTED`, `FAILED` 필터와 지원자 이름·전화번호·이메일·선정 결과·예비 번호 응답을 제공합니다.
- `submittedAt` 필드와 V38 Flyway 마이그레이션을 추가했습니다. 기존 제출 완료 데이터는 `created_at`을 임시 기준으로 백필합니다.
- 모집 공고 404, 필터·정렬·빈 결과·미제출·삭제 지원 제외·권한 거부를 테스트했습니다.
- 검증: Java 21 `./gradlew test --tests 'org.ject.support.admin.mail.*' -x jacocoTestCoverageVerification`, `./gradlew compileJava compileTestJava --no-daemon` 통과
- 전체 `./gradlew test`는 Docker 미실행으로 기존 Testcontainers 기반 컨텍스트 51건이 실패했습니다.

## 🙏 리뷰 요구사항 (선택)

- 현재 PR은 #632 (`feat/625-selection-result`) 위에 쌓은 stacked PR입니다. #632 머지 후 base를 `dev`로 변경해야 합니다.
- 기존 제출 완료 데이터의 `submittedAt`은 `created_at`을 임시 기준으로 백필한 값입니다.