### PR TITLE
hotfix: 이전 지원 이력으로 인한 PIN 인증 오류 해결

### DIFF
--- a/src/main/java/org/ject/support/domain/applicant/dto/ApplicantDto.java
+++ b/src/main/java/org/ject/support/domain/applicant/dto/ApplicantDto.java
@@ -1,6 +1,7 @@
 package org.ject.support.domain.applicant.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import org.ject.support.domain.applicant.entity.Applicant;
 import org.ject.support.domain.member.MemberStatus;
@@ -9,8 +10,8 @@ import org.ject.support.domain.member.Role;
 public class ApplicantDto {
 
     public record RegisterRequest(
-
-            @NotBlank @Pattern(regexp = "^\\d{6}$", message = "PIN 번호는 6자리 숫자여야 합니다.") String pin) {
+            @NotBlank @Pattern(regexp = "^\\d{6}$", message = "PIN 번호는 6자리 숫자여야 합니다.") String pin,
+            @NotNull Long recruitId) {
 
         public Applicant toEntity(Long semesterId, String email, String encodedPin) {
             return Applicant.builder()

--- a/src/main/java/org/ject/support/domain/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/org/ject/support/domain/applicant/repository/ApplicantRepository.java
@@ -11,6 +11,8 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long>, App
 
     Optional<Applicant> findByEmail(String email);
 
+    Optional<Applicant> findByEmailAndSemesterId(String email, Long semesterId);
+
     Optional<Applicant> findByEmailAndRole(String email, Role role);
 
     Optional<Applicant> findByEmailAndRoleIn(String email, Collection<Role> roles);
@@ -18,4 +20,6 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long>, App
     Optional<Applicant> findByIdAndRoleIn(Long id, Collection<Role> roles);
 
     boolean existsByEmail(String email);
+
+    boolean existsByEmailAndSemesterId(String email, Long semesterId);
 }

--- a/src/main/java/org/ject/support/domain/applicant/service/ApplicantService.java
+++ b/src/main/java/org/ject/support/domain/applicant/service/ApplicantService.java
@@ -10,10 +10,7 @@ import org.ject.support.domain.applicant.entity.Applicant;
 import org.ject.support.domain.applicant.exception.ApplicantErrorCode;
 import org.ject.support.domain.applicant.exception.ApplicantException;
 import org.ject.support.domain.applicant.repository.ApplicantRepository;
-import org.ject.support.domain.recruit.domain.Semester;
-import org.ject.support.domain.recruit.exception.SemesterErrorCode;
-import org.ject.support.domain.recruit.exception.SemesterException;
-import org.ject.support.domain.recruit.repository.SemesterRepository;
+import org.ject.support.domain.recruit.service.SemesterInquiryUsecase;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -26,7 +23,7 @@ import static org.ject.support.domain.applicant.exception.ApplicantErrorCode.ALR
 public class ApplicantService {
 
     private final ApplicantRepository applicantRepository;
-    private final SemesterRepository semesterRepository;
+    private final SemesterInquiryUsecase semesterInquiryUsecase;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
 
@@ -37,20 +34,13 @@ public class ApplicantService {
      */
     @Transactional
     public Authentication registerTempApplicant(RegisterRequest registerRequest, String email) {
-        // 이메일로 지원자 조회
-        /**
-         * Todo: 이메일을 단건으로 구분할 수 있는 정책 설정
-         * 기존 Member는 email에 유니크 제약조건 존재, applicant는 이력 의미도 포함하기 때문에 유니크 제약 X
-         * 여러 기수에 지원한 경우 현재 로직대로면 복수 행 응답 가능
-         * 지원데이터는 모집 공고 당 1개만 존재할 수 있음 -> 이메일 조회를 이메일+공고로 조회
-         * applicant에 recruit_id 필요 (값 참조)
-         */
-        Applicant applicant = applicantRepository.findByEmail(email)
+        Long semesterId = semesterInquiryUsecase.getSemesterIdByRecruitId(registerRequest.recruitId());
+        Applicant applicant = applicantRepository.findByEmailAndSemesterId(email, semesterId)
                 .orElse(null);
 
         if (applicant == null) {
             // 새로운 지원자 생성
-            applicant = createTempApplicantWithPin(registerRequest, email);
+            applicant = createTempApplicantWithPin(registerRequest, email, semesterId);
         } else {
             // 기존 지원자가 있는 경우 PIN 번호만 업데이트
             throw new ApplicantException(ALREADY_EXIST_APPLICANT);
@@ -64,13 +54,10 @@ public class ApplicantService {
      * PIN 번호가 설정된 지원자를 생성합니다.
      * PIN 번호는 암호화하여 저장합니다.
      */
-    private Applicant createTempApplicantWithPin(RegisterRequest registerRequest, String email) {
+    private Applicant createTempApplicantWithPin(RegisterRequest registerRequest, String email, Long semesterId) {
         String encodedPin = passwordEncoder.encode(registerRequest.pin());
 
-        Semester semester = semesterRepository.findRecruitingSemester()
-                .orElseThrow(() -> new SemesterException(SemesterErrorCode.NOT_FOUND_RECRUITING_SEMESTER));
-
-        Applicant applicant = registerRequest.toEntity(semester.getId(), email, encodedPin);
+        Applicant applicant = registerRequest.toEntity(semesterId, email, encodedPin);
 
         return applicantRepository.save(applicant);
     }

--- a/src/main/java/org/ject/support/domain/auth/controller/AuthApiSpec.java
+++ b/src/main/java/org/ject/support/domain/auth/controller/AuthApiSpec.java
@@ -49,7 +49,7 @@ public interface AuthApiSpec {
             @ApiErrorResponse(value = AuthErrorCode.class, name = "NOT_FOUND_AUTH_CODE"),
             @ApiErrorResponse(value = EmailErrorCode.class, name = "INVALID_EMAIL_TEMPLATE")
     })
-    boolean verifyAuthCode(@RequestBody AuthDto.VerifyAuthCodeRequest verifyAuthCodeRequest,
+    boolean verifyAuthCode(@Valid @RequestBody AuthDto.VerifyAuthCodeRequest verifyAuthCodeRequest,
                            HttpServletRequest request, HttpServletResponse response,
                            @RequestParam EmailTemplate template);
 
@@ -70,5 +70,5 @@ public interface AuthApiSpec {
     @Operation(
             summary = "이메일 가입 여부 확인",
             description = "입력한 이메일이 이미 가입된 사용자인지 여부를 확인합니다.")
-    boolean isExistMember(@RequestParam String email);
+    boolean isExistMember(@RequestParam String email, @RequestParam Long recruitId);
 }

--- a/src/main/java/org/ject/support/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/ject/support/domain/auth/controller/AuthController.java
@@ -36,12 +36,13 @@ public class AuthController implements AuthApiSpec {
     @Override
     @PostMapping("/code")
     @PreAuthorize("permitAll()")
-    public boolean verifyAuthCode(@RequestBody VerifyAuthCodeRequest verifyAuthCodeRequest,
+    public boolean verifyAuthCode(@Valid @RequestBody VerifyAuthCodeRequest verifyAuthCodeRequest,
                                   HttpServletRequest request, HttpServletResponse response,
                                   @RequestParam EmailTemplate template) {
         // 서비스 레이어에서 템플릿 타입에 따른 인증 검증 결과 반환
         AuthVerificationResult result = authService.verifyAuthCodeByTemplate(
-                verifyAuthCodeRequest.email(), verifyAuthCodeRequest.authCode(), template);
+                verifyAuthCodeRequest.email(), verifyAuthCodeRequest.authCode(),
+                verifyAuthCodeRequest.recruitId(), template);
 
         // 결과에 따라 적절한 응답 처리
         if (result.hasAuthentication()) {
@@ -78,7 +79,8 @@ public class AuthController implements AuthApiSpec {
     @PreAuthorize("permitAll()")
     public boolean loginWithPin(@RequestBody @Valid PinLoginRequest request,
                                 HttpServletRequest httpRequest, HttpServletResponse response) {
-        Authentication authentication = authService.loginWithPin(request.email(), request.pin());
+        Authentication authentication = authService.loginWithPin(
+                request.email(), request.pin(), request.recruitId());
 
         customSuccessHandler.onAuthenticationSuccess(httpRequest, response, authentication);
 
@@ -88,7 +90,7 @@ public class AuthController implements AuthApiSpec {
     @Override
     @GetMapping("/login/exist")
     @PreAuthorize("permitAll()")
-    public boolean isExistMember(@RequestParam String email) {
-        return authService.isExistMember(email);
+    public boolean isExistMember(@RequestParam String email, @RequestParam Long recruitId) {
+        return authService.isExistMember(email, recruitId);
     }
 }

--- a/src/main/java/org/ject/support/domain/auth/dto/AuthDto.java
+++ b/src/main/java/org/ject/support/domain/auth/dto/AuthDto.java
@@ -2,17 +2,22 @@ package org.ject.support.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 public class AuthDto {
 
-    public record VerifyAuthCodeRequest(String email, String authCode) {
+    public record VerifyAuthCodeRequest(
+            String email,
+            String authCode,
+            @NotNull Long recruitId) {
         // 이메일 인증 코드 검증 요청 DTO
     }
 
     public record PinLoginRequest(
-        @NotBlank @Email String email,
-        @NotBlank @Pattern(regexp = "^\\d{6}$", message = "PIN 번호는 6자리 숫자여야 합니다.") String pin) {
+            @NotBlank @Email String email,
+            @NotBlank @Pattern(regexp = "^\\d{6}$", message = "PIN 번호는 6자리 숫자여야 합니다.") String pin,
+            @NotNull Long recruitId) {
         // PIN 로그인 요청 DTO
     }
 

--- a/src/main/java/org/ject/support/domain/auth/service/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/service/AuthService.java
@@ -10,6 +10,7 @@ import org.ject.support.domain.applicant.exception.ApplicantException;
 import org.ject.support.domain.applicant.repository.ApplicantRepository;
 import org.ject.support.domain.auth.dto.AuthVerificationResult;
 import org.ject.support.domain.auth.exception.AuthException;
+import org.ject.support.domain.recruit.service.SemesterInquiryUsecase;
 import org.ject.support.external.email.domain.EmailTemplate;
 import org.ject.support.external.email.exception.EmailErrorCode;
 import org.ject.support.external.email.exception.EmailException;
@@ -34,6 +35,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final ApplicantRepository applicantRepository;
     private final PasswordEncoder passwordEncoder;
+    private final SemesterInquiryUsecase semesterInquiryUsecase;
 
     /**
      * 이메일 템플릿 타입에 따라 인증번호를 검증하고 적절한 결과를 반환합니다.
@@ -44,7 +46,8 @@ public class AuthService {
      * @return 템플릿 타입에 따른 결과 객체 (Authentication 또는 String)
      */
     @Transactional
-    public AuthVerificationResult verifyAuthCodeByTemplate(String email, String authCode, EmailTemplate template) {
+    public AuthVerificationResult verifyAuthCodeByTemplate(
+            String email, String authCode, Long recruitId, EmailTemplate template) {
         if (template == EmailTemplate.AUTH_CODE) {
             // 인증번호 검증 후 이메일 반환
             verifyAuthCode(email, authCode);
@@ -52,7 +55,7 @@ public class AuthService {
             return new AuthVerificationResult(email);
         } else if (template == EmailTemplate.PIN_RESET) {
             // 인증번호 검증 후 Authentication 객체 반환
-            Authentication authentication = verifyEmailByAuthCodeOnly(email, authCode);
+            Authentication authentication = verifyEmailByAuthCodeOnly(email, authCode, recruitId);
             return new AuthVerificationResult(authentication);
         }
 
@@ -66,10 +69,10 @@ public class AuthService {
      * @return 인증된 사용자의 Authentication 객체
      */
 
-    private Authentication verifyEmailByAuthCodeOnly(String email, String userInputCode) {
+    private Authentication verifyEmailByAuthCodeOnly(String email, String userInputCode, Long recruitId) {
         // 인증번호 검증
         verifyAuthCode(email, userInputCode);
-        Applicant applicant = findApplicant(email);
+        Applicant applicant = findApplicant(email, recruitId);
 
         Authentication authentication = jwtTokenProvider.createAuthenticationByApplicant(applicant);
         deleteAuthCode(email);
@@ -85,9 +88,9 @@ public class AuthService {
      * @param pin 사용자 PIN 번호
      */
     @Transactional
-    public Authentication loginWithPin(String email, String pin) {
+    public Authentication loginWithPin(String email, String pin, Long recruitId) {
         // 이메일로 회원 조회
-        Applicant applicant = findApplicant(email);
+        Applicant applicant = findApplicant(email, recruitId);
         
         // PIN 번호 검증
         if (!passwordEncoder.matches(pin, applicant.getPin())) {
@@ -98,9 +101,9 @@ public class AuthService {
         return jwtTokenProvider.createAuthenticationByApplicant(applicant);
     }
 
-    private Applicant findApplicant(String email) {
-        //Todo: Applicant는 이메일 유니크 제약없음(중복 발생) -> 고유하게 식별하도록 추가 개선 필요
-        return applicantRepository.findByEmail(email)
+    private Applicant findApplicant(String email, Long recruitId) {
+        Long semesterId = semesterInquiryUsecase.getSemesterIdByRecruitId(recruitId);
+        return applicantRepository.findByEmailAndSemesterId(email, semesterId)
                 .orElseThrow(() -> new ApplicantException(NOT_FOUND_APPLICANT));
     }
 
@@ -146,8 +149,8 @@ public class AuthService {
         }
     }
 
-    public boolean isExistMember(String email) {
-        //Todo: Applicant는 이메일 유니크 제약없음(중복 발생) -> 고유하게 식별하도록 추가 개선 필요
-        return applicantRepository.existsByEmail(email);
+    public boolean isExistMember(String email, Long recruitId) {
+        Long semesterId = semesterInquiryUsecase.getSemesterIdByRecruitId(recruitId);
+        return applicantRepository.existsByEmailAndSemesterId(email, semesterId);
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/repository/SemesterRepository.java
+++ b/src/main/java/org/ject/support/domain/recruit/repository/SemesterRepository.java
@@ -12,4 +12,7 @@ public interface SemesterRepository extends JpaRepository<Semester, Long>, Semes
     Optional<Semester> findRecruitingSemester();
 
     Optional<Semester> findByName(String name);
+
+    @Query("select r.semester.id from Recruit r where r.id = :recruitId")
+    Optional<Long> findSemesterIdByRecruitId(Long recruitId);
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/SemesterInquiryService.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/SemesterInquiryService.java
@@ -7,6 +7,8 @@ import org.ject.support.domain.recruit.dto.SemesterResponse;
 import org.ject.support.domain.recruit.dto.SemesterResponses;
 import org.ject.support.domain.recruit.exception.SemesterErrorCode;
 import org.ject.support.domain.recruit.exception.SemesterException;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -34,5 +36,12 @@ public class SemesterInquiryService implements SemesterInquiryUsecase {
             () -> new SemesterException(SemesterErrorCode.NOT_FOUND_SEMESTER)
         );
         return SemesterResponse.from(semester);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Long getSemesterIdByRecruitId(Long recruitId) {
+        return semesterRepository.findSemesterIdByRecruitId(recruitId)
+                .orElseThrow(() -> new RecruitException(RecruitErrorCode.NOT_FOUND_RECRUIT));
     }
 }

--- a/src/main/java/org/ject/support/domain/recruit/service/SemesterInquiryUsecase.java
+++ b/src/main/java/org/ject/support/domain/recruit/service/SemesterInquiryUsecase.java
@@ -12,4 +12,6 @@ public interface SemesterInquiryUsecase {
     SemesterResponses getAllSemesters();
 
     SemesterResponse getSemester(Long id);
+
+    Long getSemesterIdByRecruitId(Long recruitId);
 }

--- a/src/test/java/org/ject/support/domain/applicant/controller/ApplicantControllerTest.java
+++ b/src/test/java/org/ject/support/domain/applicant/controller/ApplicantControllerTest.java
@@ -58,6 +58,7 @@ class ApplicantControllerTest {
     private final String TEST_PHONE_NUMBER = "01012345678";
     private final String TEST_PIN = "123456";
     private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
+    private final Long TEST_RECRUIT_ID = 22L;
 
     @BeforeEach
     void setUp() {
@@ -68,7 +69,7 @@ class ApplicantControllerTest {
     @Test
     void 지원자_등록_성공() throws Exception {
         // given
-        RegisterRequest request = new RegisterRequest(TEST_PIN);
+        RegisterRequest request = new RegisterRequest(TEST_PIN, TEST_RECRUIT_ID);
         Authentication mockAuthentication = new UsernamePasswordAuthenticationToken(
                 new CustomUserDetails(TEST_EMAIL, 1L, Role.APPLY), "", null);
 

--- a/src/test/java/org/ject/support/domain/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/org/ject/support/domain/applicant/service/ApplicantServiceTest.java
@@ -14,8 +14,7 @@ import org.ject.support.domain.member.CareerDetails;
 import org.ject.support.domain.member.ExperiencePeriod;
 import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.domain.member.Region;
-import org.ject.support.domain.recruit.domain.Semester;
-import org.ject.support.domain.recruit.repository.SemesterRepository;
+import org.ject.support.domain.recruit.service.SemesterInquiryUsecase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -50,13 +49,15 @@ class ApplicantServiceTest extends UnitTestSupport {
     private Authentication authentication;
 
     @Mock
-    private SemesterRepository semesterRepository;
+    private SemesterInquiryUsecase semesterInquiryUsecase;
 
     private final String TEST_NAME = "홍길동";
     private final String TEST_EMAIL = "test@example.com";
     private final String TEST_PHONE_NUMBER = "01012345678";
     private final String TEST_PIN = "123456";
     private final String TEST_ENCODED_PIN = "encoded_pin";
+    private final Long TEST_RECRUIT_ID = 22L;
+    private final Long TEST_SEMESTER_ID = 5L;
 
     @BeforeEach
     void setUp() {
@@ -66,24 +67,20 @@ class ApplicantServiceTest extends UnitTestSupport {
     @Test
     void 임시_지원자_등록_성공() {
         // given
-        RegisterRequest request = new RegisterRequest(TEST_PIN);
+        RegisterRequest request = new RegisterRequest(TEST_PIN, TEST_RECRUIT_ID);
         Applicant applicant = Applicant.builder()
                 .id(1L)
                 .email(TEST_EMAIL)
                 .pin(TEST_ENCODED_PIN)
                 .status(MemberStatus.ACTIVE)
                 .build();
-        Semester semester = Semester.builder()
-                .id(1L)
-                .name("1기")
-                .isRecruiting(true)
-                .build();
-
-        given(applicantRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.empty());
+        given(semesterInquiryUsecase.getSemesterIdByRecruitId(TEST_RECRUIT_ID))
+                .willReturn(TEST_SEMESTER_ID);
+        given(applicantRepository.findByEmailAndSemesterId(TEST_EMAIL, TEST_SEMESTER_ID))
+                .willReturn(Optional.empty());
         given(passwordEncoder.encode(TEST_PIN)).willReturn(TEST_ENCODED_PIN);
         given(applicantRepository.save(any(Applicant.class))).willReturn(applicant);
         given(jwtTokenProvider.createAuthenticationByApplicant(any(Applicant.class))).willReturn(authentication);
-        given(semesterRepository.findRecruitingSemester()).willReturn(Optional.of(semester));
 
         // when
         Authentication result = applicantService.registerTempApplicant(request, TEST_EMAIL);
@@ -98,14 +95,17 @@ class ApplicantServiceTest extends UnitTestSupport {
     @Test
     void 이미_존재하는_지원자인_경우_예외_발생() {
         // given
-        RegisterRequest request = new RegisterRequest(TEST_PIN);
+        RegisterRequest request = new RegisterRequest(TEST_PIN, TEST_RECRUIT_ID);
         Applicant existingApplicant = Applicant.builder()
                 .email(TEST_EMAIL)
                 .pin(TEST_ENCODED_PIN)
                 .status(MemberStatus.ACTIVE)
                 .build();
 
-        given(applicantRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(existingApplicant));
+        given(semesterInquiryUsecase.getSemesterIdByRecruitId(TEST_RECRUIT_ID))
+                .willReturn(TEST_SEMESTER_ID);
+        given(applicantRepository.findByEmailAndSemesterId(TEST_EMAIL, TEST_SEMESTER_ID))
+                .willReturn(Optional.of(existingApplicant));
 
         // when & then
         assertThatThrownBy(() -> applicantService.registerTempApplicant(request, TEST_EMAIL))

--- a/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
@@ -59,43 +59,48 @@ class AuthControllerTest extends UnitTestSupport {
     private final String TEST_AUTH_CODE = "123456";
     private final String TEST_REFRESH_TOKEN = "test.refresh.token";
     private final Long TEST_APPLICANT_ID = 1L;
+    private final Long TEST_RECRUIT_ID = 22L;
 
     @Test
     void 인증_코드_검증_AUTH_CODE_템플릿_이메일만_반환_성공() {
         // given
-        VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE);
+        VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID);
         EmailTemplate template = EmailTemplate.AUTH_CODE;
         
         AuthVerificationResult mockResult = new AuthVerificationResult(TEST_EMAIL);
         
-        given(authService.verifyAuthCodeByTemplate(request.email(), request.authCode(), template))
+        given(authService.verifyAuthCodeByTemplate(
+                request.email(), request.authCode(), request.recruitId(), template))
             .willReturn(mockResult);
 
         // when
         authController.verifyAuthCode(request, mock(HttpServletRequest.class), mock(HttpServletResponse.class), template);
 
         // then
-        verify(authService).verifyAuthCodeByTemplate(eq(TEST_EMAIL), eq(TEST_AUTH_CODE), eq(template));
+        verify(authService).verifyAuthCodeByTemplate(
+                eq(TEST_EMAIL), eq(TEST_AUTH_CODE), eq(TEST_RECRUIT_ID), eq(template));
         verify(customSuccessHandler).onAuthenticationSuccess(any(HttpServletResponse.class), eq(TEST_EMAIL));
     }
     
     @Test
     void 인증_코드_검증_PIN_RESET_템플릿_인증_토큰_발급_성공() {
         // given
-        VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE);
+        VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID);
         EmailTemplate template = EmailTemplate.PIN_RESET;
         
         Authentication mockAuthentication = mock(Authentication.class);
         AuthVerificationResult mockResult = new AuthVerificationResult(mockAuthentication);
         
-        given(authService.verifyAuthCodeByTemplate(request.email(), request.authCode(), template))
+        given(authService.verifyAuthCodeByTemplate(
+                request.email(), request.authCode(), request.recruitId(), template))
             .willReturn(mockResult);
 
         // when
         authController.verifyAuthCode(request, mock(HttpServletRequest.class), mock(HttpServletResponse.class), template);
 
         // then
-        verify(authService).verifyAuthCodeByTemplate(TEST_EMAIL, TEST_AUTH_CODE, template);
+        verify(authService).verifyAuthCodeByTemplate(
+                TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID, template);
         verify(customSuccessHandler).onAuthenticationSuccess(any(HttpServletRequest.class), any(HttpServletResponse.class), eq(mockAuthentication));
     }
     
@@ -119,33 +124,33 @@ class AuthControllerTest extends UnitTestSupport {
     @Test
     void PIN_로그인_성공() {
         // given
-        PinLoginRequest request = new PinLoginRequest(TEST_EMAIL, TEST_AUTH_CODE);
+        PinLoginRequest request = new PinLoginRequest(TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID);
         HttpServletRequest mockRequest = mock(HttpServletRequest.class);
         HttpServletResponse mockResponse = mock(HttpServletResponse.class);
         Authentication mockAuthentication = mock(Authentication.class);
         
-        given(authService.loginWithPin(request.email(), request.pin()))
+        given(authService.loginWithPin(request.email(), request.pin(), request.recruitId()))
             .willReturn(mockAuthentication);
 
         // when
         authController.loginWithPin(request, mockRequest, mockResponse);
 
         // then
-        verify(authService).loginWithPin(TEST_EMAIL, TEST_AUTH_CODE);
+        verify(authService).loginWithPin(TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID);
         verify(customSuccessHandler).onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
     }
     
     @Test
     void 회원_존재_여부_확인_성공() {
         // given
-        given(authService.isExistMember(TEST_EMAIL))
+        given(authService.isExistMember(TEST_EMAIL, TEST_RECRUIT_ID))
             .willReturn(true);
 
         // when
-        boolean result = authController.isExistMember(TEST_EMAIL);
+        boolean result = authController.isExistMember(TEST_EMAIL, TEST_RECRUIT_ID);
 
         // then
-        verify(authService).isExistMember(TEST_EMAIL);
+        verify(authService).isExistMember(TEST_EMAIL, TEST_RECRUIT_ID);
         org.assertj.core.api.Assertions.assertThat(result).isTrue();
     }
 }
@@ -170,12 +175,13 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
     private final String TEST_EMAIL = "test@example.com";
     private final String TEST_AUTH_CODE = "123456";
     private final String TEST_REFRESH_TOKEN = "test.refresh.token";
+    private final Long TEST_RECRUIT_ID = 22L;
     
     @Test
     @DisplayName("인증 코드 검증 API - 인증 없이 접근 가능 및 쿠키 발급 테스트")
     void verifyAuthCode_WithPermitAll_ShouldAllowAccessAndSetCookies() throws Exception {
         // given
-        VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE);
+        VerifyAuthCodeRequest request = new VerifyAuthCodeRequest(TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID);
         
         // Redis에서 인증 코드를 반환하도록 설정
         when(valueOperations.get(TEST_EMAIL)).thenReturn(TEST_AUTH_CODE);
@@ -184,7 +190,8 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
         // PIN_RESET 템플릿은 Authentication 객체 반환
         Authentication mockAuthentication = mock(Authentication.class);
         AuthVerificationResult mockResult = new AuthVerificationResult(mockAuthentication);
-        given(authService.verifyAuthCodeByTemplate(TEST_EMAIL, TEST_AUTH_CODE, EmailTemplate.PIN_RESET))
+        given(authService.verifyAuthCodeByTemplate(
+                TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID, EmailTemplate.PIN_RESET))
             .willReturn(mockResult);
         
         // 쿠키 발급을 위한 모킹 설정
@@ -213,7 +220,7 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
     @DisplayName("@PreAuthorize(\"hasRole('ROLE_APPLY')\") 설정으로 인증이 필요한지 확인")
     void refreshToken_WithRoleTemp_ShouldRequireAuthentication() throws Exception {
         // given
-        PinLoginRequest request = new PinLoginRequest("test@email.com", "123456");
+        PinLoginRequest request = new PinLoginRequest("test@email.com", "123456", TEST_RECRUIT_ID);
 
         // when & then
         mockMvc.perform(post("/auth/login/pin")
@@ -226,7 +233,7 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
     @DisplayName("PIN 로그인 API 인증 없이 접근 가능한지 확인")
     void loginWithPin_WithPermitAll_ShouldAllowAccessWithoutAuthentication() throws Exception {
         // given
-        PinLoginRequest request = new PinLoginRequest(TEST_EMAIL, TEST_AUTH_CODE);
+        PinLoginRequest request = new PinLoginRequest(TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID);
         
         // when & then
         // 인증 없이 접근 가능한지 확인 (permitAll 설정)
@@ -241,7 +248,9 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
     void isExistMember_WithPermitAll_ShouldAllowAccessWithoutAuthentication() throws Exception {
         // when & then
         // 인증 없이 접근 가능한지 확인 (permitAll 설정)
-        mockMvc.perform(get("/auth/login/exist?email=" + TEST_EMAIL)
+        mockMvc.perform(get("/auth/login/exist")
+                .param("email", TEST_EMAIL)
+                .param("recruitId", String.valueOf(TEST_RECRUIT_ID))
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }

--- a/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import org.ject.support.domain.applicant.entity.Applicant;
 import org.ject.support.domain.applicant.exception.ApplicantException;
 import org.ject.support.domain.applicant.repository.ApplicantRepository;
+import org.ject.support.domain.recruit.service.SemesterInquiryUsecase;
 import org.ject.support.domain.member.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -67,6 +68,9 @@ class AuthServiceTest {
     @Mock
     private org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
 
+    @Mock
+    private SemesterInquiryUsecase semesterInquiryUsecase;
+
     private final String TEST_EMAIL = "test@example.com";
     private final String TEST_AUTH_CODE = "123456";
     private final String TEST_VERIFICATION_TOKEN = "test.verification.token";
@@ -75,10 +79,14 @@ class AuthServiceTest {
     private final String TEST_ACCESS_TOKEN = "test.access.token";
     private final String TEST_REFRESH_TOKEN = "test.refresh.token";
     private final Long TEST_APPLICANT_ID = 1L;
+    private final Long TEST_RECRUIT_ID = 22L;
+    private final Long TEST_SEMESTER_ID = 5L;
 
     @BeforeEach
     void setUp() {
         lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        lenient().when(semesterInquiryUsecase.getSemesterIdByRecruitId(TEST_RECRUIT_ID))
+                .thenReturn(TEST_SEMESTER_ID);
     }
 
     @Test
@@ -94,12 +102,14 @@ class AuthServiceTest {
                 .build();
         
         given(valueOperations.get(TEST_EMAIL)).willReturn(TEST_AUTH_CODE);
-        given(applicantRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(applicant));
+        given(applicantRepository.findByEmailAndSemesterId(TEST_EMAIL, TEST_SEMESTER_ID))
+                .willReturn(Optional.of(applicant));
         given(jwtTokenProvider.createAuthenticationByApplicant(applicant)).willReturn(authentication);
         given(jwtTokenProvider.createAccessToken(authentication, TEST_APPLICANT_ID)).willReturn(TEST_ACCESS_TOKEN);
 
         // when
-        AuthVerificationResult result = authService.verifyAuthCodeByTemplate(TEST_EMAIL, TEST_AUTH_CODE, EmailTemplate.PIN_RESET);
+        AuthVerificationResult result = authService.verifyAuthCodeByTemplate(
+                TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID, EmailTemplate.PIN_RESET);
 
         // then
         assertThat(result).isNotNull();
@@ -174,14 +184,15 @@ class AuthServiceTest {
                 .status(MemberStatus.ACTIVE)
                 .build();
         
-        given(applicantRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(applicant));
+        given(applicantRepository.findByEmailAndSemesterId(TEST_EMAIL, TEST_SEMESTER_ID))
+                .willReturn(Optional.of(applicant));
         given(passwordEncoder.matches(TEST_PIN, TEST_ENCODED_PIN)).willReturn(true);
         given(jwtTokenProvider.createAuthenticationByApplicant(applicant)).willReturn(authentication);
         given(jwtTokenProvider.createAccessToken(authentication, TEST_APPLICANT_ID)).willReturn(TEST_ACCESS_TOKEN);
         given(jwtTokenProvider.createRefreshToken(authentication, applicant.getId())).willReturn(TEST_REFRESH_TOKEN);
         
         // when
-        Authentication result = authService.loginWithPin(TEST_EMAIL, TEST_PIN);
+        Authentication result = authService.loginWithPin(TEST_EMAIL, TEST_PIN, TEST_RECRUIT_ID);
         
         // then
         assertThat(result).isEqualTo(authentication);
@@ -191,10 +202,11 @@ class AuthServiceTest {
     @DisplayName("PIN 로그인 실패 - 회원 없음")
     void loginWithPin_MemberNotFound_ThrowsException() {
         // given
-        given(applicantRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.empty());
+        given(applicantRepository.findByEmailAndSemesterId(TEST_EMAIL, TEST_SEMESTER_ID))
+                .willReturn(Optional.empty());
         
         // when & then
-        assertThatThrownBy(() -> authService.loginWithPin(TEST_EMAIL, TEST_PIN))
+        assertThatThrownBy(() -> authService.loginWithPin(TEST_EMAIL, TEST_PIN, TEST_RECRUIT_ID))
             .isInstanceOf(ApplicantException.class)
             .extracting(e -> ((ApplicantException) e).getErrorCode())
             .isEqualTo(NOT_FOUND_APPLICANT);
@@ -212,11 +224,12 @@ class AuthServiceTest {
                 .status(MemberStatus.ACTIVE)
                 .build();
         
-        given(applicantRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(applicant));
+        given(applicantRepository.findByEmailAndSemesterId(TEST_EMAIL, TEST_SEMESTER_ID))
+                .willReturn(Optional.of(applicant));
         given(passwordEncoder.matches(TEST_PIN, TEST_ENCODED_PIN)).willReturn(false);
         
         // when & then
-        assertThatThrownBy(() -> authService.loginWithPin(TEST_EMAIL, TEST_PIN))
+        assertThatThrownBy(() -> authService.loginWithPin(TEST_EMAIL, TEST_PIN, TEST_RECRUIT_ID))
             .isInstanceOf(AuthException.class)
             .extracting(e -> ((AuthException) e).getErrorCode())
             .isEqualTo(INVALID_CREDENTIALS);
@@ -226,10 +239,10 @@ class AuthServiceTest {
     @DisplayName("회원 존재 여부 확인 - 회원 존재")
     void isExistMember_MemberExists_ReturnsTrue() {
         // given
-        given(applicantRepository.existsByEmail(TEST_EMAIL)).willReturn(true);
+        given(applicantRepository.existsByEmailAndSemesterId(TEST_EMAIL, TEST_SEMESTER_ID)).willReturn(true);
         
         // when
-        boolean result = authService.isExistMember(TEST_EMAIL);
+        boolean result = authService.isExistMember(TEST_EMAIL, TEST_RECRUIT_ID);
         
         // then
         assertThat(result).isTrue();
@@ -239,10 +252,10 @@ class AuthServiceTest {
     @DisplayName("회원 존재 여부 확인 - 회원 없음")
     void isExistMember_MemberNotExists_ReturnsFalse() {
         // given
-        given(applicantRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
+        given(applicantRepository.existsByEmailAndSemesterId(TEST_EMAIL, TEST_SEMESTER_ID)).willReturn(false);
         
         // when
-        boolean result = authService.isExistMember(TEST_EMAIL);
+        boolean result = authService.isExistMember(TEST_EMAIL, TEST_RECRUIT_ID);
         
         // then
         assertThat(result).isFalse();
@@ -255,7 +268,8 @@ class AuthServiceTest {
         given(redisTemplate.opsForValue().get(TEST_EMAIL)).willReturn(TEST_AUTH_CODE);
         
         // when
-        AuthVerificationResult result = authService.verifyAuthCodeByTemplate(TEST_EMAIL, TEST_AUTH_CODE, EmailTemplate.AUTH_CODE);
+        AuthVerificationResult result = authService.verifyAuthCodeByTemplate(
+                TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID, EmailTemplate.AUTH_CODE);
         
         // then
         assertThat(result).isNotNull();
@@ -278,12 +292,14 @@ class AuthServiceTest {
                 .build();
         Authentication mockAuthentication = mock(Authentication.class);
         
-        given(applicantRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(applicant));
+        given(applicantRepository.findByEmailAndSemesterId(TEST_EMAIL, TEST_SEMESTER_ID))
+                .willReturn(Optional.of(applicant));
         given(redisTemplate.opsForValue().get(TEST_EMAIL)).willReturn(TEST_AUTH_CODE);
         given(jwtTokenProvider.createAuthenticationByApplicant(any(Applicant.class))).willReturn(mockAuthentication);
         
         // when
-        AuthVerificationResult result = authService.verifyAuthCodeByTemplate(TEST_EMAIL, TEST_AUTH_CODE, EmailTemplate.PIN_RESET);
+        AuthVerificationResult result = authService.verifyAuthCodeByTemplate(
+                TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID, EmailTemplate.PIN_RESET);
         
         // then
         assertThat(result).isNotNull();
@@ -303,7 +319,7 @@ class AuthServiceTest {
         
         // when & then
         assertThatThrownBy(() -> 
-            authService.verifyAuthCodeByTemplate(TEST_EMAIL, TEST_AUTH_CODE, invalidTemplate)
+            authService.verifyAuthCodeByTemplate(TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID, invalidTemplate)
         ).isInstanceOf(EmailException.class)
          .hasFieldOrPropertyWithValue("errorCode", EmailErrorCode.INVALID_EMAIL_TEMPLATE);
     }

--- a/src/test/java/org/ject/support/domain/recruit/repository/RecruitRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/repository/RecruitRepositoryTest.java
@@ -33,6 +33,26 @@ class RecruitRepositoryTest {
     private SemesterRepository semesterRepository;
 
     @Test
+    void 모집_공고에_연결된_기수를_조회한다() {
+        // given
+        Semester savedSemester = semesterRepository.save(
+                Semester.builder().name("5기").isRecruiting(true).build());
+        Recruit savedRecruit = recruitRepository.save(Recruit.builder()
+                .semester(savedSemester)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .jobFamily(BE)
+                .build());
+
+        // when
+        Long semesterId = semesterRepository.findSemesterIdByRecruitId(savedRecruit.getId())
+                .orElseThrow();
+
+        // then
+        assertThat(semesterId).isEqualTo(savedSemester.getId());
+    }
+
+    @Test
     void 특정_직군의_마감되지_않은_모집_정보가_존재하면_true를_반환한다() {
         // given
         Semester savedSemester = semesterRepository.save(Semester.builder().name("3기").isRecruiting(true).build());

--- a/src/test/java/org/ject/support/domain/recruit/service/SemesterInquiryServiceTest.java
+++ b/src/test/java/org/ject/support/domain/recruit/service/SemesterInquiryServiceTest.java
@@ -9,6 +9,8 @@ import org.ject.support.domain.recruit.domain.Semester;
 import org.ject.support.domain.recruit.dto.SemesterResponse;
 import org.ject.support.domain.recruit.exception.SemesterErrorCode;
 import org.ject.support.domain.recruit.exception.SemesterException;
+import org.ject.support.domain.recruit.exception.RecruitErrorCode;
+import org.ject.support.domain.recruit.exception.RecruitException;
 import org.ject.support.domain.recruit.repository.SemesterRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +27,41 @@ class SemesterInquiryServiceTest {
 
     @InjectMocks
     private SemesterInquiryService semesterInquiryService;
+
+    @Test
+    @DisplayName("모집 공고에 연결된 기수 ID를 조회한다")
+    void 모집_공고에_연결된_기수_ID를_조회한다() {
+        // given
+        Long recruitId = 22L;
+        Long semesterId = 5L;
+        given(semesterRepository.findSemesterIdByRecruitId(recruitId))
+                .willReturn(Optional.of(semesterId));
+
+        // when
+        Long result = semesterInquiryService.getSemesterIdByRecruitId(recruitId);
+
+        // then
+        assertThat(result).isEqualTo(semesterId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모집 공고로 기수를 조회하면 예외가 발생한다")
+    void 존재하지_않는_모집_공고로_기수를_조회하면_예외가_발생한다() {
+        // given
+        Long recruitId = 22L;
+        given(semesterRepository.findSemesterIdByRecruitId(recruitId))
+                .willReturn(Optional.empty());
+
+        // when
+        Throwable throwable = catchThrowable(
+                () -> semesterInquiryService.getSemesterIdByRecruitId(recruitId));
+
+        // then
+        assertThat(throwable)
+                .isInstanceOf(RecruitException.class)
+                .extracting("errorCode")
+                .isEqualTo(RecruitErrorCode.NOT_FOUND_RECRUIT);
+    }
 
     @Test
     @DisplayName("기수 ID로 기수를 조회한다")


### PR DESCRIPTION
## #️⃣연관된 이슈

#640

## 📝 작업 내용

### 문제

- 이메일만으로 지원자를 조회해 이전 기수의 지원 정보가 선택됨
- 이전 기수의 PIN을 요구하거나, 인증 후 종료된 모집공고를 조회해 지원이 불가능했음

### 조치

- PIN 인증 관련 요청에 `recruitId`를 필수로 추가
- `recruitId`로 기수를 확인한 뒤 `email + semesterId`로 지원자를 식별하도록 변경

### 변경 후 동작

- 현재 기수 지원 이력이 없으면 신규 이메일 인증 및 PIN 설정 진행
- 현재 기수 지원 이력이 있으면 해당 기수의 PIN으로 로그인
- 이전 기수의 지원 정보와 충돌하지 않고 현재 모집공고로 지원 가능

## API 계약 변경

| 엔드포인트 | AS-IS | TO-BE |
|---|---|---|
| `GET /auth/login/exist` | `email` | `email`, `recruitId` |
| `POST /auth/code` | `{ email, authCode }` | `{ email, authCode, recruitId }` |
| `POST /auth/login/pin` | `{ email, pin }` | `{ email, pin, recruitId }` |
| `POST /applicants/apply` | `{ pin }` | `{ pin, recruitId }` |

모집 초기로 기존 지원자의 재지원 가능성이 낮다고 판단해 하위 호환은 제공하지 않고, `recruitId`를 필수값으로 변경했습니다. 기존 프론트 요청은 `400 Bad Request`가 발생하므로 프론트엔드와 함께 배포해야 합니다.
