### PR TITLE
feat/#626 메일 템플릿 입력 변수에 날짜/시간 타입 추가

### DIFF
--- a/src/main/java/org/ject/support/admin/mail/domain/VariableInputType.java
+++ b/src/main/java/org/ject/support/admin/mail/domain/VariableInputType.java
@@ -12,7 +12,8 @@ public enum VariableInputType {
     TEXT("텍스트"),
     URL("URL 링크"),
     EMAIL("이메일 주소"),
-    PHONE("전화번호");
+    PHONE("전화번호"),
+    DATE_TIME("날짜/시간");
 
     private final String description;
 }

--- a/src/main/java/org/ject/support/admin/mail/exception/MailErrorCode.java
+++ b/src/main/java/org/ject/support/admin/mail/exception/MailErrorCode.java
@@ -27,6 +27,7 @@ public enum MailErrorCode implements ErrorCode {
     DISPATCH_JOB_NOT_FOUND(NOT_FOUND, "MAIL-9", "메일 발송 작업을 찾을 수 없습니다."),
     INVALID_DISPATCH_JOB_STATUS(BAD_REQUEST, "MAIL-10", "현재 상태에서는 발송 실행을 수행할 수 없습니다."),
     TEST_MAIL_SEND_FAILURE(SERVICE_UNAVAILABLE, "MAIL-11", "테스트 메일 발송에 실패했습니다."),
+    INVALID_VARIABLE_VALUE(BAD_REQUEST, "MAIL-12", "메일 입력 변수 값이 올바르지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/ject/support/admin/mail/service/MailScenarioService.java
+++ b/src/main/java/org/ject/support/admin/mail/service/MailScenarioService.java
@@ -130,7 +130,7 @@ public class MailScenarioService {
     @Transactional(readOnly = true)
     public String renderScenario(Long scenarioId, Map<String, Object> variables) {
         MailScenario scenario = findScenarioById(scenarioId);
-        mailTemplateValidator.validateRequiredCommonVariables(scenario.getCustomVariables(), variables);
+        mailTemplateValidator.validateVariables(scenario.getCustomVariables(), variables);
         return mailTemplateEngine.render(scenario.getBodyTemplate(), variables);
     }
 

--- a/src/main/java/org/ject/support/admin/mail/service/MailTemplateValidator.java
+++ b/src/main/java/org/ject/support/admin/mail/service/MailTemplateValidator.java
@@ -1,5 +1,7 @@
 package org.ject.support.admin.mail.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -8,8 +10,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.ject.support.admin.mail.domain.MailScenarioVariable;
 import org.ject.support.admin.mail.domain.ReservedMailVariable;
+import org.ject.support.admin.mail.domain.VariableInputType;
 import org.ject.support.admin.mail.exception.MailErrorCode;
 import org.ject.support.admin.mail.exception.MailException;
+import org.ject.support.common.util.DateTimeUtil;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -17,6 +21,8 @@ public class MailTemplateValidator {
 
     private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([A-Za-z0-9_]+)}");
     private static final Pattern PLACEHOLDER_KEY_PATTERN = Pattern.compile("[A-Za-z0-9_]+");
+    private static final Pattern DATE_TIME_PATTERN =
+            Pattern.compile("(?!0000-)\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}");
 
     /**
      * ${KEY} 형태의 기본 문법이 올바른지 검증합니다.
@@ -57,13 +63,7 @@ public class MailTemplateValidator {
 
         Set<MailScenarioVariable> safeCustomVariables = customVariables != null ? customVariables : Set.of();
 
-        Set<String> allowedKeys = new HashSet<>();
-        for (ReservedMailVariable rv : ReservedMailVariable.values()) {
-            allowedKeys.add(rv.name());
-        }
-        for (MailScenarioVariable cv : safeCustomVariables) {
-            allowedKeys.add(cv.getKey());
-        }
+        Set<String> allowedKeys = getAllowedVariableKeys(safeCustomVariables);
 
         Set<String> usedKeys = extractPlaceholderKeys(template);
         Set<String> invalidKeys = usedKeys.stream()
@@ -78,7 +78,7 @@ public class MailTemplateValidator {
         }
     }
 
-    public void validateRequiredCommonVariables(Set<MailScenarioVariable> customVariables, Map<String, ?> variables) {
+    private void validateRequiredVariables(Set<MailScenarioVariable> customVariables, Map<String, ?> variables) {
         Set<MailScenarioVariable> safeCustomVariables = customVariables != null ? customVariables : Set.of();
         Map<String, ?> safeVariables = variables != null ? variables : Map.of();
 
@@ -96,6 +96,77 @@ public class MailTemplateValidator {
                 throw new MailException(MailErrorCode.MISSING_REQUIRED_COMMON_VARIABLE);
             }
         }
+    }
+
+    /**
+     * 미리보기와 발송에 사용할 입력 변수의 선언, 필수 여부, 타입을 검증합니다.
+     */
+    public void validateVariables(Set<MailScenarioVariable> customVariables, Map<String, ?> variables) {
+        Set<MailScenarioVariable> safeCustomVariables = customVariables != null ? customVariables : Set.of();
+        Map<String, ?> safeVariables = variables != null ? variables : Map.of();
+
+        validateRequiredVariables(safeCustomVariables, safeVariables);
+        validateDeclaredVariableKeys(safeCustomVariables, safeVariables);
+
+        for (MailScenarioVariable variable : safeCustomVariables) {
+            Object value = safeVariables.get(variable.getKey());
+            if (isBlank(value)) {
+                continue;
+            }
+
+            if (variable.getInputType() == VariableInputType.DATE_TIME) {
+                validateDateTime(variable.getKey(), value);
+            }
+        }
+    }
+
+    private void validateDeclaredVariableKeys(Set<MailScenarioVariable> customVariables, Map<String, ?> variables) {
+        Set<String> allowedKeys = getAllowedVariableKeys(customVariables);
+        Set<String> invalidKeys = variables.keySet().stream()
+                .filter(key -> !allowedKeys.contains(key))
+                .map(key -> key == null ? "null" : key)
+                .collect(Collectors.toSet());
+
+        if (!invalidKeys.isEmpty()) {
+            String message = String.format("%s : [%s]",
+                    MailErrorCode.UNSUPPORTED_TEMPLATE_VARIABLE.getMessage(),
+                    String.join(", ", invalidKeys.stream().sorted().toList()));
+            throw new MailException(MailErrorCode.UNSUPPORTED_TEMPLATE_VARIABLE, message);
+        }
+    }
+
+    private void validateDateTime(String key, Object value) {
+        if (!(value instanceof CharSequence charSequence)
+                || !DATE_TIME_PATTERN.matcher(charSequence).matches()) {
+            throwInvalidVariableValue(key);
+            return;
+        }
+
+        try {
+            LocalDateTime.parse(charSequence, DateTimeUtil.DEFAULT_DATETIME_FORMATTER);
+        } catch (DateTimeParseException e) {
+            throwInvalidVariableValue(key);
+        }
+    }
+
+    private void throwInvalidVariableValue(String key) {
+        String message = String.format("%s : [%s]", MailErrorCode.INVALID_VARIABLE_VALUE.getMessage(), key);
+        throw new MailException(MailErrorCode.INVALID_VARIABLE_VALUE, message);
+    }
+
+    private boolean isBlank(Object value) {
+        return value == null || value instanceof CharSequence charSequence && charSequence.toString().isBlank();
+    }
+
+    private Set<String> getAllowedVariableKeys(Set<MailScenarioVariable> customVariables) {
+        Set<String> allowedKeys = new HashSet<>();
+        for (ReservedMailVariable rv : ReservedMailVariable.values()) {
+            allowedKeys.add(rv.name());
+        }
+        for (MailScenarioVariable cv : customVariables) {
+            allowedKeys.add(cv.getKey());
+        }
+        return allowedKeys;
     }
 
     private Set<String> extractPlaceholderKeys(String template) {

--- a/src/main/java/org/ject/support/common/util/DateTimeUtil.java
+++ b/src/main/java/org/ject/support/common/util/DateTimeUtil.java
@@ -4,13 +4,15 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 import java.util.Optional;
 
 public final class DateTimeUtil {
 
     private static final String[] DAY_OF_WEEK_NAMES = {"월", "화", "수", "목", "금", "토", "일"};
     public static final DateTimeFormatter DEFAULT_DATETIME_FORMATTER =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+            DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm")
+                    .withResolverStyle(ResolverStyle.STRICT);
     public static final DateTimeFormatter DEFAULT_DATE_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd");
     public static final DateTimeFormatter DEFAULT_TIME_FORMATTER =

--- a/src/test/java/org/ject/support/admin/mail/controller/AdminMailScenarioControllerTest.java
+++ b/src/test/java/org/ject/support/admin/mail/controller/AdminMailScenarioControllerTest.java
@@ -71,7 +71,10 @@ class AdminMailScenarioControllerTest extends UnitTestSupport {
         MailScenarioResponse scenarioResponse = new MailScenarioResponse(
                 1L, "테스트 시나리오", MailScenarioCategory.CLUB_MEMBER, MailScenarioType.ETC,
                 "TEST_SCENARIO", "[JECT] ${RECRUIT_NAME}", "${name}", true, LocalDateTime.now(),
-                List.of(new MailScenarioResponse.CustomVariableResponse("RECRUIT_NAME", "모집명", "TEXT", true, null))
+                List.of(
+                        new MailScenarioResponse.CustomVariableResponse("RECRUIT_NAME", "모집명", "TEXT", true, null),
+                        new MailScenarioResponse.CustomVariableResponse("INTERVIEW_AT", "면접 일시", "DATE_TIME", true, null)
+                )
         );
         given(mailScenarioService.searchScenarios(
                 isNull(MailScenarioCategory.class),
@@ -85,7 +88,8 @@ class AdminMailScenarioControllerTest extends UnitTestSupport {
                 .andExpect(jsonPath("$.data.content[0].id").value(scenarioResponse.id()))
                 .andExpect(jsonPath("$.data.content[0].name").value(scenarioResponse.name()))
                 .andExpect(jsonPath("$.data.content[0].category").value(scenarioResponse.category().name()))
-                .andExpect(jsonPath("$.data.content[0].type").value(scenarioResponse.type().name()));
+                .andExpect(jsonPath("$.data.content[0].type").value(scenarioResponse.type().name()))
+                .andExpect(jsonPath("$.data.content[0].customVariables[1].inputType").value("DATE_TIME"));
 
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
         verify(mailScenarioService).searchScenarios(
@@ -167,12 +171,12 @@ class AdminMailScenarioControllerTest extends UnitTestSupport {
         MailScenarioRequest request = new MailScenarioRequest(
                 "수정 시나리오", MailScenarioCategory.MAKERS, MailScenarioType.FINAL_PASS, "UPDATED_SCENARIO",
                 "[JECT] ${RECRUIT_NAME}", "${name}", false, 
-                List.of(new CustomVariableRequest("RECRUIT_NAME", "모집명", VariableInputType.TEXT, true, null))
+                List.of(new CustomVariableRequest("RECRUIT_NAME", "모집명", VariableInputType.DATE_TIME, true, null))
         );
         MailScenarioResponse response = new MailScenarioResponse(
                 scenarioId, "수정 시나리오", MailScenarioCategory.MAKERS, MailScenarioType.FINAL_PASS,
                 "UPDATED_SCENARIO", "[JECT] ${RECRUIT_NAME}", "${name}", false, LocalDateTime.now(),
-                List.of(new MailScenarioResponse.CustomVariableResponse("RECRUIT_NAME", "모집명", "TEXT", true, null))
+                List.of(new MailScenarioResponse.CustomVariableResponse("RECRUIT_NAME", "모집명", "DATE_TIME", true, null))
         );
         given(mailScenarioService.updateScenario(eq(scenarioId), any(MailScenarioRequest.class))).willReturn(response);
 
@@ -183,7 +187,8 @@ class AdminMailScenarioControllerTest extends UnitTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.name").value("수정 시나리오"))
                 .andExpect(jsonPath("$.data.category").value(MailScenarioCategory.MAKERS.name()))
-                .andExpect(jsonPath("$.data.type").value(MailScenarioType.FINAL_PASS.name()));
+                .andExpect(jsonPath("$.data.type").value(MailScenarioType.FINAL_PASS.name()))
+                .andExpect(jsonPath("$.data.customVariables[0].inputType").value("DATE_TIME"));
     }
 
     @Test
@@ -202,7 +207,7 @@ class AdminMailScenarioControllerTest extends UnitTestSupport {
         MailScenarioVariableResponse response = new MailScenarioVariableResponse(
                 scenarioId,
                 "일반 구성원 - 예비 합격 통지",
-                List.of(new MailScenarioVariableResponse.CustomVariableResponse("RECRUIT_ALERT_APPLY_URL", "모집 알림 신청 URL", "URL", true, null)),
+                List.of(new MailScenarioVariableResponse.CustomVariableResponse("INTERVIEW_AT", "면접 일시", "DATE_TIME", true, null)),
                 List.of("name", "semester")
         );
 
@@ -213,9 +218,31 @@ class AdminMailScenarioControllerTest extends UnitTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.scenarioId").value(scenarioId))
                 .andExpect(jsonPath("$.data.name").value("일반 구성원 - 예비 합격 통지"))
-                .andExpect(jsonPath("$.data.customVariables[0].key").value("RECRUIT_ALERT_APPLY_URL"))
-                .andExpect(jsonPath("$.data.customVariables[0].inputType").value("URL"))
+                .andExpect(jsonPath("$.data.customVariables[0].key").value("INTERVIEW_AT"))
+                .andExpect(jsonPath("$.data.customVariables[0].inputType").value("DATE_TIME"))
                 .andExpect(jsonPath("$.data.personalVariables[0]").value("name"));
+    }
+
+    @Test
+    @DisplayName("날짜와 시간 입력 변수 타입을 생성 요청과 응답에서 유지한다")
+    void 날짜와_시간_입력_변수_타입을_생성_요청과_응답에서_유지한다() throws Exception {
+        MailScenarioRequest request = new MailScenarioRequest(
+                "면접 안내", MailScenarioCategory.CLUB_MEMBER, MailScenarioType.ETC, "INTERVIEW_NOTICE",
+                "면접 안내", "면접 일시: ${INTERVIEW_AT}", true,
+                List.of(new CustomVariableRequest("INTERVIEW_AT", "면접 일시", VariableInputType.DATE_TIME, true, null))
+        );
+        MailScenarioResponse response = new MailScenarioResponse(
+                1L, "면접 안내", MailScenarioCategory.CLUB_MEMBER, MailScenarioType.ETC,
+                "INTERVIEW_NOTICE", "면접 안내", "면접 일시: ${INTERVIEW_AT}", true, LocalDateTime.now(),
+                List.of(new MailScenarioResponse.CustomVariableResponse("INTERVIEW_AT", "면접 일시", "DATE_TIME", true, null))
+        );
+        given(mailScenarioService.createScenario(any(MailScenarioRequest.class))).willReturn(response);
+
+        mockMvc.perform(post("/admin/mails/scenarios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.customVariables[0].inputType").value("DATE_TIME"));
     }
 
     @Test

--- a/src/test/java/org/ject/support/admin/mail/service/MailScenarioServiceTest.java
+++ b/src/test/java/org/ject/support/admin/mail/service/MailScenarioServiceTest.java
@@ -184,4 +184,28 @@ class MailScenarioServiceTest {
 
         then(mailScenarioRepository).should().delete(existing);
     }
+
+    @Test
+    @DisplayName("미리보기 입력값을 날짜와 시간 타입으로 검증한다")
+    void 미리보기_입력값이_잘못된_날짜와_시간이면_거부한다() {
+        Long scenarioId = 1L;
+        MailScenario scenario = MailScenario.builder()
+                .bodyTemplate("면접 일시: ${INTERVIEW_AT}")
+                .customVariables(Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(true)
+                        .build()))
+                .build();
+        given(mailScenarioRepository.findById(scenarioId)).willReturn(Optional.of(scenario));
+
+        assertThatThrownBy(() -> mailScenarioService.renderScenario(
+                scenarioId,
+                Map.of("INTERVIEW_AT", "2026-02-30 10:00")
+        ))
+                .isInstanceOf(MailException.class)
+                .extracting("errorCode")
+                .isEqualTo(MailErrorCode.INVALID_VARIABLE_VALUE);
+    }
 }

--- a/src/test/java/org/ject/support/admin/mail/service/MailTemplateValidatorTest.java
+++ b/src/test/java/org/ject/support/admin/mail/service/MailTemplateValidatorTest.java
@@ -67,8 +67,8 @@ class MailTemplateValidatorTest {
 
     @Test
     @DisplayName("필수 공통 변수 누락 시 예외를 발생시킨다")
-    void validateRequiredCommonVariables_Fail() {
-        assertThatThrownBy(() -> validator.validateRequiredCommonVariables(
+    void 필수_입력_변수가_누락되면_예외를_발생시킨다() {
+        assertThatThrownBy(() -> validator.validateVariables(
                 Set.of(MailScenarioVariable.builder().key("RECRUIT_ALERT_APPLY_URL").label("URL").inputType(VariableInputType.URL).required(true).build()),
                 Map.of("NAME", "젝트")
         ))
@@ -79,10 +79,120 @@ class MailTemplateValidatorTest {
 
     @Test
     @DisplayName("필수 공통 변수가 모두 있으면 통과한다")
-    void validateRequiredCommonVariables_Success() {
-        assertThatCode(() -> validator.validateRequiredCommonVariables(
+    void 필수_입력_변수가_모두_있으면_검증을_통과한다() {
+        assertThatCode(() -> validator.validateVariables(
                 Set.of(MailScenarioVariable.builder().key("RECRUIT_ALERT_APPLY_URL").label("URL").inputType(VariableInputType.URL).required(true).build()),
-                Map.of("RECRUIT_ALERT_APPLY_URL", "https://ject.kr", "NAME", "젝트")
+                Map.of("RECRUIT_ALERT_APPLY_URL", "https://ject.kr")
         )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("날짜와 시간이 올바른 형식이면 입력 변수 검증을 통과한다")
+    void 날짜와_시간이_올바른_형식이면_입력_변수_검증을_통과한다() {
+        assertThatCode(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(true)
+                        .build()),
+                Map.of("INTERVIEW_AT", "2026-02-28 10:00")
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 날짜와 시간이면 입력 변수 오류를 발생시킨다")
+    void 존재하지_않는_날짜와_시간이면_입력_변수_오류를_발생시킨다() {
+        assertThatThrownBy(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(true)
+                        .build()),
+                Map.of("INTERVIEW_AT", "2026-02-30 10:00")
+        ))
+                .isInstanceOf(MailException.class)
+                .extracting("errorCode")
+                .isEqualTo(MailErrorCode.INVALID_VARIABLE_VALUE);
+    }
+
+    @Test
+    @DisplayName("날짜와 시간이 계약된 형식과 다르면 입력 변수 오류를 발생시킨다")
+    void 날짜와_시간이_계약된_형식과_다르면_입력_변수_오류를_발생시킨다() {
+        assertThatThrownBy(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(true)
+                        .build()),
+                Map.of("INTERVIEW_AT", "2026/02/28 10:00")
+        ))
+                .isInstanceOf(MailException.class)
+                .extracting("errorCode")
+                .isEqualTo(MailErrorCode.INVALID_VARIABLE_VALUE);
+    }
+
+    @Test
+    @DisplayName("선택 입력 변수의 빈 날짜와 시간은 검증을 통과한다")
+    void 선택_입력_변수의_빈_날짜와_시간은_검증을_통과한다() {
+        assertThatCode(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(false)
+                        .build()),
+                Map.of("INTERVIEW_AT", " ")
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("선언되지 않은 입력 변수 키는 입력 변수 오류를 발생시킨다")
+    void 선언되지_않은_입력_변수_키는_입력_변수_오류를_발생시킨다() {
+        assertThatThrownBy(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(false)
+                        .build()),
+                Map.of("UNKNOWN", "값")
+        ))
+                .isInstanceOf(MailException.class)
+                .extracting("errorCode")
+                .isEqualTo(MailErrorCode.UNSUPPORTED_TEMPLATE_VARIABLE);
+    }
+
+    @Test
+    @DisplayName("기존 텍스트 입력 변수는 기존 방식으로 검증을 통과한다")
+    void 기존_텍스트_입력_변수는_기존_방식으로_검증을_통과한다() {
+        assertThatCode(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("MESSAGE")
+                        .label("메시지")
+                        .inputType(VariableInputType.TEXT)
+                        .required(true)
+                        .build()),
+                Map.of("MESSAGE", "안내 내용")
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("연도가 네 자리보다 길면 입력 변수 오류를 발생시킨다")
+    void 연도가_네_자리보다_길면_입력_변수_오류를_발생시킨다() {
+        assertThatThrownBy(() -> validator.validateVariables(
+                Set.of(MailScenarioVariable.builder()
+                        .key("INTERVIEW_AT")
+                        .label("면접 일시")
+                        .inputType(VariableInputType.DATE_TIME)
+                        .required(true)
+                        .build()),
+                Map.of("INTERVIEW_AT", "+10000-01-01 00:00")
+        ))
+                .isInstanceOf(MailException.class)
+                .extracting("errorCode")
+                .isEqualTo(MailErrorCode.INVALID_VARIABLE_VALUE);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#626

## 📝 작업 내용

- `VariableInputType.DATE_TIME` 입력 타입 추가
- `DATE_TIME` 생성·수정 요청과 템플릿 목록/변수 목록 응답 호환
- `yyyy-MM-dd HH:mm` 형식과 실제 날짜·시간을 엄격하게 검증
- 필수 입력 누락, 선택 입력 빈 값, 선언되지 않은 입력 변수 키 검증
- 미리보기 렌더링 경로가 `MailTemplateValidator.validateVariables`를 사용하도록 연결
- 기존 입력 타입과 enum 문자열 저장 방식 유지
- DB migration 및 배포 설정 변경 없음

### stacked PR

- 부모 PR: #638 (`feat/624-mail-recruit-list`)
- 부모 PR 변경 위에만 쌓은 PR입니다. 부모 PR이 `dev`에 병합되면 base를 `dev`로 변경하고 최신 `dev` 기준 중복 diff를 확인해야 합니다.
- 현재 기준 브랜치에는 별도 실제 발송 API가 없으므로, 후속 발송 경로도 `MailTemplateValidator.validateVariables`를 재사용해야 합니다.

### 검증 결과

- `./gradlew test --tests 'org.ject.support.admin.mail.*' --no-daemon -x jacocoTestCoverageVerification` 통과
- `git diff --check` 통과
- 전체 `./gradlew test`: 582개 중 51개 실패. Docker 미가동으로 `RedisTestContainersConfig` 초기화 실패. 변경 영역 테스트와 무관한 환경 실패입니다.
- Standards/Spec Code Review 완료: P0/P1 없음, P2 보완 완료

## 🙏 리뷰 요구사항 (선택)

- strict 날짜·시간 파싱과 미선언 입력 변수 거부 정책을 확인 부탁드립니다.
