### PR TITLE
feat/#624 메일 발송용 모집 공고 목록 조회

### DIFF
--- a/src/main/java/org/ject/support/admin/mail/controller/AdminMailRecruitApiSpec.java
+++ b/src/main/java/org/ject/support/admin/mail/controller/AdminMailRecruitApiSpec.java
@@ -1,0 +1,15 @@
+package org.ject.support.admin.mail.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailRecruitResponse;
+
+@Tag(name = "AdminMailRecruit", description = "메일 발송용 모집 공고 조회 API (어드민 전용)")
+public interface AdminMailRecruitApiSpec {
+
+    @Operation(
+            summary = "메일 발송용 모집 공고 목록 조회",
+            description = "메일 발송 기준으로 사용할 모집 공고를 등록일 최신순으로 조회합니다.")
+    List<MailRecruitResponse> getRecruits();
+}

--- a/src/main/java/org/ject/support/admin/mail/controller/AdminMailRecruitController.java
+++ b/src/main/java/org/ject/support/admin/mail/controller/AdminMailRecruitController.java
@@ -1,0 +1,23 @@
+package org.ject.support.admin.mail.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.mail.dto.MailRecruitResponse;
+import org.ject.support.admin.mail.service.MailRecruitService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/mails/recruits")
+public class AdminMailRecruitController implements AdminMailRecruitApiSpec {
+
+    private final MailRecruitService mailRecruitService;
+
+    @Override
+    @GetMapping
+    public List<MailRecruitResponse> getRecruits() {
+        return mailRecruitService.getRecruits();
+    }
+}

--- a/src/main/java/org/ject/support/admin/mail/domain/VariableInputType.java
+++ b/src/main/java/org/ject/support/admin/mail/domain/VariableInputType.java
@@ -12,7 +12,8 @@ public enum VariableInputType {
     TEXT("텍스트"),
     URL("URL 링크"),
     EMAIL("이메일 주소"),
-    PHONE("전화번호");
+    PHONE("전화번호"),
+    DATE_TIME("날짜/시간");
 
     private final String description;
 }

--- a/src/main/java/org/ject/support/admin/mail/dto/MailRecruitResponse.java
+++ b/src/main/java/org/ject/support/admin/mail/dto/MailRecruitResponse.java
@@ -1,0 +1,53 @@
+package org.ject.support.admin.mail.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.RecruitType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+
+public record MailRecruitResponse(
+        @Schema(description = "모집 공고 ID", example = "1")
+        Long recruitId,
+        @Schema(description = "기수 ID", example = "2")
+        Long semesterId,
+        @Schema(description = "기수명", example = "10기")
+        String semesterName,
+        @Schema(description = "직군", example = "BE")
+        JobFamily jobFamily,
+        @Schema(description = "직군 표시명", example = "백엔드 개발자(BE)")
+        String jobFamilyDescription,
+        @Schema(description = "모집 유형", example = "SEMESTER")
+        RecruitType recruitType,
+        @Schema(description = "모집 유형 표시명", example = "정규 기수 모집")
+        String recruitTypeDescription,
+        @Schema(description = "모집 세부 유형", example = "REGULAR")
+        RecruitTypeDetail recruitTypeDetail,
+        @Schema(description = "모집 세부 유형 표시명", example = "정규 모집")
+        String recruitTypeDetailDescription,
+        @Schema(description = "모집 시작일", example = "2026-08-01T00:00:00")
+        LocalDateTime startDate,
+        @Schema(description = "모집 종료일", example = "2026-08-31T23:59:00")
+        LocalDateTime endDate,
+        @Schema(description = "등록일", example = "2026-07-01T10:00:00")
+        LocalDateTime createdAt
+) {
+
+    public static MailRecruitResponse from(Recruit recruit) {
+        return new MailRecruitResponse(
+                recruit.getId(),
+                recruit.getSemester().getId(),
+                recruit.getSemester().getName(),
+                recruit.getJobFamily(),
+                recruit.getJobFamily().getDescription(),
+                recruit.getRecruitType(),
+                recruit.getRecruitType().getDescription(),
+                recruit.getRecruitTypeDetail(),
+                recruit.getRecruitTypeDetail().getDescription(),
+                recruit.getStartDate(),
+                recruit.getEndDate(),
+                recruit.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/ject/support/admin/mail/exception/MailErrorCode.java
+++ b/src/main/java/org/ject/support/admin/mail/exception/MailErrorCode.java
@@ -27,6 +27,7 @@ public enum MailErrorCode implements ErrorCode {
     DISPATCH_JOB_NOT_FOUND(NOT_FOUND, "MAIL-9", "메일 발송 작업을 찾을 수 없습니다."),
     INVALID_DISPATCH_JOB_STATUS(BAD_REQUEST, "MAIL-10", "현재 상태에서는 발송 실행을 수행할 수 없습니다."),
     TEST_MAIL_SEND_FAILURE(SERVICE_UNAVAILABLE, "MAIL-11", "테스트 메일 발송에 실패했습니다."),
+    INVALID_VARIABLE_VALUE(BAD_REQUEST, "MAIL-12", "메일 입력 변수 값이 올바르지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/ject/support/admin/mail/service/MailRecruitService.java
+++ b/src/main/java/org/ject/support/admin/mail/service/MailRecruitService.java
@@ -1,0 +1,22 @@
+package org.ject.support.admin.mail.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.ject.support.admin.mail.dto.MailRecruitResponse;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MailRecruitService {
+
+    private final RecruitRepository recruitRepository;
+
+    public List<MailRecruitResponse> getRecruits() {
+        return recruitRepository.findAllForMailDispatch().stream()
+                .map(MailRecruitResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/org/ject/support/admin/mail/service/MailScenarioService.java
+++ b/src/main/java/org/ject/support/admin/mail/service/MailScenarioService.java
@@ -130,7 +130,7 @@ public class MailScenarioService {
     @Transactional(readOnly = true)
     public String renderScenario(Long scenarioId, Map<String, Object> variables) {
         MailScenario scenario = findScenarioById(scenarioId);
-        mailTemplateValidator.validateRequiredCommonVariables(scenario.getCustomVariables(), variables);
+        mailTemplateValidator.validateVariables(scenario.getCustomVariables(), variables);
         return mailTemplateEngine.render(scenario.getBodyTemplate(), variables);
     }
 

--- a/src/main/java/org/ject/support/admin/mail/service/MailTemplateValidator.java
+++ b/src/main/java/org/ject/support/admin/mail/service/MailTemplateValidator.java
@@ -1,5 +1,7 @@
 package org.ject.support.admin.mail.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -8,8 +10,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.ject.support.admin.mail.domain.MailScenarioVariable;
 import org.ject.support.admin.mail.domain.ReservedMailVariable;
+import org.ject.support.admin.mail.domain.VariableInputType;
 import org.ject.support.admin.mail.exception.MailErrorCode;
 import org.ject.support.admin.mail.exception.MailException;
+import org.ject.support.common.util.DateTimeUtil;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -17,6 +21,8 @@ public class MailTemplateValidator {
 
     private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([A-Za-z0-9_]+)}");
     private static final Pattern PLACEHOLDER_KEY_PATTERN = Pattern.compile("[A-Za-z0-9_]+");
+    private static final Pattern DATE_TIME_PATTERN =
+            Pattern.compile("(?!0000-)\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}");
 
     /**
      * ${KEY} 형태의 기본 문법이 올바른지 검증합니다.
@@ -57,13 +63,7 @@ public class MailTemplateValidator {
 
         Set<MailScenarioVariable> safeCustomVariables = customVariables != null ? customVariables : Set.of();
 
-        Set<String> allowedKeys = new HashSet<>();
-        for (ReservedMailVariable rv : ReservedMailVariable.values()) {
-            allowedKeys.add(rv.name());
-        }
-        for (MailScenarioVariable cv : safeCustomVariables) {
-            allowedKeys.add(cv.getKey());
-        }
+        Set<String> allowedKeys = getAllowedVariableKeys(safeCustomVariables);
 
         Set<String> usedKeys = extractPlaceholderKeys(template);
         Set<String> invalidKeys = usedKeys.stream()
@@ -78,7 +78,7 @@ public class MailTemplateValidator {
         }
     }
 
-    public void validateRequiredCommonVariables(Set<MailScenarioVariable> customVariables, Map<String, ?> variables) {
+    private void validateRequiredVariables(Set<MailScenarioVariable> customVariables, Map<String, ?> variables) {
         Set<MailScenarioVariable> safeCustomVariables = customVariables != null ? customVariables : Set.of();
         Map<String, ?> safeVariables = variables != null ? variables : Map.of();
 
@@ -96,6 +96,77 @@ public class MailTemplateValidator {
                 throw new MailException(MailErrorCode.MISSING_REQUIRED_COMMON_VARIABLE);
             }
         }
+    }
+
+    /**
+     * 미리보기와 발송에 사용할 입력 변수의 선언, 필수 여부, 타입을 검증합니다.
+     */
+    public void validateVariables(Set<MailScenarioVariable> customVariables, Map<String, ?> variables) {
+        Set<MailScenarioVariable> safeCustomVariables = customVariables != null ? customVariables : Set.of();
+        Map<String, ?> safeVariables = variables != null ? variables : Map.of();
+
+        validateRequiredVariables(safeCustomVariables, safeVariables);
+        validateDeclaredVariableKeys(safeCustomVariables, safeVariables);
+
+        for (MailScenarioVariable variable : safeCustomVariables) {
+            Object value = safeVariables.get(variable.getKey());
+            if (isBlank(value)) {
+                continue;
+            }
+
+            if (variable.getInputType() == VariableInputType.DATE_TIME) {
+                validateDateTime(variable.getKey(), value);
+            }
+        }
+    }
+
+    private void validateDeclaredVariableKeys(Set<MailScenarioVariable> customVariables, Map<String, ?> variables) {
+        Set<String> allowedKeys = getAllowedVariableKeys(customVariables);
+        Set<String> invalidKeys = variables.keySet().stream()
+                .filter(key -> !allowedKeys.contains(key))
+                .map(key -> key == null ? "null" : key)
+                .collect(Collectors.toSet());
+
+        if (!invalidKeys.isEmpty()) {
+            String message = String.format("%s : [%s]",
+                    MailErrorCode.UNSUPPORTED_TEMPLATE_VARIABLE.getMessage(),
+                    String.join(", ", invalidKeys.stream().sorted().toList()));
+            throw new MailException(MailErrorCode.UNSUPPORTED_TEMPLATE_VARIABLE, message);
+        }
+    }
+
+    private void validateDateTime(String key, Object value) {
+        if (!(value instanceof CharSequence charSequence)
+                || !DATE_TIME_PATTERN.matcher(charSequence).matches()) {
+            throwInvalidVariableValue(key);
+            return;
+        }
+
+        try {
+            LocalDateTime.parse(charSequence, DateTimeUtil.DEFAULT_DATETIME_FORMATTER);
+        } catch (DateTimeParseException e) {
+            throwInvalidVariableValue(key);
+        }
+    }
+
+    private void throwInvalidVariableValue(String key) {
+        String message = String.format("%s : [%s]", MailErrorCode.INVALID_VARIABLE_VALUE.getMessage(), key);
+        throw new MailException(MailErrorCode.INVALID_VARIABLE_VALUE, message);
+    }
+
+    private boolean isBlank(Object value) {
+        return value == null || value instanceof CharSequence charSequence && charSequence.toString().isBlank();
+    }
+
+    private Set<String> getAllowedVariableKeys(Set<MailScenarioVariable> customVariables) {
+        Set<String> allowedKeys = new HashSet<>();
+        for (ReservedMailVariable rv : ReservedMailVariable.values()) {
+            allowedKeys.add(rv.name());
+        }
+        for (MailScenarioVariable cv : customVariables) {
+            allowedKeys.add(cv.getKey());
+        }
+        return allowedKeys;
     }
 
     private Set<String> extractPlaceholderKeys(String template) {

--- a/src/main/java/org/ject/support/common/util/DateTimeUtil.java
+++ b/src/main/java/org/ject/support/common/util/DateTimeUtil.java
@@ -4,13 +4,15 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 import java.util.Optional;
 
 public final class DateTimeUtil {
 
     private static final String[] DAY_OF_WEEK_NAMES = {"월", "화", "수", "목", "금", "토", "일"};
     public static final DateTimeFormatter DEFAULT_DATETIME_FORMATTER =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+            DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm")
+                    .withResolverStyle(ResolverStyle.STRICT);
     public static final DateTimeFormatter DEFAULT_DATE_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd");
     public static final DateTimeFormatter DEFAULT_TIME_FORMATTER =

--- a/src/main/java/org/ject/support/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/RecruitRepository.java
@@ -19,6 +19,10 @@ public interface RecruitRepository extends JpaRepository<Recruit, Long> {
             + "ORDER BY r.startDate ASC, r.id ASC")
     List<Recruit> findActiveRecruitments(@Param("now") LocalDateTime now);
 
+    @Query("SELECT r FROM Recruit r JOIN FETCH r.semester "
+            + "ORDER BY r.createdAt DESC, r.id DESC")
+    List<Recruit> findAllForMailDispatch();
+
     @Query("SELECT EXISTS(SELECT 1 FROM Recruit r "
             + "WHERE r.semester.id = :semesterId AND r.jobFamily IN :jobFamilies AND r.endDate >= now())")
     boolean existsByJobFamilyAndIsNotClosed(@Param("semesterId") Long semesterId,

--- a/src/test/java/org/ject/support/admin/mail/controller/AdminMailRecruitControllerTest.java
+++ b/src/test/java/org/ject/support/admin/mail/controller/AdminMailRecruitControllerTest.java
@@ -1,0 +1,100 @@
+package org.ject.support.admin.mail.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailRecruitResponse;
+import org.ject.support.admin.mail.service.MailRecruitService;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.common.exception.GlobalExceptionHandler;
+import org.ject.support.common.response.ResponseWrapper;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.RecruitType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.OptionalValidatorFactoryBean;
+
+class AdminMailRecruitControllerTest extends UnitTestSupport {
+
+    private MockMvc mockMvc;
+
+    private final OptionalValidatorFactoryBean validator = new OptionalValidatorFactoryBean();
+
+    @Mock
+    private MailRecruitService mailRecruitService;
+
+    @InjectMocks
+    private AdminMailRecruitController adminMailRecruitController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(adminMailRecruitController)
+                .setControllerAdvice(new GlobalExceptionHandler(), new ResponseWrapper())
+                .setValidator(validator)
+                .build();
+    }
+
+    @Test
+    void 메일_발송용_모집_공고_목록을_조회한다() throws Exception {
+        // given
+        LocalDateTime startDate = LocalDateTime.of(2026, 8, 1, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2026, 8, 31, 23, 59);
+        LocalDateTime createdAt = LocalDateTime.of(2026, 7, 1, 10, 0);
+        MailRecruitResponse response = new MailRecruitResponse(
+                1L,
+                2L,
+                "10기",
+                JobFamily.BE,
+                JobFamily.BE.getDescription(),
+                RecruitType.SEMESTER,
+                RecruitType.SEMESTER.getDescription(),
+                RecruitTypeDetail.REGULAR,
+                RecruitTypeDetail.REGULAR.getDescription(),
+                startDate,
+                endDate,
+                createdAt);
+        given(mailRecruitService.getRecruits()).willReturn(List.of(response));
+
+        // when & then
+        mockMvc.perform(get("/admin/mails/recruits"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].recruitId").value(1))
+                .andExpect(jsonPath("$.data[0].semesterId").value(2))
+                .andExpect(jsonPath("$.data[0].semesterName").value("10기"))
+                .andExpect(jsonPath("$.data[0].jobFamily").value("BE"))
+                .andExpect(jsonPath("$.data[0].jobFamilyDescription").value("백엔드 개발자(BE)"))
+                .andExpect(jsonPath("$.data[0].recruitType").value("SEMESTER"))
+                .andExpect(jsonPath("$.data[0].recruitTypeDescription").value("정규 기수 모집"))
+                .andExpect(jsonPath("$.data[0].recruitTypeDetail").value("REGULAR"))
+                .andExpect(jsonPath("$.data[0].recruitTypeDetailDescription").value("정규 모집"))
+                .andExpect(jsonPath("$.data[0].startDate[0]").value(2026))
+                .andExpect(jsonPath("$.data[0].startDate[1]").value(8))
+                .andExpect(jsonPath("$.data[0].startDate[2]").value(1))
+                .andExpect(jsonPath("$.data[0].endDate[0]").value(2026))
+                .andExpect(jsonPath("$.data[0].endDate[2]").value(31))
+                .andExpect(jsonPath("$.data[0].createdAt[0]").value(2026))
+                .andExpect(jsonPath("$.data[0].createdAt[2]").value(1));
+        then(mailRecruitService).should().getRecruits();
+    }
+
+    @Test
+    void 모집_공고가_없으면_빈_목록을_반환한다() throws Exception {
+        // given
+        given(mailRecruitService.getRecruits()).willReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get("/admin/mails/recruits"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+}

--- a/src/test/java/org/ject/support/admin/mail/controller/AdminMailRecruitSecurityTest.java
+++ b/src/test/java/org/ject/support/admin/mail/controller/AdminMailRecruitSecurityTest.java
@@ -1,0 +1,60 @@
+package org.ject.support.admin.mail.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailRecruitResponse;
+import org.ject.support.admin.mail.service.MailRecruitService;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.RecruitType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+import org.ject.support.testconfig.ApplicationPeriodTest;
+import org.ject.support.testconfig.AuthenticatedUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"spring.data.redis.repositories.enabled=false"})
+class AdminMailRecruitSecurityTest extends ApplicationPeriodTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MailRecruitService mailRecruitService;
+
+    @Test
+    void 인증되지_않은_사용자는_메일_발송용_모집_공고를_조회할_수_없다() throws Exception {
+        mockMvc.perform(get("/admin/mails/recruits"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @AuthenticatedUser(isAdmin = false)
+    void 일반_사용자는_메일_발송용_모집_공고를_조회할_수_없다() throws Exception {
+        mockMvc.perform(get("/admin/mails/recruits"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @AuthenticatedUser(isAdmin = true)
+    void 관리자는_메일_발송용_모집_공고를_조회할_수_있다() throws Exception {
+        given(mailRecruitService.getRecruits()).willReturn(List.of(
+                new MailRecruitResponse(
+                        1L, 2L, "10기", JobFamily.BE, JobFamily.BE.getDescription(),
+                        RecruitType.SEMESTER, RecruitType.SEMESTER.getDescription(),
+                        RecruitTypeDetail.REGULAR, RecruitTypeDetail.REGULAR.getDescription(),
+                        null, null, null)));
+
+        mockMvc.perform(get("/admin/mails/recruits"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/org/ject/support/admin/mail/controller/AdminMailScenarioControllerTest.java
+++ b/src/test/java/org/ject/support/admin/mail/controller/AdminMailScenarioControllerTest.java
@@ -71,7 +71,10 @@ class AdminMailScenarioControllerTest extends UnitTestSupport {
         MailScenarioResponse scenarioResponse = new MailScenarioResponse(
                 1L, "테스트 시나리오", MailScenarioCategory.CLUB_MEMBER, MailScenarioType.ETC,
                 "TEST_SCENARIO", "[JECT] ${RECRUIT_NAME}", "${name}", true, LocalDateTime.now(),
-                List.of(new MailScenarioResponse.CustomVariableResponse("RECRUIT_NAME", "모집명", "TEXT", true, null))
+                List.of(
+                        new MailScenarioResponse.CustomVariableResponse("RECRUIT_NAME", "모집명", "TEXT", true, null),
+                        new MailScenarioResponse.CustomVariableResponse("INTERVIEW_AT", "면접 일시", "DATE_TIME", true, null)
+                )
         );
         given(mailScenarioService.searchScenarios(
                 isNull(MailScenarioCategory.class),
@@ -85,7 +88,8 @@ class AdminMailScenarioControllerTest extends UnitTestSupport {
                 .andExpect(jsonPath("$.data.content[0].id").value(scenarioResponse.id()))
                 .andExpect(jsonPath("$.data.content[0].name").value(scenarioResponse.name()))
                 .andExpect(jsonPath("$.data.content[0].category").value(scenarioResponse.category().name()))
-                .andExpect(jsonPath("$.data.content[0].type").value(scenarioResponse.type().name()));
+                .andExpect(jsonPath("$.data.content[0].type").value(scenarioResponse.type().name()))
+                .andExpect(jsonPath("$.data.content[0].customVariables[1].inputType").value("DATE_TIME"));
 
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
         verify(mailScenarioService).searchScenarios(
@@ -167,12 +171,12 @@ class AdminMailScenarioControllerTest extends UnitTestSupport {
         MailScenarioRequest request = new MailScenarioRequest(
                 "수정 시나리오", MailScenarioCategory.MAKERS, MailScenarioType.FINAL_PASS, "UPDATED_SCENARIO",
                 "[JECT] ${RECRUIT_NAME}", "${name}", false, 
-                List.of(new CustomVariableRequest("RECRUIT_NAME", "모집명", VariableInputType.TEXT, true, null))
+                List.of(new CustomVariableRequest("RECRUIT_NAME", "모집명", VariableInputType.DATE_TIME, true, null))
         );
         MailScenarioResponse response = new MailScenarioResponse(
                 scenarioId, "수정 시나리오", MailScenarioCategory.MAKERS, MailScenarioType.FINAL_PASS,
                 "UPDATED_SCENARIO", "[JECT] ${RECRUIT_NAME}", "${name}", false, LocalDateTime.now(),
-                List.of(new MailScenarioResponse.CustomVariableResponse("RECRUIT_NAME", "모집명", "TEXT", true, null))
+                List.of(new MailScenarioResponse.CustomVariableResponse("RECRUIT_NAME", "모집명", "DATE_TIME", true, null))
         );
         given(mailScenarioService.updateScenario(eq(scenarioId), any(MailScenarioRequest.class))).willReturn(response);
 
@@ -183,7 +187,8 @@ class AdminMailScenarioControllerTest extends UnitTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.name").value("수정 시나리오"))
                 .andExpect(jsonPath("$.data.category").value(MailScenarioCategory.MAKERS.name()))
-                .andExpect(jsonPath("$.data.type").value(MailScenarioType.FINAL_PASS.name()));
+                .andExpect(jsonPath("$.data.type").value(MailScenarioType.FINAL_PASS.name()))
+                .andExpect(jsonPath("$.data.customVariables[0].inputType").value("DATE_TIME"));
     }
 
     @Test
@@ -202,7 +207,7 @@ class AdminMailScenarioControllerTest extends UnitTestSupport {
         MailScenarioVariableResponse response = new MailScenarioVariableResponse(
                 scenarioId,
                 "일반 구성원 - 예비 합격 통지",
-                List.of(new MailScenarioVariableResponse.CustomVariableResponse("RECRUIT_ALERT_APPLY_URL", "모집 알림 신청 URL", "URL", true, null)),
+                List.of(new MailScenarioVariableResponse.CustomVariableResponse("INTERVIEW_AT", "면접 일시", "DATE_TIME", true, null)),
                 List.of("name", "semester")
         );
 
@@ -213,9 +218,31 @@ class AdminMailScenarioControllerTest extends UnitTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.scenarioId").value(scenarioId))
                 .andExpect(jsonPath("$.data.name").value("일반 구성원 - 예비 합격 통지"))
-                .andExpect(jsonPath("$.data.customVariables[0].key").value("RECRUIT_ALERT_APPLY_URL"))
-                .andExpect(jsonPath("$.data.customVariables[0].inputType").value("URL"))
+                .andExpect(jsonPath("$.data.customVariables[0].key").value("INTERVIEW_AT"))
+                .andExpect(jsonPath("$.data.customVariables[0].inputType").value("DATE_TIME"))
                 .andExpect(jsonPath("$.data.personalVariables[0]").value("name"));
+    }
+
+    @Test
+    @DisplayName("날짜와 시간 입력 변수 타입을 생성 요청과 응답에서 유지한다")
+    void 날짜와_시간_입력_변수_타입을_생성_요청과_응답에서_유지한다() throws Exception {
+        MailScenarioRequest request = new MailScenarioRequest(
+                "면접 안내", MailScenarioCategory.CLUB_MEMBER, MailScenarioType.ETC, "INTERVIEW_NOTICE",
+                "면접 안내", "면접 일시: ${INTERVIEW_AT}", true,
+                List.of(new CustomVariableRequest("INTERVIEW_AT", "면접 일시", VariableInputType.DATE_TIME, true, null))
+        );
+        MailScenarioResponse response = new MailScenarioResponse(
+                1L, "면접 안내", MailScenarioCategory.CLUB_MEMBER, MailScenarioType.ETC,
+                "INTERVIEW_NOTICE", "면접 안내", "면접 일시: ${INTERVIEW_AT}", true, LocalDateTime.now(),
+                List.of(new MailScenarioResponse.CustomVariableResponse("INTERVIEW_AT", "면접 일시", "DATE_TIME", true, null))
+        );
+        given(mailScenarioService.createScenario(any(MailScenarioRequest.class))).willReturn(response);
+
+        mockMvc.perform(post("/admin/mails/scenarios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.customVariables[0].inputType").value("DATE_TIME"));
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/mail/service/MailRecruitServiceTest.java
+++ b/src/test/java/org/ject/support/admin/mail/service/MailRecruitServiceTest.java
@@ -1,0 +1,67 @@
+package org.ject.support.admin.mail.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.ject.support.admin.mail.dto.MailRecruitResponse;
+import org.ject.support.base.UnitTestSupport;
+import org.ject.support.domain.member.JobFamily;
+import org.ject.support.domain.recruit.domain.Recruit;
+import org.ject.support.domain.recruit.domain.RecruitType;
+import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
+import org.ject.support.domain.recruit.domain.Semester;
+import org.ject.support.domain.recruit.repository.RecruitRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class MailRecruitServiceTest extends UnitTestSupport {
+
+    @InjectMocks
+    private MailRecruitService mailRecruitService;
+
+    @Mock
+    private RecruitRepository recruitRepository;
+
+    @Test
+    void 모집_공고를_메일_발송용_응답으로_변환한다() {
+        // given
+        LocalDateTime startDate = LocalDateTime.of(2026, 8, 1, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2026, 8, 31, 23, 59);
+        LocalDateTime createdAt = LocalDateTime.of(2026, 7, 1, 10, 0);
+        Semester semester = Semester.builder().id(2L).name("10기").isRecruiting(true).build();
+        Recruit recruit = Recruit.builder()
+                .id(1L)
+                .semester(semester)
+                .startDate(startDate)
+                .endDate(endDate)
+                .jobFamily(JobFamily.BE)
+                .recruitType(RecruitType.SEMESTER)
+                .recruitTypeDetail(RecruitTypeDetail.REGULAR)
+                .build();
+        ReflectionTestUtils.setField(recruit, "createdAt", createdAt);
+        given(recruitRepository.findAllForMailDispatch()).willReturn(List.of(recruit));
+
+        // when
+        List<MailRecruitResponse> result = mailRecruitService.getRecruits();
+
+        // then
+        assertThat(result).singleElement().satisfies(response -> {
+            assertThat(response.recruitId()).isEqualTo(1L);
+            assertThat(response.semesterId()).isEqualTo(2L);
+            assertThat(response.semesterName()).isEqualTo("10기");
+            assertThat(response.jobFamily()).isEqualTo(JobFamily.BE);
+            assertThat(response.jobFamilyDescription()).isEqualTo("백엔드 개발자(BE)");
+            assertThat(response.recruitType()).isEqualTo(RecruitType.SEMESTER);
+            assertThat(response.recruitTypeDescription()).isEqualTo("정규 기수 모집");
+            assertThat(response.recruitTypeDetail()).isEqualTo(RecruitTypeDetail.REGULAR);
+            assertThat(response.recruitTypeDetailDescription()).isEqualTo("정규 모집");
+            assertThat(response.startDate()).isEqualTo(startDate);
+            assertThat(response.endDate()).isEqualTo(endDate);
+            assertThat(response.createdAt()).isEqualTo(createdAt);
+        });
+    }
+}

--- a/src/test/java/org/ject/support/admin/mail/service/MailScenarioServiceTest.java
+++ b/src/test/java/org/ject/support/admin/mail/service/MailScenarioServiceTest.java
@@ -184,4 +184,28 @@ class MailScenarioServiceTest {
 
         then(mailScenarioRepository).should().delete(existing);
     }
+
+    @Test
+    @DisplayName("미리보기 입력값을 날짜와 시간 타입으로 검증한다")
+    void 미리보기_입력값이_잘못된_날짜와_시간이면_거부한다() {
+        Long scenarioId = 1L;
+        MailScenario scenario = MailScenario.builder()
+                .bodyTemplate("면접 일시: ${INTERVIEW_AT}")
+                .customVariables(Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(true)
+                        .build()))
+                .build();
+        given(mailScenarioRepository.findById(scenarioId)).willReturn(Optional.of(scenario));
+
+        assertThatThrownBy(() -> mailScenarioService.renderScenario(
+                scenarioId,
+                Map.of("INTERVIEW_AT", "2026-02-30 10:00")
+        ))
+                .isInstanceOf(MailException.class)
+                .extracting("errorCode")
+                .isEqualTo(MailErrorCode.INVALID_VARIABLE_VALUE);
+    }
 }

--- a/src/test/java/org/ject/support/admin/mail/service/MailTemplateValidatorTest.java
+++ b/src/test/java/org/ject/support/admin/mail/service/MailTemplateValidatorTest.java
@@ -67,8 +67,8 @@ class MailTemplateValidatorTest {
 
     @Test
     @DisplayName("필수 공통 변수 누락 시 예외를 발생시킨다")
-    void validateRequiredCommonVariables_Fail() {
-        assertThatThrownBy(() -> validator.validateRequiredCommonVariables(
+    void 필수_입력_변수가_누락되면_예외를_발생시킨다() {
+        assertThatThrownBy(() -> validator.validateVariables(
                 Set.of(MailScenarioVariable.builder().key("RECRUIT_ALERT_APPLY_URL").label("URL").inputType(VariableInputType.URL).required(true).build()),
                 Map.of("NAME", "젝트")
         ))
@@ -79,10 +79,120 @@ class MailTemplateValidatorTest {
 
     @Test
     @DisplayName("필수 공통 변수가 모두 있으면 통과한다")
-    void validateRequiredCommonVariables_Success() {
-        assertThatCode(() -> validator.validateRequiredCommonVariables(
+    void 필수_입력_변수가_모두_있으면_검증을_통과한다() {
+        assertThatCode(() -> validator.validateVariables(
                 Set.of(MailScenarioVariable.builder().key("RECRUIT_ALERT_APPLY_URL").label("URL").inputType(VariableInputType.URL).required(true).build()),
-                Map.of("RECRUIT_ALERT_APPLY_URL", "https://ject.kr", "NAME", "젝트")
+                Map.of("RECRUIT_ALERT_APPLY_URL", "https://ject.kr")
         )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("날짜와 시간이 올바른 형식이면 입력 변수 검증을 통과한다")
+    void 날짜와_시간이_올바른_형식이면_입력_변수_검증을_통과한다() {
+        assertThatCode(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(true)
+                        .build()),
+                Map.of("INTERVIEW_AT", "2026-02-28 10:00")
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 날짜와 시간이면 입력 변수 오류를 발생시킨다")
+    void 존재하지_않는_날짜와_시간이면_입력_변수_오류를_발생시킨다() {
+        assertThatThrownBy(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(true)
+                        .build()),
+                Map.of("INTERVIEW_AT", "2026-02-30 10:00")
+        ))
+                .isInstanceOf(MailException.class)
+                .extracting("errorCode")
+                .isEqualTo(MailErrorCode.INVALID_VARIABLE_VALUE);
+    }
+
+    @Test
+    @DisplayName("날짜와 시간이 계약된 형식과 다르면 입력 변수 오류를 발생시킨다")
+    void 날짜와_시간이_계약된_형식과_다르면_입력_변수_오류를_발생시킨다() {
+        assertThatThrownBy(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(true)
+                        .build()),
+                Map.of("INTERVIEW_AT", "2026/02/28 10:00")
+        ))
+                .isInstanceOf(MailException.class)
+                .extracting("errorCode")
+                .isEqualTo(MailErrorCode.INVALID_VARIABLE_VALUE);
+    }
+
+    @Test
+    @DisplayName("선택 입력 변수의 빈 날짜와 시간은 검증을 통과한다")
+    void 선택_입력_변수의_빈_날짜와_시간은_검증을_통과한다() {
+        assertThatCode(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(false)
+                        .build()),
+                Map.of("INTERVIEW_AT", " ")
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("선언되지 않은 입력 변수 키는 입력 변수 오류를 발생시킨다")
+    void 선언되지_않은_입력_변수_키는_입력_변수_오류를_발생시킨다() {
+        assertThatThrownBy(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(false)
+                        .build()),
+                Map.of("UNKNOWN", "값")
+        ))
+                .isInstanceOf(MailException.class)
+                .extracting("errorCode")
+                .isEqualTo(MailErrorCode.UNSUPPORTED_TEMPLATE_VARIABLE);
+    }
+
+    @Test
+    @DisplayName("기존 텍스트 입력 변수는 기존 방식으로 검증을 통과한다")
+    void 기존_텍스트_입력_변수는_기존_방식으로_검증을_통과한다() {
+        assertThatCode(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("MESSAGE")
+                        .label("메시지")
+                        .inputType(VariableInputType.TEXT)
+                        .required(true)
+                        .build()),
+                Map.of("MESSAGE", "안내 내용")
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("연도가 네 자리보다 길면 입력 변수 오류를 발생시킨다")
+    void 연도가_네_자리보다_길면_입력_변수_오류를_발생시킨다() {
+        assertThatThrownBy(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(true)
+                        .build()),
+                Map.of("INTERVIEW_AT", "+10000-01-01 00:00")
+        ))
+                .isInstanceOf(MailException.class)
+                .extracting("errorCode")
+                .isEqualTo(MailErrorCode.INVALID_VARIABLE_VALUE);
     }
 }

--- a/src/test/java/org/ject/support/domain/recruit/repository/RecruitRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/repository/RecruitRepositoryTest.java
@@ -1,5 +1,7 @@
 package org.ject.support.domain.recruit.repository;
 
+import jakarta.persistence.EntityManager;
+import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.recruit.domain.Recruit;
 import org.ject.support.domain.recruit.domain.RecruitType;
 import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
@@ -11,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,6 +34,9 @@ class RecruitRepositoryTest {
 
     @Autowired
     private SemesterRepository semesterRepository;
+
+    @Autowired
+    private EntityManager entityManager;
 
     @Test
     void 특정_직군의_마감되지_않은_모집_정보가_존재하면_true를_반환한다() {
@@ -110,6 +116,31 @@ class RecruitRepositoryTest {
     }
 
     @Test
+    void 메일_발송용_모집_공고를_등록일_내림차순으로_조회하고_동일하면_ID_내림차순으로_조회한다() {
+        // given
+        Semester savedSemester = semesterRepository.save(Semester.builder().name("3기").isRecruiting(true).build());
+        Recruit oldestRecruit = saveRecruit(savedSemester, PM);
+        Recruit firstTieRecruit = saveRecruit(savedSemester, BE);
+        Recruit secondTieRecruit = saveRecruit(savedSemester, FE);
+        Recruit latestRecruit = saveRecruit(savedSemester, SUPPORTER);
+        entityManager.flush();
+        setCreatedAt(oldestRecruit, LocalDateTime.of(2026, 8, 1, 10, 0));
+        setCreatedAt(firstTieRecruit, LocalDateTime.of(2026, 8, 2, 10, 0));
+        setCreatedAt(secondTieRecruit, LocalDateTime.of(2026, 8, 2, 10, 0));
+        setCreatedAt(latestRecruit, LocalDateTime.of(2026, 8, 3, 10, 0));
+        entityManager.clear();
+
+        // when
+        List<Recruit> result = recruitRepository.findAllForMailDispatch();
+
+        // then
+        assertThat(result)
+                .extracting(Recruit::getId)
+                .containsExactly(latestRecruit.getId(), secondTieRecruit.getId(), firstTieRecruit.getId(), oldestRecruit.getId());
+        assertThat(org.hibernate.Hibernate.isInitialized(result.getFirst().getSemester())).isTrue();
+    }
+
+    @Test
     void 허용되지_않은_모집_유형과_모집_사유_조합은_저장할_수_없다() {
         // given
         Semester savedSemester = semesterRepository.save(Semester.builder().name("3기").isRecruiting(true).build());
@@ -126,5 +157,22 @@ class RecruitRepositoryTest {
         assertThatThrownBy(() -> recruitRepository.saveAndFlush(recruit))
                 .isInstanceOf(RecruitException.class)
                 .hasFieldOrPropertyWithValue("errorCode", RecruitErrorCode.INVALID_RECRUIT_TYPE_DETAIL);
+    }
+
+    private Recruit saveRecruit(Semester semester, JobFamily jobFamily) {
+        return recruitRepository.save(Recruit.builder()
+                .semester(semester)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .jobFamily(jobFamily)
+                .build());
+    }
+
+    private void setCreatedAt(Recruit recruit, LocalDateTime createdAt) {
+        entityManager.createNativeQuery("UPDATE recruit SET created_at = :createdAt WHERE id = :recruitId")
+                .setParameter("createdAt", createdAt)
+                .setParameter("recruitId", recruit.getId())
+                .executeUpdate();
+        ReflectionTestUtils.setField(recruit, "createdAt", createdAt);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#624

## 📝 작업 내용

- `GET /admin/mails/recruits` 메일 발송용 모집 공고 목록 조회 API 추가
- `Recruit.createdAt DESC, id DESC` 정렬 적용
- `JOIN FETCH r.semester`로 `Semester` N+1 조회 방지
- `MailRecruitResponse` DTO로 응답을 분리하고 기수·직군·모집 유형·모집 기간·등록일 제공
- 기존 관리자 인증·인가 규칙 적용
- `AdminMailRecruitApiSpec`에 Swagger 명세 추가
- 정상 조회·빈 목록·응답 필드·정렬·권한 테스트 추가
- DB migration 및 배포 설정 변경 없음

### API 응답 예시

```json
{
  "recruitId": 1,
  "semesterId": 2,
  "semesterName": "10기",
  "jobFamily": "BE",
  "jobFamilyDescription": "백엔드 개발자(BE)",
  "recruitType": "SEMESTER",
  "recruitTypeDescription": "정규 기수 모집",
  "recruitTypeDetail": "REGULAR",
  "recruitTypeDetailDescription": "정규 모집",
  "startDate": "2026-08-01T00:00:00",
  "endDate": "2026-08-31T23:59:00",
  "createdAt": "2026-07-01T10:00:00"
}
```

### 검증 결과

- 관련 테스트 10개 통과
- `git diff --check` 통과
- 전체 `./gradlew test`: 573개 중 522개 통과, 51개는 로컬 Docker 미가동으로 `RedisTestContainers` 초기화 실패
- 원격 CI에서 전체 테스트와 coverage 검증 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 관리자 전용 모집 공고 조회 API를 추가했습니다.
  * 기수, 직무, 모집 유형, 모집 기간, 등록일 정보를 제공하며 최신 등록일과 ID 순으로 정렬됩니다.
  * 인증되지 않은 사용자와 일반 사용자의 접근을 제한합니다.
  * 메일 변수에 날짜·시간 입력 유형과 형식 검증을 지원합니다.
  * 잘못된 변수 값에 대한 오류 안내를 제공합니다.

* **테스트**
  * 모집 공고 조회, 데이터 변환, 정렬, 권한 및 날짜·시간 변수 검증을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->