### PR TITLE
feat: 일반 구성원 단건, 다건 삭제 API 구현

### DIFF
--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberSemesterApiSpec.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberSemesterApiSpec.java
@@ -1,10 +1,12 @@
 package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
 import org.ject.support.admin.member.dto.response.SearchMemberSemesterResponse;
 import org.ject.support.common.response.CursorPageResponse;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,4 +28,16 @@ public interface AdminMemberSemesterApiSpec {
 	CursorPageResponse<SearchMemberSemesterResponse> searchAdminMemberSemesterList(
 		@ModelAttribute @Valid MemberSemesterSearchCondition request
 	);
+
+	@Operation(
+		summary = "일반 구성원 삭제",
+		description = "일반 구성원을 삭제합니다."
+	)
+	void deleteAdminMemberSemester(@PathVariable Long memberActivityId);
+
+	@Operation(
+		summary = "일반 구성원 일괄 삭제",
+		description = "선택한 일반 구성원을 일괄 삭제합니다."
+	)
+	void deleteAdminMemberSemesterList(@RequestBody @Valid DeleteMembersRequest request);
 }

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberSemesterController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberSemesterController.java
@@ -1,13 +1,16 @@
 package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
 import org.ject.support.admin.member.dto.response.SearchMemberSemesterResponse;
 import org.ject.support.admin.member.service.AdminMemberSemesterUseCase;
 import org.ject.support.common.response.CursorPageResponse;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,5 +40,17 @@ public class AdminMemberSemesterController implements AdminMemberSemesterApiSpec
 	public CursorPageResponse<SearchMemberSemesterResponse> searchAdminMemberSemesterList(
 		@ParameterObject @ModelAttribute @Valid MemberSemesterSearchCondition request) {
 		return adminMemberUsecase.searchMemberSemester(request);
+	}
+
+	@Override
+	@DeleteMapping("/{memberActivityId}")
+	public void deleteAdminMemberSemester(@PathVariable Long memberActivityId) {
+		adminMemberUsecase.deleteMemberSemester(memberActivityId);
+	}
+
+	@Override
+	@DeleteMapping
+	public void deleteAdminMemberSemesterList(@RequestBody @Valid DeleteMembersRequest request) {
+		adminMemberUsecase.deleteMemberSemesterList(request);
 	}
 }

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberSemesterUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberSemesterUseCase.java
@@ -3,9 +3,11 @@ package org.ject.support.admin.member.service;
 import static org.ject.support.domain.member.exception.MemberErrorCode.*;
 
 import java.util.List;
+import java.util.Set;
 
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
 import org.ject.support.admin.member.dto.response.SearchMemberSemesterResponse;
 import org.ject.support.admin.member.dto.result.MemberPageResult;
@@ -60,6 +62,23 @@ public class AdminMemberSemesterUseCase {
 			SearchMemberSemesterResponse::from,
 			SearchMemberSemesterProjection::memberActivityId
 		);
+	}
+
+	// 일반 구성원 단건 삭제
+	@Transactional
+	public void deleteMemberSemester(Long memberActivityId) {
+		Long memberId = adminMemberActivityService.deleteMemberActivity(memberActivityId, MemberType.SEMESTER);
+		adminMemberService.deleteMemberIfNoActivity(memberId);
+	}
+
+	// 일반 구성원 일괄 삭제
+	@Transactional
+	public void deleteMemberSemesterList(DeleteMembersRequest request) {
+		Set<Long> memberIds = adminMemberActivityService.deleteMemberActivities(
+			request.memberActivityIds(),
+			MemberType.SEMESTER
+		);
+		adminMemberService.deleteMembersIfNoActivity(memberIds);
 	}
 
 	/*

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberSemesterControllerTest.java
@@ -2,8 +2,10 @@ package org.ject.support.admin.member.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.ject.support.domain.member.fixture.MakersActivityFixture.makersActivity;
 import static org.ject.support.domain.member.fixture.MemberFixture.member;
 import static org.ject.support.domain.member.fixture.SemesterActivityFixture.semesterActivity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -12,7 +14,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
@@ -298,6 +302,93 @@ class AdminMemberSemesterControllerTest {
 				.param("status", ActivityStatus.DROPOUT.name()))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.status").value(MemberErrorCode.INVALID_ACTIVITY_STATUS.getCode()));
+	}
+
+	@Test
+	@DisplayName("일반 구성원을 삭제한다")
+	void 일반_구성원을_삭제한다() throws Exception {
+		// given
+		Semester semester = saveSemester();
+		MemberActivity memberActivity = saveMemberSemesterActivity(
+			uniqueEmail("delete"),
+			semester.getId(),
+			null,
+			JobFamily.BE,
+			RecruitTypeDetail.REGULAR,
+			CareerDetails.EMPLOYEE,
+			ExperiencePeriod.ONE_TO_TWO
+		);
+
+		// when
+		mockMvc.perform(delete("/admin/members/semester/{memberActivityId}", memberActivity.getId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("SUCCESS"));
+
+		// then
+		assertThat(memberActivityRepository.findById(memberActivity.getId())).isEmpty();
+		assertThat(memberRepository.findById(memberActivity.getMemberId())).isEmpty();
+	}
+
+	@Test
+	@DisplayName("선택한 일반 구성원을 모두 삭제한다")
+	void 선택한_일반_구성원을_모두_삭제한다() throws Exception {
+		// given
+		Semester semester = saveSemester();
+		MemberActivity first = saveMemberSemesterActivity(
+			uniqueEmail("bulk1"),
+			semester.getId(),
+			null,
+			JobFamily.BE,
+			RecruitTypeDetail.REGULAR,
+			CareerDetails.EMPLOYEE,
+			ExperiencePeriod.ONE_TO_TWO
+		);
+		MemberActivity second = saveMemberSemesterActivity(
+			uniqueEmail("bulk2"),
+			semester.getId(),
+			null,
+			JobFamily.FE,
+			RecruitTypeDetail.REGULAR,
+			CareerDetails.STUDENT,
+			ExperiencePeriod.NONE
+		);
+		DeleteMembersRequest request = new DeleteMembersRequest(Set.of(first.getId(), second.getId()));
+
+		// when
+		mockMvc.perform(delete("/admin/members/semester")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("SUCCESS"));
+
+		// then
+		assertThat(memberActivityRepository.findAllById(List.of(first.getId(), second.getId()))).isEmpty();
+		assertThat(memberRepository.findAllById(List.of(first.getMemberId(), second.getMemberId()))).isEmpty();
+	}
+
+	@Test
+	@DisplayName("일반 구성원이 아닌 구성원은 삭제할 수 없다")
+	void 일반_구성원이_아닌_구성원은_삭제할_수_없다() throws Exception {
+		// given
+		Member member = memberRepository.save(member().email(uniqueEmail("invalid-type")).build());
+		MemberActivity makers = memberActivityRepository.saveAndFlush(makersActivity().memberId(member.getId()).build());
+
+		// when & then
+		mockMvc.perform(delete("/admin/members/semester/{memberActivityId}", makers.getId()))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.status").value(MemberErrorCode.NOT_FOUND_MEMBER_SEMESTER_ACTIVITY.getCode()));
+		assertThat(memberActivityRepository.findById(makers.getId())).isPresent();
+		assertThat(memberRepository.findById(member.getId())).isPresent();
+	}
+
+	@Test
+	@DisplayName("삭제할 일반 구성원이 없으면 요청에 실패한다")
+	void 삭제할_일반_구성원이_없으면_요청에_실패한다() throws Exception {
+		mockMvc.perform(delete("/admin/members/semester")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"memberActivityIds\":[]}"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
 	}
 
 	private CreateMemberSemesterRequest createMemberSemesterRequest(String email, Long semesterId, Long teamId) {

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberSemesterUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberSemesterUseCaseTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
+import java.util.Set;
 
 import org.ject.support.admin.member.dto.projection.SearchMemberSemesterProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberSemesterRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.admin.member.dto.request.MemberSemesterSearchCondition;
 import org.ject.support.admin.member.dto.response.SearchMemberSemesterResponse;
 import org.ject.support.admin.member.dto.result.MemberPageResult;
@@ -15,6 +17,7 @@ import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.member.MemberType;
 import org.ject.support.domain.member.Region;
 import org.ject.support.domain.member.exception.MemberErrorCode;
 import org.ject.support.domain.member.exception.MemberException;
@@ -321,5 +324,37 @@ class AdminMemberSemesterUseCaseTest {
 		// then
 		assertThat(response.content()).isEmpty();
 		verify(adminMemberActivityService).searchMemberSemesterList(condition);
+	}
+
+	@Test
+	@DisplayName("일반 구성원 활동을 삭제하고 남은 활동이 없으면 구성원도 삭제한다")
+	void 일반_구성원_활동을_삭제하고_남은_활동이_없으면_구성원도_삭제한다() {
+		// given
+		Long memberActivityId = 1L;
+		Long memberId = 10L;
+		given(adminMemberActivityService.deleteMemberActivity(memberActivityId, MemberType.SEMESTER))
+			.willReturn(memberId);
+
+		// when
+		adminMemberSemesterUseCase.deleteMemberSemester(memberActivityId);
+
+		// then
+		verify(adminMemberService).deleteMemberIfNoActivity(memberId);
+	}
+
+	@Test
+	@DisplayName("선택한 일반 구성원을 모두 삭제한다")
+	void 선택한_일반_구성원을_모두_삭제한다() {
+		// given
+		DeleteMembersRequest request = new DeleteMembersRequest(Set.of(1L, 2L));
+		Set<Long> memberIds = Set.of(10L, 20L);
+		given(adminMemberActivityService.deleteMemberActivities(request.memberActivityIds(), MemberType.SEMESTER))
+			.willReturn(memberIds);
+
+		// when
+		adminMemberSemesterUseCase.deleteMemberSemesterList(request);
+
+		// then
+		verify(adminMemberService).deleteMembersIfNoActivity(memberIds);
 	}
 }

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -1360,6 +1360,49 @@ class MemberActivityRepositoryTest {
 		assertThat(entityManager.find(MemberSupporters.class, second.getId())).isNotNull();
 	}
 
+	@Test
+	@DisplayName("일반 구성원 활동을 삭제해도 활동 관리 항목은 유지한다")
+	void 일반_구성원_활동을_삭제해도_활동_관리_항목은_유지한다() {
+		// given
+		Member member = memberRepository.save(member().email("semester-delete@test.com").build());
+		MemberActivity memberActivity = memberActivityRepository.saveAndFlush(
+			semesterActivity().memberId(member.getId()).semesterId(SEMESTER_ID).build()
+		);
+
+		// when
+		memberActivityRepository.delete(memberActivity);
+		memberActivityRepository.flush();
+		entityManager.clear();
+
+		// then
+		assertThat(memberActivityRepository.findById(memberActivity.getId())).isEmpty();
+		assertThat(entityManager.find(MemberSemester.class, memberActivity.getId())).isNotNull();
+	}
+
+	@Test
+	@DisplayName("일반 구성원 활동 여러 건을 삭제해도 활동 관리 항목은 유지한다")
+	void 일반_구성원_활동_여러_건을_삭제해도_활동_관리_항목은_유지한다() {
+		// given
+		Member firstMember = memberRepository.save(member().email("semester-bulk1@test.com").build());
+		Member secondMember = memberRepository.save(member().email("semester-bulk2@test.com").build());
+		MemberActivity first = memberActivityRepository.saveAndFlush(
+			semesterActivity().memberId(firstMember.getId()).semesterId(SEMESTER_ID).build()
+		);
+		MemberActivity second = memberActivityRepository.saveAndFlush(
+			semesterActivity().memberId(secondMember.getId()).semesterId(SEMESTER_ID).build()
+		);
+
+		// when
+		memberActivityRepository.deleteAll(List.of(first, second));
+		memberActivityRepository.flush();
+		entityManager.clear();
+
+		// then
+		assertThat(memberActivityRepository.findAllById(List.of(first.getId(), second.getId()))).isEmpty();
+		assertThat(entityManager.find(MemberSemester.class, first.getId())).isNotNull();
+		assertThat(entityManager.find(MemberSemester.class, second.getId())).isNotNull();
+	}
+
 	private MemberActivity saveSupportersActivity(Long memberId, String activityCertNumber) {
 		return memberActivityRepository.saveAndFlush(MemberActivity.createSupportersActivity(
 			memberId,


### PR DESCRIPTION
## #️⃣연관된 이슈

close #520

## 📝 작업 내용

- 일반 구성원 단건 삭제 API를 구현했습니다.
- 일반 구성원 다건 삭제 API를 구현했습니다.
- 공통 구성원 삭제 요청 DTO와 삭제 로직을 재사용했습니다.
- 활동 삭제 후 남은 활동이 없으면 구성원도 소프트 삭제하도록 처리했습니다.
- 일반 구성원 활동 삭제 후 활동 관리 항목은 유지하도록 처리했습니다.
- Controller, UseCase, Repository 테스트를 추가했습니다.

## ✅ 검증 결과

- 관련 테스트 3개 클래스 통과
- 단건·다건 삭제 API `200 SUCCESS` 확인
- `member_activity`와 활동 없는 `member` 소프트 삭제 확인
- `member_semester` 활동 관리 항목 유지 확인

## 🙏 리뷰 요구사항 (선택)

- 단건·다건 삭제 후 구성원 정리 흐름을 확인해주세요.
- 활동 삭제 후 `member_semester` 활동 관리 항목이 유지되는지 확인해주세요.