### PR TITLE
feat: 메이커스팀 구성원 단건, 다건 삭제 API 구현

### DIFF
--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersApiSpec.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersApiSpec.java
@@ -1,6 +1,7 @@
 package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMemberMakersRequest;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
 import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
@@ -32,4 +33,16 @@ public interface AdminMemberMakersApiSpec {
 		description = "메이커스팀 구성원을 상세 조회합니다."
 	)
 	MemberMakersDetailResponse getAdminMemberMakersDetail(@PathVariable Long memberActivityId);
+
+	@Operation(
+		summary = "메이커스팀 구성원 삭제",
+		description = "전달한 활동 ID에 해당하는 메이커스팀 구성원을 삭제합니다."
+	)
+	void deleteAdminMemberMakers(@PathVariable Long memberActivityId);
+
+	@Operation(
+		summary = "메이커스팀 구성원 일괄 삭제",
+		description = "선택한 메이커스팀 구성원을 일괄 삭제합니다. 유효하지 않은 ID가 있으면 전체 요청이 실패합니다."
+	)
+	void deleteAdminMemberMakersList(@RequestBody @Valid DeleteMemberMakersRequest request);
 }

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersController.java
@@ -1,12 +1,14 @@
 package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMemberMakersRequest;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
 import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
 import org.ject.support.admin.member.service.AdminMemberMakersUseCase;
 import org.ject.support.common.response.CursorPageResponse;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/admin/members/makers")
 @RequiredArgsConstructor
-public class AdminMemberMakersController implements AdminMemberMakersApiSpec{
+public class AdminMemberMakersController implements AdminMemberMakersApiSpec {
 
 	private final AdminMemberMakersUseCase adminMemberMakersUseCase;
 
@@ -44,6 +46,18 @@ public class AdminMemberMakersController implements AdminMemberMakersApiSpec{
 	@GetMapping("/{memberActivityId}")
 	public MemberMakersDetailResponse getAdminMemberMakersDetail(@PathVariable Long memberActivityId) {
 		return adminMemberMakersUseCase.getMemberMakersDetail(memberActivityId);
+	}
+
+	@Override
+	@DeleteMapping("/{memberActivityId}")
+	public void deleteAdminMemberMakers(@PathVariable Long memberActivityId) {
+		adminMemberMakersUseCase.deleteMemberMakers(memberActivityId);
+	}
+
+	@Override
+	@DeleteMapping
+	public void deleteAdminMemberMakersList(@RequestBody @Valid DeleteMemberMakersRequest request) {
+		adminMemberMakersUseCase.deleteMemberMakersList(request);
 	}
 
 }

--- a/src/main/java/org/ject/support/admin/member/dto/request/DeleteMemberMakersRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/DeleteMemberMakersRequest.java
@@ -1,0 +1,14 @@
+package org.ject.support.admin.member.dto.request;
+
+import java.util.Set;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "메이커스팀 구성원 일괄 삭제 요청")
+public record DeleteMemberMakersRequest(
+	@Schema(description = "삭제할 메이커스팀 구성원 활동 ID 목록", example = "[1, 2, 3]")
+	@NotEmpty Set<@NotNull Long> memberActivityIds
+) {
+}

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
@@ -2,6 +2,11 @@ package org.ject.support.admin.member.service;
 
 import static org.ject.support.domain.member.exception.MemberErrorCode.*;
 
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.projection.MemberSupportersDetailProjection;
@@ -22,11 +27,11 @@ import org.ject.support.domain.member.repository.MemberActivityRepository;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AdminMemberActivityService {
 
 	private final MemberActivityRepository memberActivityRepository;
@@ -135,6 +140,32 @@ public class AdminMemberActivityService {
 	public MemberMakersDetailProjection getMemberMakersDetail(Long memberActivityId) {
 		return memberActivityRepository.findMemberMakersDetail(memberActivityId)
 			.orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+	}
+
+	// 메이커스팀 구성원 활동 단건 삭제
+	public Long deleteMemberMakersActivity(Long memberActivityId) {
+		MemberActivity memberActivity = memberActivityRepository.findByIdAndMemberType(memberActivityId, MemberType.MAKERS)
+			.orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_MAKERS_ACTIVITY));
+		memberActivityRepository.delete(memberActivity);
+		return memberActivity.getMemberId();
+	}
+
+	// 메이커스팀 구성원 활동 전체 검증 후 일괄 삭제
+	public Set<Long> deleteMemberMakersActivities(Set<Long> memberActivityIds) {
+		List<MemberActivity> memberActivities = memberActivityRepository.findAllByIdInAndMemberType(
+			memberActivityIds,
+			MemberType.MAKERS
+		);
+		Set<Long> foundIds = memberActivities.stream().map(MemberActivity::getId).collect(Collectors.toSet());
+		memberActivityIds.stream().filter(id -> !foundIds.contains(id)).findFirst().ifPresent(invalidId -> {
+			log.warn("메이커스팀 구성원 일괄 삭제 검증 실패: invalidMemberActivityId={}", invalidId);
+			throw new MemberException(NOT_FOUND_MEMBER_MAKERS_ACTIVITY);
+		});
+		Set<Long> memberIds = memberActivities.stream()
+			.map(MemberActivity::getMemberId)
+			.collect(Collectors.toCollection(LinkedHashSet::new));
+		memberActivityRepository.deleteAll(memberActivities);
+		return memberIds;
 	}
 
 	// 운영 서포터즈 구성원 상세 조회

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberActivityService.java
@@ -22,6 +22,7 @@ import org.ject.support.admin.member.dto.result.MemberPageResult;
 import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.entity.MemberActivity;
+import org.ject.support.domain.member.exception.MemberErrorCode;
 import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberActivityRepository;
 import org.springframework.stereotype.Service;
@@ -142,30 +143,38 @@ public class AdminMemberActivityService {
 			.orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 	}
 
-	// 메이커스팀 구성원 활동 단건 삭제
-	public Long deleteMemberMakersActivity(Long memberActivityId) {
-		MemberActivity memberActivity = memberActivityRepository.findByIdAndMemberType(memberActivityId, MemberType.MAKERS)
-			.orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_MAKERS_ACTIVITY));
+	// 구성원 유형에 맞는 활동 단건 삭제
+	public Long deleteMemberActivity(Long memberActivityId, MemberType memberType) {
+		MemberActivity memberActivity = memberActivityRepository.findByIdAndMemberType(memberActivityId, memberType)
+			.orElseThrow(() -> new MemberException(getNotFoundActivityErrorCode(memberType)));
 		memberActivityRepository.delete(memberActivity);
 		return memberActivity.getMemberId();
 	}
 
-	// 메이커스팀 구성원 활동 전체 검증 후 일괄 삭제
-	public Set<Long> deleteMemberMakersActivities(Set<Long> memberActivityIds) {
+	// 구성원 유형에 맞는 활동 전체 검증 후 일괄 삭제
+	public Set<Long> deleteMemberActivities(Set<Long> memberActivityIds, MemberType memberType) {
 		List<MemberActivity> memberActivities = memberActivityRepository.findAllByIdInAndMemberType(
 			memberActivityIds,
-			MemberType.MAKERS
+			memberType
 		);
 		Set<Long> foundIds = memberActivities.stream().map(MemberActivity::getId).collect(Collectors.toSet());
 		memberActivityIds.stream().filter(id -> !foundIds.contains(id)).findFirst().ifPresent(invalidId -> {
-			log.warn("메이커스팀 구성원 일괄 삭제 검증 실패: invalidMemberActivityId={}", invalidId);
-			throw new MemberException(NOT_FOUND_MEMBER_MAKERS_ACTIVITY);
+			log.warn("구성원 활동 일괄 삭제 검증 실패: memberType={}, invalidMemberActivityId={}", memberType, invalidId);
+			throw new MemberException(getNotFoundActivityErrorCode(memberType));
 		});
 		Set<Long> memberIds = memberActivities.stream()
 			.map(MemberActivity::getMemberId)
 			.collect(Collectors.toCollection(LinkedHashSet::new));
 		memberActivityRepository.deleteAll(memberActivities);
 		return memberIds;
+	}
+
+	private MemberErrorCode getNotFoundActivityErrorCode(MemberType memberType) {
+		return switch (memberType) {
+			case SEMESTER -> NOT_FOUND_MEMBER_SEMESTER_ACTIVITY;
+			case MAKERS -> NOT_FOUND_MEMBER_MAKERS_ACTIVITY;
+			case SUPPORTERS -> NOT_FOUND_MEMBER_SUPPORTERS_ACTIVITY;
+		};
 	}
 
 	// 운영 서포터즈 구성원 상세 조회

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberMakersUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberMakersUseCase.java
@@ -11,6 +11,7 @@ import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
 import org.ject.support.admin.member.dto.result.MemberPageResult;
 import org.ject.support.common.response.CursorPageResponse;
+import org.ject.support.domain.member.MemberType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,14 +59,17 @@ public class AdminMemberMakersUseCase {
 	// 메이커스팀 구성원 단건 삭제
 	@Transactional
 	public void deleteMemberMakers(Long memberActivityId) {
-		Long memberId = adminMemberActivityService.deleteMemberMakersActivity(memberActivityId);
+		Long memberId = adminMemberActivityService.deleteMemberActivity(memberActivityId, MemberType.MAKERS);
 		adminMemberService.deleteMemberIfNoActivity(memberId);
 	}
 
 	// 메이커스팀 구성원 일괄 삭제
 	@Transactional
 	public void deleteMemberMakersList(DeleteMemberMakersRequest request) {
-		Set<Long> memberIds = adminMemberActivityService.deleteMemberMakersActivities(request.memberActivityIds());
+		Set<Long> memberIds = adminMemberActivityService.deleteMemberActivities(
+			request.memberActivityIds(),
+			MemberType.MAKERS
+		);
 		adminMemberService.deleteMembersIfNoActivity(memberIds);
 	}
 }

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberMakersUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberMakersUseCase.java
@@ -1,8 +1,11 @@
 package org.ject.support.admin.member.service;
 
+import java.util.Set;
+
 import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMemberMakersRequest;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
 import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
@@ -50,5 +53,19 @@ public class AdminMemberMakersUseCase {
 	public MemberMakersDetailResponse getMemberMakersDetail(Long memberActivityId) {
 		MemberMakersDetailProjection projection = adminMemberActivityService.getMemberMakersDetail(memberActivityId);
 		return MemberMakersDetailResponse.from(projection);
+	}
+
+	// 메이커스팀 구성원 단건 삭제
+	@Transactional
+	public void deleteMemberMakers(Long memberActivityId) {
+		Long memberId = adminMemberActivityService.deleteMemberMakersActivity(memberActivityId);
+		adminMemberService.deleteMemberIfNoActivity(memberId);
+	}
+
+	// 메이커스팀 구성원 일괄 삭제
+	@Transactional
+	public void deleteMemberMakersList(DeleteMemberMakersRequest request) {
+		Set<Long> memberIds = adminMemberActivityService.deleteMemberMakersActivities(request.memberActivityIds());
+		adminMemberService.deleteMembersIfNoActivity(memberIds);
 	}
 }

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberService.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberService.java
@@ -1,7 +1,14 @@
 package org.ject.support.admin.member.service;
 
+import static org.ject.support.domain.member.exception.MemberErrorCode.NOT_FOUND_MEMBER;
+
+import java.util.List;
+import java.util.Set;
+
 import org.ject.support.admin.member.dto.request.CreateMemberRequest;
 import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.exception.MemberException;
+import org.ject.support.domain.member.repository.MemberActivityRepository;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class AdminMemberService {
 
 	private final MemberRepository memberRepository;
+	private final MemberActivityRepository memberActivityRepository;
 
 	/*
 	(2026.06.23)
@@ -55,6 +63,30 @@ public class AdminMemberService {
 
 		Member savedMember = memberRepository.save(member);
 		return savedMember.getId();
+	}
+
+	// 남은 구성원 활동이 없으면 구성원 삭제
+	public void deleteMemberIfNoActivity(Long memberId) {
+		if (memberActivityRepository.existsByMemberId(memberId)) {
+			return;
+		}
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+		memberRepository.delete(member);
+	}
+
+	// 남은 구성원 활동이 없는 구성원 일괄 삭제
+	public void deleteMembersIfNoActivity(Set<Long> memberIds) {
+		Set<Long> activeMemberIds = memberActivityRepository.findMemberIdsWithActivity(memberIds);
+		List<Long> deleteMemberIds = memberIds.stream().filter(id -> !activeMemberIds.contains(id)).toList();
+		if (deleteMemberIds.isEmpty()) {
+			return;
+		}
+		List<Member> members = memberRepository.findAllById(deleteMemberIds);
+		if (deleteMemberIds.size() != members.size()) {
+			throw new MemberException(NOT_FOUND_MEMBER);
+		}
+		memberRepository.deleteAll(members);
 	}
 
 }

--- a/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
@@ -25,6 +25,8 @@ public enum MemberErrorCode implements ErrorCode {
     ALREADY_EXIST_ACTIVE_MEMBER_SUPPORTERS_ACTIVITY(CONFLICT, "MEMBER-13", "이미 활동 중인 운영 서포터즈 구성원입니다."),
     INVALID_ACTIVITY_PERIOD(BAD_REQUEST, "MEMBER-14", "활동 기간이 올바르지 않습니다."),
     NOT_FOUND_MEMBER_MAKERS_ACTIVITY(NOT_FOUND, "MEMBER-15", "메이커스팀 구성원 활동을 찾을 수 없습니다."),
+    NOT_FOUND_MEMBER_SEMESTER_ACTIVITY(NOT_FOUND, "MEMBER-16", "일반 구성원 활동을 찾을 수 없습니다."),
+    NOT_FOUND_MEMBER_SUPPORTERS_ACTIVITY(NOT_FOUND, "MEMBER-17", "운영 서포터즈 구성원 활동을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/ject/support/domain/member/exception/MemberErrorCode.java
@@ -24,6 +24,7 @@ public enum MemberErrorCode implements ErrorCode {
     INVALID_JOB_FAMILY(BAD_REQUEST, "MEMBER-12", "구성원 유형에 맞지 않는 직군입니다."),
     ALREADY_EXIST_ACTIVE_MEMBER_SUPPORTERS_ACTIVITY(CONFLICT, "MEMBER-13", "이미 활동 중인 운영 서포터즈 구성원입니다."),
     INVALID_ACTIVITY_PERIOD(BAD_REQUEST, "MEMBER-14", "활동 기간이 올바르지 않습니다."),
+    NOT_FOUND_MEMBER_MAKERS_ACTIVITY(NOT_FOUND, "MEMBER-15", "메이커스팀 구성원 활동을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/ject/support/domain/member/repository/MemberActivityRepository.java
+++ b/src/main/java/org/ject/support/domain/member/repository/MemberActivityRepository.java
@@ -1,5 +1,10 @@
 package org.ject.support.domain.member.repository;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
 import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.entity.MemberActivity;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +14,15 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberActivityRepository extends JpaRepository<MemberActivity, Long>, MemberActivityQueryRepository {
+
+	Optional<MemberActivity> findByIdAndMemberType(Long id, MemberType memberType);
+
+	List<MemberActivity> findAllByIdInAndMemberType(Collection<Long> ids, MemberType memberType);
+
+	boolean existsByMemberId(Long memberId);
+
+	@Query("select distinct ma.memberId from MemberActivity ma where ma.memberId in :memberIds")
+	Set<Long> findMemberIdsWithActivity(@Param("memberIds") Collection<Long> memberIds);
 
 	@Query("""
 		select count(ma) > 0

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.ject.support.domain.member.fixture.MakersActivityFixture.makersActivity;
 import static org.ject.support.domain.member.fixture.MemberFixture.member;
+import static org.ject.support.domain.member.fixture.SemesterActivityFixture.semesterActivity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -11,7 +13,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import java.util.Set;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMemberMakersRequest;
 import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.Availability;
 import org.ject.support.domain.member.CareerDetails;
@@ -258,6 +262,156 @@ class AdminMemberMakersControllerTest {
 		mockMvc.perform(get("/admin/members/makers/{memberActivityId}", 999999999L))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.status").value(MemberErrorCode.NOT_FOUND_MEMBER.getCode()));
+	}
+
+	@Test
+	@DisplayName("메이커스팀 구성원을 삭제하고 남은 활동이 없으면 구성원도 삭제한다")
+	void 메이커스팀_구성원을_삭제하고_남은_활동이_없으면_구성원도_삭제한다() throws Exception {
+		// given
+		MemberActivity memberActivity = saveMakersActivity(uniqueEmail("delete"), JobFamily.FE, MakersTeam.TEAM_1);
+		Long memberId = memberActivity.getMemberId();
+
+		// when
+		mockMvc.perform(delete("/admin/members/makers/{memberActivityId}", memberActivity.getId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("SUCCESS"));
+
+		// then
+		assertThat(memberActivityRepository.findById(memberActivity.getId())).isEmpty();
+		assertThat(memberRepository.findById(memberId)).isEmpty();
+	}
+
+	@Test
+	@DisplayName("메이커스팀 활동을 삭제해도 다른 활동이 남아 있으면 구성원을 유지한다")
+	void 메이커스팀_활동을_삭제해도_다른_활동이_남아_있으면_구성원을_유지한다() throws Exception {
+		// given
+		Member member = memberRepository.save(member().email(uniqueEmail("remain")).build());
+		MemberActivity makers = memberActivityRepository.saveAndFlush(makersActivity().memberId(member.getId()).build());
+		MemberActivity semester = memberActivityRepository.saveAndFlush(semesterActivity().memberId(member.getId()).build());
+
+		// when
+		mockMvc.perform(delete("/admin/members/makers/{memberActivityId}", makers.getId()))
+			.andExpect(status().isOk());
+
+		// then
+		assertThat(memberActivityRepository.findById(makers.getId())).isEmpty();
+		assertThat(memberActivityRepository.findById(semester.getId())).isPresent();
+		assertThat(memberRepository.findById(member.getId())).isPresent();
+	}
+
+	@Test
+	@DisplayName("메이커스팀이 아닌 활동은 삭제하지 않는다")
+	void 메이커스팀이_아닌_활동은_삭제하지_않는다() throws Exception {
+		// given
+		Member member = memberRepository.save(member().email(uniqueEmail("invalid-type")).build());
+		MemberActivity semester = memberActivityRepository.saveAndFlush(semesterActivity().memberId(member.getId()).build());
+
+		// when & then
+		mockMvc.perform(delete("/admin/members/makers/{memberActivityId}", semester.getId()))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.status").value(MemberErrorCode.NOT_FOUND_MEMBER_MAKERS_ACTIVITY.getCode()));
+		assertThat(memberActivityRepository.findById(semester.getId())).isPresent();
+		assertThat(memberRepository.findById(member.getId())).isPresent();
+	}
+
+	@Test
+	@DisplayName("선택한 메이커스팀 구성원을 모두 삭제한다")
+	void 선택한_메이커스팀_구성원을_모두_삭제한다() throws Exception {
+		// given
+		MemberActivity first = saveMakersActivity(uniqueEmail("bulk1"), JobFamily.FE, MakersTeam.TEAM_1);
+		MemberActivity second = saveMakersActivity(uniqueEmail("bulk2"), JobFamily.BE, MakersTeam.TEAM_2);
+		DeleteMemberMakersRequest request = new DeleteMemberMakersRequest(Set.of(first.getId(), second.getId()));
+
+		// when
+		mockMvc.perform(delete("/admin/members/makers")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("SUCCESS"));
+
+		// then
+		assertThat(memberActivityRepository.findAllById(List.of(first.getId(), second.getId()))).isEmpty();
+		assertThat(memberRepository.findAllById(List.of(first.getMemberId(), second.getMemberId()))).isEmpty();
+	}
+
+	@Test
+	@DisplayName("일괄 삭제 대상에 존재하지 않는 활동이 있으면 아무도 삭제하지 않는다")
+	void 일괄_삭제_대상에_존재하지_않는_활동이_있으면_아무도_삭제하지_않는다() throws Exception {
+		// given
+		MemberActivity memberActivity = saveMakersActivity(uniqueEmail("bulk-invalid"), JobFamily.FE, MakersTeam.TEAM_1);
+		DeleteMemberMakersRequest request = new DeleteMemberMakersRequest(Set.of(memberActivity.getId(), 999999999L));
+
+		// when
+		mockMvc.perform(delete("/admin/members/makers")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.status").value(MemberErrorCode.NOT_FOUND_MEMBER_MAKERS_ACTIVITY.getCode()));
+
+		// then
+		assertThat(memberActivityRepository.findById(memberActivity.getId())).isPresent();
+		assertThat(memberRepository.findById(memberActivity.getMemberId())).isPresent();
+	}
+
+	@Test
+	@DisplayName("일괄 삭제 대상에 메이커스팀이 아닌 활동이 포함되면 모든 활동을 유지한다")
+	void 일괄_삭제_대상에_메이커스팀이_아닌_활동이_포함되면_모든_활동을_유지한다() throws Exception {
+		// given
+		MemberActivity makers = saveMakersActivity(uniqueEmail("bulk-makers"), JobFamily.FE, MakersTeam.TEAM_1);
+		Member member = memberRepository.save(member().email(uniqueEmail("bulk-semester")).build());
+		MemberActivity semester = memberActivityRepository.saveAndFlush(semesterActivity().memberId(member.getId()).build());
+		DeleteMemberMakersRequest request = new DeleteMemberMakersRequest(Set.of(makers.getId(), semester.getId()));
+
+		// when
+		mockMvc.perform(delete("/admin/members/makers")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.status").value(MemberErrorCode.NOT_FOUND_MEMBER_MAKERS_ACTIVITY.getCode()));
+
+		// then
+		assertThat(memberActivityRepository.findById(makers.getId())).isPresent();
+		assertThat(memberActivityRepository.findById(semester.getId())).isPresent();
+	}
+
+	@Test
+	@DisplayName("중복된 활동 ID는 하나로 처리해 메이커스팀 구성원을 삭제한다")
+	void 중복된_활동_ID는_하나로_처리해_메이커스팀_구성원을_삭제한다() throws Exception {
+		// given
+		MemberActivity memberActivity = saveMakersActivity(uniqueEmail("bulk-duplicate"), JobFamily.FE, MakersTeam.TEAM_1);
+		String request = "{\"memberActivityIds\":[%d,%d]}".formatted(memberActivity.getId(), memberActivity.getId());
+
+		// when
+		mockMvc.perform(delete("/admin/members/makers")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(request))
+			.andExpect(status().isOk());
+
+		// then
+		assertThat(memberActivityRepository.findById(memberActivity.getId())).isEmpty();
+		assertThat(memberRepository.findById(memberActivity.getMemberId())).isEmpty();
+	}
+
+	@Test
+	@DisplayName("삭제할 메이커스팀 구성원이 없으면 일괄 삭제하지 않는다")
+	void 삭제할_메이커스팀_구성원이_없으면_일괄_삭제하지_않는다() throws Exception {
+		// when & then
+		mockMvc.perform(delete("/admin/members/makers")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"memberActivityIds\":[]}"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
+	}
+
+	@Test
+	@DisplayName("삭제할 메이커스팀 구성원 ID에 빈 값이 있으면 일괄 삭제하지 않는다")
+	void 삭제할_메이커스팀_구성원_ID에_빈_값이_있으면_일괄_삭제하지_않는다() throws Exception {
+		// when & then
+		mockMvc.perform(delete("/admin/members/makers")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"memberActivityIds\":[null]}"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
 	}
 
 	private CreateMemberMakersRequest createMemberMakersRequest(String email) {

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -6,9 +6,11 @@ import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberSupportersDetailProjection;
@@ -349,7 +351,7 @@ class AdminMemberActivityServiceTest {
 
     @Test
     @DisplayName("운영 서포터즈 구성원을 찾을 수 없으면 예외가 발생한다")
-    void 운영_서포터즈_구성원을_찾을_수_없으면_예외가_발생한다() {
+	void 운영_서포터즈_구성원을_찾을_수_없으면_예외가_발생한다() {
         // given
         Long memberActivityId = 1L;
         given(memberActivityRepository.findMemberSupportersDetail(memberActivityId))
@@ -364,10 +366,102 @@ class AdminMemberActivityServiceTest {
             .isInstanceOf(MemberException.class)
             .extracting("errorCode")
             .isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
-        verify(memberActivityRepository).findMemberSupportersDetail(memberActivityId);
-    }
+		verify(memberActivityRepository).findMemberSupportersDetail(memberActivityId);
+	}
 
-    private CreateMemberSemesterRequest createMemberSemesterRequest() {
+	@Test
+	@DisplayName("메이커스팀 활동이 존재하면 삭제된다")
+	void 메이커스팀_활동이_존재하면_삭제된다() {
+		// given
+		Long memberActivityId = 1L;
+		MemberActivity memberActivity = mock(MemberActivity.class);
+		given(memberActivity.getMemberId()).willReturn(10L);
+		given(memberActivityRepository.findByIdAndMemberType(memberActivityId, MemberType.MAKERS))
+			.willReturn(Optional.of(memberActivity));
+
+		// when
+		Long memberId = adminMemberActivityService.deleteMemberMakersActivity(memberActivityId);
+
+		// then
+		assertThat(memberId).isEqualTo(10L);
+		verify(memberActivityRepository).delete(memberActivity);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 활동은 삭제하지 않는다")
+	void 존재하지_않는_활동은_삭제하지_않는다() {
+		// given
+		Long memberActivityId = 1L;
+		given(memberActivityRepository.findByIdAndMemberType(memberActivityId, MemberType.MAKERS))
+			.willReturn(Optional.empty());
+
+		// when
+		Throwable throwable = catchThrowable(() ->
+			adminMemberActivityService.deleteMemberMakersActivity(memberActivityId)
+		);
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER_MAKERS_ACTIVITY);
+		verify(memberActivityRepository, never()).delete(any(MemberActivity.class));
+	}
+
+	@Test
+	@DisplayName("선택한 메이커스팀 활동을 모두 삭제한다")
+	void 선택한_메이커스팀_활동을_모두_삭제한다() {
+		// given
+		Set<Long> memberActivityIds = Set.of(1L, 2L);
+		MemberActivity first = memberActivity(1L, 10L);
+		MemberActivity second = memberActivity(2L, 20L);
+		List<MemberActivity> memberActivities = List.of(first, second);
+		given(memberActivityRepository.findAllByIdInAndMemberType(memberActivityIds, MemberType.MAKERS))
+			.willReturn(memberActivities);
+
+		// when
+		Set<Long> memberIds = adminMemberActivityService.deleteMemberMakersActivities(memberActivityIds);
+
+		// then
+		assertThat(memberIds).containsExactlyInAnyOrder(10L, 20L);
+		verify(memberActivityRepository).deleteAll(memberActivities);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 활동이 포함되면 모든 활동을 유지한다")
+	void 존재하지_않는_활동이_포함되면_모든_활동을_유지한다() {
+		// given
+		Set<Long> memberActivityIds = Set.of(1L, 2L);
+		MemberActivity memberActivity = memberActivity(1L);
+		given(memberActivityRepository.findAllByIdInAndMemberType(memberActivityIds, MemberType.MAKERS))
+			.willReturn(List.of(memberActivity));
+
+		// when
+		Throwable throwable = catchThrowable(() ->
+			adminMemberActivityService.deleteMemberMakersActivities(memberActivityIds)
+		);
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER_MAKERS_ACTIVITY);
+		verify(memberActivityRepository, never()).deleteAll(any());
+	}
+
+	private MemberActivity memberActivity(Long memberActivityId) {
+		MemberActivity memberActivity = mock(MemberActivity.class);
+		given(memberActivity.getId()).willReturn(memberActivityId);
+		return memberActivity;
+	}
+
+	private MemberActivity memberActivity(Long memberActivityId, Long memberId) {
+		MemberActivity memberActivity = memberActivity(memberActivityId);
+		given(memberActivity.getMemberId()).willReturn(memberId);
+		return memberActivity;
+	}
+
+	private CreateMemberSemesterRequest createMemberSemesterRequest() {
         return new CreateMemberSemesterRequest(
             "김젝트",
             "jectkim@ject.kr",

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -380,7 +380,7 @@ class AdminMemberActivityServiceTest {
 			.willReturn(Optional.of(memberActivity));
 
 		// when
-		Long memberId = adminMemberActivityService.deleteMemberMakersActivity(memberActivityId);
+		Long memberId = adminMemberActivityService.deleteMemberActivity(memberActivityId, MemberType.MAKERS);
 
 		// then
 		assertThat(memberId).isEqualTo(10L);
@@ -397,7 +397,7 @@ class AdminMemberActivityServiceTest {
 
 		// when
 		Throwable throwable = catchThrowable(() ->
-			adminMemberActivityService.deleteMemberMakersActivity(memberActivityId)
+			adminMemberActivityService.deleteMemberActivity(memberActivityId, MemberType.MAKERS)
 		);
 
 		// then
@@ -405,6 +405,48 @@ class AdminMemberActivityServiceTest {
 			.isInstanceOf(MemberException.class)
 			.extracting("errorCode")
 			.isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER_MAKERS_ACTIVITY);
+		verify(memberActivityRepository, never()).delete(any(MemberActivity.class));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 일반 구성원 활동은 삭제하지 않는다")
+	void 존재하지_않는_일반_구성원_활동은_삭제하지_않는다() {
+		// given
+		Long memberActivityId = 1L;
+		given(memberActivityRepository.findByIdAndMemberType(memberActivityId, MemberType.SEMESTER))
+			.willReturn(Optional.empty());
+
+		// when
+		Throwable throwable = catchThrowable(() ->
+			adminMemberActivityService.deleteMemberActivity(memberActivityId, MemberType.SEMESTER)
+		);
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER_SEMESTER_ACTIVITY);
+		verify(memberActivityRepository, never()).delete(any(MemberActivity.class));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 운영 서포터즈 활동은 삭제하지 않는다")
+	void 존재하지_않는_운영_서포터즈_활동은_삭제하지_않는다() {
+		// given
+		Long memberActivityId = 1L;
+		given(memberActivityRepository.findByIdAndMemberType(memberActivityId, MemberType.SUPPORTERS))
+			.willReturn(Optional.empty());
+
+		// when
+		Throwable throwable = catchThrowable(() ->
+			adminMemberActivityService.deleteMemberActivity(memberActivityId, MemberType.SUPPORTERS)
+		);
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER_SUPPORTERS_ACTIVITY);
 		verify(memberActivityRepository, never()).delete(any(MemberActivity.class));
 	}
 
@@ -420,7 +462,7 @@ class AdminMemberActivityServiceTest {
 			.willReturn(memberActivities);
 
 		// when
-		Set<Long> memberIds = adminMemberActivityService.deleteMemberMakersActivities(memberActivityIds);
+		Set<Long> memberIds = adminMemberActivityService.deleteMemberActivities(memberActivityIds, MemberType.MAKERS);
 
 		// then
 		assertThat(memberIds).containsExactlyInAnyOrder(10L, 20L);
@@ -438,7 +480,7 @@ class AdminMemberActivityServiceTest {
 
 		// when
 		Throwable throwable = catchThrowable(() ->
-			adminMemberActivityService.deleteMemberMakersActivities(memberActivityIds)
+			adminMemberActivityService.deleteMemberActivities(memberActivityIds, MemberType.MAKERS)
 		);
 
 		// then

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberMakersUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberMakersUseCaseTest.java
@@ -5,8 +5,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 
 import java.util.List;
+import java.util.Set;
+
 import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
+import org.ject.support.admin.member.dto.request.DeleteMemberMakersRequest;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
 import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
@@ -113,6 +116,37 @@ class AdminMemberMakersUseCaseTest {
 		assertThat(response.makersTeam()).isEqualTo(projection.makersTeam());
 		assertThat(response.activityStatus()).isEqualTo(projection.activityStatus());
 		verify(adminMemberActivityService).getMemberMakersDetail(memberActivityId);
+	}
+
+	@Test
+	@DisplayName("메이커스팀 구성원을 삭제한다")
+	void 메이커스팀_구성원을_삭제한다() {
+		// given
+		Long memberActivityId = 1L;
+		Long memberId = 10L;
+		given(adminMemberActivityService.deleteMemberMakersActivity(memberActivityId)).willReturn(memberId);
+
+		// when
+		adminMemberMakersUseCase.deleteMemberMakers(memberActivityId);
+
+		// then
+		verify(adminMemberService).deleteMemberIfNoActivity(memberId);
+	}
+
+	@Test
+	@DisplayName("선택한 메이커스팀 구성원을 모두 삭제한다")
+	void 선택한_메이커스팀_구성원을_모두_삭제한다() {
+		// given
+		DeleteMemberMakersRequest request = new DeleteMemberMakersRequest(Set.of(1L, 2L));
+		Set<Long> memberIds = Set.of(10L, 20L);
+		given(adminMemberActivityService.deleteMemberMakersActivities(request.memberActivityIds()))
+			.willReturn(memberIds);
+
+		// when
+		adminMemberMakersUseCase.deleteMemberMakersList(request);
+
+		// then
+		verify(adminMemberService).deleteMembersIfNoActivity(memberIds);
 	}
 
 	private MemberMakersListProjection makersProjection(Long memberActivityId, String name) {

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberMakersUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberMakersUseCaseTest.java
@@ -22,6 +22,7 @@ import org.ject.support.domain.member.CareerLevel;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MakersTeam;
+import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 import org.junit.jupiter.api.DisplayName;
@@ -124,7 +125,7 @@ class AdminMemberMakersUseCaseTest {
 		// given
 		Long memberActivityId = 1L;
 		Long memberId = 10L;
-		given(adminMemberActivityService.deleteMemberMakersActivity(memberActivityId)).willReturn(memberId);
+		given(adminMemberActivityService.deleteMemberActivity(memberActivityId, MemberType.MAKERS)).willReturn(memberId);
 
 		// when
 		adminMemberMakersUseCase.deleteMemberMakers(memberActivityId);
@@ -139,7 +140,7 @@ class AdminMemberMakersUseCaseTest {
 		// given
 		DeleteMemberMakersRequest request = new DeleteMemberMakersRequest(Set.of(1L, 2L));
 		Set<Long> memberIds = Set.of(10L, 20L);
-		given(adminMemberActivityService.deleteMemberMakersActivities(request.memberActivityIds()))
+		given(adminMemberActivityService.deleteMemberActivities(request.memberActivityIds(), MemberType.MAKERS))
 			.willReturn(memberIds);
 
 		// when

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
@@ -14,6 +14,8 @@ import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.exception.MemberErrorCode;
+import org.ject.support.domain.member.exception.MemberException;
 import org.ject.support.domain.member.repository.MemberActivityRepository;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
@@ -165,6 +167,22 @@ class AdminMemberServiceTest {
 	}
 
 	@Test
+	@DisplayName("남은 활동은 없지만 구성원을 찾을 수 없으면 삭제에 실패한다")
+	void 남은_활동은_없지만_구성원을_찾을_수_없으면_삭제에_실패한다() {
+		// given
+		Long memberId = 1L;
+		given(memberActivityRepository.existsByMemberId(memberId)).willReturn(false);
+		given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> adminMemberService.deleteMemberIfNoActivity(memberId))
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+		verify(memberRepository, never()).delete(any(Member.class));
+	}
+
+	@Test
 	@DisplayName("다른 활동이 남아 있으면 구성원을 유지한다")
 	void 다른_활동이_남아_있으면_구성원을_유지한다() {
 		// given
@@ -198,6 +216,23 @@ class AdminMemberServiceTest {
 			return true;
 		}));
 		verify(memberRepository).deleteAll(List.of(first, third));
+	}
+
+	@Test
+	@DisplayName("일괄 삭제할 구성원 일부를 찾을 수 없으면 모두 삭제하지 않는다")
+	void 일괄_삭제할_구성원_일부를_찾을_수_없으면_모두_삭제하지_않는다() {
+		// given
+		Set<Long> memberIds = Set.of(1L, 2L);
+		Member member = mock(Member.class);
+		given(memberActivityRepository.findMemberIdsWithActivity(memberIds)).willReturn(Set.of());
+		given(memberRepository.findAllById(any())).willReturn(List.of(member));
+
+		// when & then
+		assertThatThrownBy(() -> adminMemberService.deleteMembersIfNoActivity(memberIds))
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER);
+		verify(memberRepository, never()).deleteAll(any());
 	}
 
 	@Test

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.*;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
 import org.ject.support.domain.member.ActivityStatus;
@@ -13,6 +14,7 @@ import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.entity.Member;
+import org.ject.support.domain.member.repository.MemberActivityRepository;
 import org.ject.support.domain.member.repository.MemberRepository;
 import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +31,9 @@ class AdminMemberServiceTest {
 
 	@Mock
 	private MemberRepository memberRepository;
+
+	@Mock
+	private MemberActivityRepository memberActivityRepository;
 
 	@InjectMocks
 	private AdminMemberService adminMemberService;
@@ -141,5 +146,72 @@ class AdminMemberServiceTest {
 		assertThat(deletedMember.getRegion()).isEqualTo(request.region());
 		verify(memberRepository).findByEmailIncludingDeleted(request.email());
 		verify(memberRepository, never()).save(any(Member.class));
+	}
+
+	@Test
+	@DisplayName("남은 활동이 없으면 구성원을 삭제한다")
+	void 남은_활동이_없으면_구성원을_삭제한다() {
+		// given
+		Long memberId = 1L;
+		Member member = mock(Member.class);
+		given(memberActivityRepository.existsByMemberId(memberId)).willReturn(false);
+		given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+		// when
+		adminMemberService.deleteMemberIfNoActivity(memberId);
+
+		// then
+		verify(memberRepository).delete(member);
+	}
+
+	@Test
+	@DisplayName("다른 활동이 남아 있으면 구성원을 유지한다")
+	void 다른_활동이_남아_있으면_구성원을_유지한다() {
+		// given
+		Long memberId = 1L;
+		given(memberActivityRepository.existsByMemberId(memberId)).willReturn(true);
+
+		// when
+		adminMemberService.deleteMemberIfNoActivity(memberId);
+
+		// then
+		verify(memberRepository, never()).findById(memberId);
+		verify(memberRepository, never()).delete(any(Member.class));
+	}
+
+	@Test
+	@DisplayName("여러 구성원 중 남은 활동이 없는 구성원만 삭제한다")
+	void 여러_구성원_중_남은_활동이_없는_구성원만_삭제한다() {
+		// given
+		Set<Long> memberIds = Set.of(1L, 2L, 3L);
+		Member first = mock(Member.class);
+		Member third = mock(Member.class);
+		given(memberActivityRepository.findMemberIdsWithActivity(memberIds)).willReturn(Set.of(2L));
+		given(memberRepository.findAllById(any())).willReturn(List.of(first, third));
+
+		// when
+		adminMemberService.deleteMembersIfNoActivity(memberIds);
+
+		// then
+		verify(memberRepository).findAllById(argThat(ids -> {
+			assertThat(ids).containsExactlyInAnyOrder(1L, 3L);
+			return true;
+		}));
+		verify(memberRepository).deleteAll(List.of(first, third));
+	}
+
+	@Test
+	@DisplayName("모든 구성원에게 활동이 남아 있으면 모두 유지한다")
+	void 모든_구성원에게_활동이_남아_있으면_모두_유지한다() {
+		// given
+		Set<Long> memberIds = Set.of(1L, 2L);
+		given(memberActivityRepository.findMemberIdsWithActivity(memberIds)).willReturn(memberIds);
+
+		// when
+		adminMemberService.deleteMembersIfNoActivity(memberIds);
+
+		// then
+		verify(memberRepository, never()).findAllById(any());
+		verify(memberRepository, never()).deleteAll(any());
 	}
 }

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -7,6 +7,7 @@ import static org.ject.support.domain.member.fixture.SemesterActivityFixture.sem
 
 import jakarta.persistence.EntityManager;
 import java.util.List;
+import java.util.Set;
 
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
@@ -1209,4 +1210,115 @@ class MemberActivityRepositoryTest {
         // when & then
         assertThat(memberActivityRepository.findMemberSupportersDetail(memberActivity.getId())).isEmpty();
     }
+
+	@Test
+	@DisplayName("ID와 유형이 일치하는 구성원 활동을 조회한다")
+	void ID와_유형이_일치하는_구성원_활동을_조회한다() {
+		// given
+		Member member = memberRepository.save(member().email("makers-type@test.com").build());
+		MemberActivity memberActivity = memberActivityRepository.saveAndFlush(
+			makersActivity().memberId(member.getId()).build()
+		);
+
+		// when & then
+		assertThat(memberActivityRepository.findByIdAndMemberType(memberActivity.getId(), MemberType.MAKERS))
+			.contains(memberActivity);
+	}
+
+	@Test
+	@DisplayName("ID가 같아도 유형이 다르면 조회하지 않는다")
+	void ID가_같아도_유형이_다르면_조회하지_않는다() {
+		// given
+		Member member = memberRepository.save(member().email("semester-type@test.com").build());
+		MemberActivity memberActivity = memberActivityRepository.saveAndFlush(
+			semesterActivity().memberId(member.getId()).build()
+		);
+
+		// when & then
+		assertThat(memberActivityRepository.findByIdAndMemberType(memberActivity.getId(), MemberType.MAKERS))
+			.isEmpty();
+	}
+
+	@Test
+	@DisplayName("선택한 ID에 해당하는 메이커스팀 활동만 조회한다")
+	void 선택한_ID에_해당하는_메이커스팀_활동만_조회한다() {
+		// given
+		Member makersMember = memberRepository.save(member().email("makers-list@test.com").build());
+		Member semesterMember = memberRepository.save(member().email("semester-list@test.com").build());
+		MemberActivity makers = memberActivityRepository.saveAndFlush(
+			makersActivity().memberId(makersMember.getId()).build()
+		);
+		MemberActivity semester = memberActivityRepository.saveAndFlush(
+			semesterActivity().memberId(semesterMember.getId()).build()
+		);
+
+		// when
+		List<MemberActivity> result = memberActivityRepository.findAllByIdInAndMemberType(
+			Set.of(makers.getId(), semester.getId()),
+			MemberType.MAKERS
+		);
+
+		// then
+		assertThat(result).containsExactly(makers);
+	}
+
+	@Test
+	@DisplayName("구성원에게 활동이 남아 있으면 true를 반환한다")
+	void 구성원에게_활동이_남아_있으면_true를_반환한다() {
+		// given
+		Member member = memberRepository.save(member().email("activity-exists@test.com").build());
+		memberActivityRepository.saveAndFlush(makersActivity().memberId(member.getId()).build());
+
+		// when & then
+		assertThat(memberActivityRepository.existsByMemberId(member.getId())).isTrue();
+	}
+
+	@Test
+	@DisplayName("삭제된 활동만 있으면 false를 반환한다")
+	void 삭제된_활동만_있으면_false를_반환한다() {
+		// given
+		Member member = memberRepository.save(member().email("activity-deleted@test.com").build());
+		MemberActivity memberActivity = memberActivityRepository.saveAndFlush(
+			makersActivity().memberId(member.getId()).build()
+		);
+		memberActivityRepository.delete(memberActivity);
+		memberActivityRepository.flush();
+		entityManager.clear();
+
+		// when & then
+		assertThat(memberActivityRepository.existsByMemberId(member.getId())).isFalse();
+	}
+
+	@Test
+	@DisplayName("활동이 남아 있는 구성원 ID만 조회한다")
+	void 활동이_남아_있는_구성원_ID만_조회한다() {
+		// given
+		Member activeMember = memberRepository.save(member().email("active-member@test.com").build());
+		Member inactiveMember = memberRepository.save(member().email("inactive-member@test.com").build());
+		memberActivityRepository.saveAndFlush(makersActivity().memberId(activeMember.getId()).build());
+
+		// when
+		Set<Long> memberIds = memberActivityRepository.findMemberIdsWithActivity(
+			Set.of(activeMember.getId(), inactiveMember.getId())
+		);
+
+		// then
+		assertThat(memberIds).containsExactly(activeMember.getId());
+	}
+
+	@Test
+	@DisplayName("삭제된 활동의 구성원 ID는 조회하지 않는다")
+	void 삭제된_활동의_구성원_ID는_조회하지_않는다() {
+		// given
+		Member member = memberRepository.save(member().email("deleted-member-id@test.com").build());
+		MemberActivity memberActivity = memberActivityRepository.saveAndFlush(
+			makersActivity().memberId(member.getId()).build()
+		);
+		memberActivityRepository.delete(memberActivity);
+		memberActivityRepository.flush();
+		entityManager.clear();
+
+		// when & then
+		assertThat(memberActivityRepository.findMemberIdsWithActivity(Set.of(member.getId()))).isEmpty();
+	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #623

## 📝 작업 내용

- 메이커스팀 구성원 단건·다건 삭제 API를 추가했습니다.
- 다건 요청에 존재하지 않거나 메이커스팀이 아닌 활동이 포함되면 전체 요청이 실패하도록 검증했습니다.
- 활동 삭제 후 남은 구성원 활동이 없으면 Member도 soft delete하도록 처리했습니다.
- 다건 요청은 `Set`으로 받아 중복 ID를 하나로 처리하고, 검증 실패 시 대표 실패 ID를 로그에 남깁니다.
- Controller, Service, UseCase, Repository 테스트를 추가했습니다.

## ✅ 검증 결과

- `./gradlew test` 통과
- 단건 등록·상세 조회·삭제 후 404 전환 확인
- 유효하지 않은 ID가 포함된 다건 삭제의 전체 롤백 확인
- 정상 다건 삭제 후 대상 전체 조회 제외 확인

## 🙏 리뷰 요구사항

- `@SQLDelete`가 적용된 활동과 Member를 `delete()`·`deleteAll()`로 처리하는 흐름을 확인해주세요.
- 다건 삭제의 전체 검증과 트랜잭션 경계를 확인해주세요.
