### PR TITLE
hotfix: 다른 공고 지원 중 PIN 로그인 충돌 처리

### DIFF
--- a/src/main/java/org/ject/support/domain/apply/exception/ApplyErrorCode.java
+++ b/src/main/java/org/ject/support/domain/apply/exception/ApplyErrorCode.java
@@ -17,7 +17,8 @@ public enum ApplyErrorCode implements ErrorCode {
     NOT_FOUND_TEMP_APPLICATION_FORM(NOT_FOUND, "APPLY-3", "임시 저장한 지원서가 존재하지 않습니다."),
     NOT_FOUND_SUBMITTED_APPLICATION_FORM(NOT_FOUND, "APPLY-4", "제출된 지원서가 존재하지 않습니다."),
     NOT_SUBMITTED(CONFLICT, "APPLY-5", "제출 완료된 지원서가 아닙니다."),
-    PORTFOLIO_REQUIRED(BAD_REQUEST, "APPLY-6", "포트폴리오를 필수로 제출해야 합니다.")
+    PORTFOLIO_REQUIRED(BAD_REQUEST, "APPLY-6", "포트폴리오를 필수로 제출해야 합니다."),
+    APPLY_EXISTS_IN_OTHER_RECRUIT(CONFLICT, "APPLY-12", "다른 공고에서 작성 중인 지원서가 있습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ject/support/domain/apply/repository/ApplyRepository.java
@@ -28,6 +28,9 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
                                                            @Param("recruitId") Long recruitId,
                                                            @Param("now") LocalDateTime now);
 
+    @Query("select a.recruit.id from Apply a where a.applicant.id = :applicantId")
+    Optional<Long> findRecruitIdByApplicantId(@Param("applicantId") Long applicantId);
+
     List<Apply> findByRecruitAndStatus(Recruit recruit, ApplyStatus status);
 
     @Query("select a from Apply a join fetch a.applicant m where a.id = :applyId and a.status = :status")

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyQueryService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyQueryService.java
@@ -1,0 +1,8 @@
+package org.ject.support.domain.apply.service;
+
+import java.util.Optional;
+
+public interface ApplyQueryService {
+
+    Optional<Long> getRecruitIdByApplicantId(Long applicantId);
+}

--- a/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ject/support/domain/apply/service/ApplyService.java
@@ -46,7 +46,7 @@ import static org.ject.support.domain.apply.exception.ApplyErrorCode.NOT_FOUND_A
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ApplyService implements ApplyUsecase {
+public class ApplyService implements ApplyUsecase, ApplyQueryService {
     private static final int RECRUIT_ID_PARAMETER_INDEX = 1;
 
     private final RecruitRepository recruitRepository;
@@ -55,6 +55,12 @@ public class ApplyService implements ApplyUsecase {
     private final ApplicantRepository applicantRepository;
     private final Map2JsonSerializer map2JsonSerializer;
     private final String2MapSerializer string2MapSerializer;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<Long> getRecruitIdByApplicantId(Long applicantId) {
+        return applyRepository.findRecruitIdByApplicantId(applicantId);
+    }
 
     @Override
     @PeriodAccessible(recruitIdParameterIndex = RECRUIT_ID_PARAMETER_INDEX)

--- a/src/main/java/org/ject/support/domain/auth/service/AuthService.java
+++ b/src/main/java/org/ject/support/domain/auth/service/AuthService.java
@@ -10,6 +10,8 @@ import org.ject.support.domain.applicant.exception.ApplicantException;
 import org.ject.support.domain.applicant.repository.ApplicantRepository;
 import org.ject.support.domain.auth.dto.AuthVerificationResult;
 import org.ject.support.domain.auth.exception.AuthException;
+import org.ject.support.domain.apply.exception.ApplyException;
+import org.ject.support.domain.apply.service.ApplyQueryService;
 import org.ject.support.domain.recruit.service.SemesterInquiryUsecase;
 import org.ject.support.external.email.domain.EmailTemplate;
 import org.ject.support.external.email.exception.EmailErrorCode;
@@ -26,6 +28,7 @@ import static org.ject.support.domain.auth.exception.AuthErrorCode.INVALID_CREDE
 import static org.ject.support.domain.auth.exception.AuthErrorCode.INVALID_REFRESH_TOKEN;
 import static org.ject.support.domain.auth.exception.AuthErrorCode.NOT_FOUND_AUTH_CODE;
 import static org.ject.support.domain.applicant.exception.ApplicantErrorCode.NOT_FOUND_APPLICANT;
+import static org.ject.support.domain.apply.exception.ApplyErrorCode.APPLY_EXISTS_IN_OTHER_RECRUIT;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +39,7 @@ public class AuthService {
     private final ApplicantRepository applicantRepository;
     private final PasswordEncoder passwordEncoder;
     private final SemesterInquiryUsecase semesterInquiryUsecase;
+    private final ApplyQueryService applyQueryService;
 
     /**
      * 이메일 템플릿 타입에 따라 인증번호를 검증하고 적절한 결과를 반환합니다.
@@ -96,6 +100,12 @@ public class AuthService {
         if (!passwordEncoder.matches(pin, applicant.getPin())) {
             throw new AuthException(INVALID_CREDENTIALS);
         }
+
+        applyQueryService.getRecruitIdByApplicantId(applicant.getId())
+                .filter(existingRecruitId -> !existingRecruitId.equals(recruitId))
+                .ifPresent(existingRecruitId -> {
+                    throw new ApplyException(APPLY_EXISTS_IN_OTHER_RECRUIT);
+                });
         
         // 인증 및 토큰 발급
         return jwtTokenProvider.createAuthenticationByApplicant(applicant);

--- a/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/apply/repository/ApplyRepositoryTest.java
@@ -153,6 +153,21 @@ class ApplyRepositoryTest {
     }
 
     @Test
+    void 지원자가_작성한_공고_ID를_조회한다() {
+        // given
+        Applicant applicant = createApplicant("email@test.com", Role.APPLY);
+        applicantRepository.save(applicant);
+
+        applyRepository.save(getApply(applicant, beRecruit, TEMP_SAVED));
+
+        // when
+        Long result = applyRepository.findRecruitIdByApplicantId(applicant.getId()).orElseThrow();
+
+        // then
+        assertThat(result).isEqualTo(beRecruit.getId());
+    }
+
+    @Test
     void 지원ID와_지원서의_상태로_지원서를_상세_조회한다() {
         // given
         Applicant feApplicant = createApplicant("emailFE@test.com", Role.APPLY);

--- a/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthControllerTest.java
@@ -11,6 +11,8 @@ import static org.mockito.BDDMockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.ject.support.domain.apply.exception.ApplyErrorCode.APPLY_EXISTS_IN_OTHER_RECRUIT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
@@ -25,6 +27,7 @@ import org.ject.support.domain.auth.dto.AuthDto.TokenRefreshRequest;
 import org.ject.support.domain.auth.dto.AuthDto.VerifyAuthCodeRequest;
 import org.ject.support.domain.auth.dto.AuthVerificationResult;
 import org.ject.support.domain.auth.service.AuthService;
+import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.external.email.domain.EmailTemplate;
 import org.ject.support.testconfig.ApplicationPeriodTest;
 import org.junit.jupiter.api.DisplayName;
@@ -241,6 +244,24 @@ class AuthControllerIntegrationTest extends ApplicationPeriodTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("다른 공고에 지원서가 있으면 명확한 충돌 응답을 반환한다")
+    void 다른_공고에_지원서가_있으면_명확한_충돌_응답을_반환한다() throws Exception {
+        // given
+        PinLoginRequest request = new PinLoginRequest(TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID);
+        given(authService.loginWithPin(TEST_EMAIL, TEST_AUTH_CODE, TEST_RECRUIT_ID))
+                .willThrow(new ApplyException(APPLY_EXISTS_IN_OTHER_RECRUIT));
+
+        // when & then
+        mockMvc.perform(post("/auth/login/pin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value("APPLY-12"))
+                .andExpect(jsonPath("$.data[0]")
+                        .value("다른 공고에서 작성 중인 지원서가 있습니다."));
     }
     
     @Test

--- a/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
+++ b/src/test/java/org/ject/support/domain/auth/AuthServiceTest.java
@@ -6,9 +6,11 @@ import static org.ject.support.domain.auth.exception.AuthErrorCode.EXPIRED_REFRE
 import static org.ject.support.domain.auth.exception.AuthErrorCode.INVALID_REFRESH_TOKEN;
 import static org.ject.support.domain.auth.exception.AuthErrorCode.INVALID_CREDENTIALS;
 import static org.ject.support.domain.applicant.exception.ApplicantErrorCode.NOT_FOUND_APPLICANT;
+import static org.ject.support.domain.apply.exception.ApplyErrorCode.APPLY_EXISTS_IN_OTHER_RECRUIT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.mock;
 
 import io.jsonwebtoken.ExpiredJwtException;
@@ -16,7 +18,9 @@ import io.jsonwebtoken.JwtException;
 import org.ject.support.common.security.jwt.JwtTokenProvider;
 import org.ject.support.domain.auth.dto.AuthVerificationResult;
 import org.ject.support.domain.auth.exception.AuthException;
+import org.ject.support.domain.apply.exception.ApplyException;
 import org.ject.support.domain.auth.service.AuthService;
+import org.ject.support.domain.apply.service.ApplyQueryService;
 import org.ject.support.domain.member.MemberStatus;
 import org.ject.support.external.email.domain.EmailTemplate;
 import org.ject.support.external.email.exception.EmailErrorCode;
@@ -70,6 +74,9 @@ class AuthServiceTest {
 
     @Mock
     private SemesterInquiryUsecase semesterInquiryUsecase;
+
+    @Mock
+    private ApplyQueryService applyQueryService;
 
     private final String TEST_EMAIL = "test@example.com";
     private final String TEST_AUTH_CODE = "123456";
@@ -187,6 +194,7 @@ class AuthServiceTest {
         given(applicantRepository.findByEmailAndSemesterId(TEST_EMAIL, TEST_SEMESTER_ID))
                 .willReturn(Optional.of(applicant));
         given(passwordEncoder.matches(TEST_PIN, TEST_ENCODED_PIN)).willReturn(true);
+        given(applyQueryService.getRecruitIdByApplicantId(TEST_APPLICANT_ID)).willReturn(Optional.empty());
         given(jwtTokenProvider.createAuthenticationByApplicant(applicant)).willReturn(authentication);
         given(jwtTokenProvider.createAccessToken(authentication, TEST_APPLICANT_ID)).willReturn(TEST_ACCESS_TOKEN);
         given(jwtTokenProvider.createRefreshToken(authentication, applicant.getId())).willReturn(TEST_REFRESH_TOKEN);
@@ -196,6 +204,58 @@ class AuthServiceTest {
         
         // then
         assertThat(result).isEqualTo(authentication);
+    }
+
+    @Test
+    @DisplayName("현재 공고에 작성 중인 지원서가 있으면 PIN 로그인에 성공한다")
+    void 현재_공고에_작성_중인_지원서가_있으면_PIN_로그인에_성공한다() {
+        // given
+        Applicant applicant = Applicant.builder()
+                .id(TEST_APPLICANT_ID)
+                .email(TEST_EMAIL)
+                .pin(TEST_ENCODED_PIN)
+                .role(Role.SEMESTER)
+                .status(MemberStatus.ACTIVE)
+                .build();
+
+        given(applicantRepository.findByEmailAndSemesterId(TEST_EMAIL, TEST_SEMESTER_ID))
+                .willReturn(Optional.of(applicant));
+        given(passwordEncoder.matches(TEST_PIN, TEST_ENCODED_PIN)).willReturn(true);
+        given(applyQueryService.getRecruitIdByApplicantId(TEST_APPLICANT_ID))
+                .willReturn(Optional.of(TEST_RECRUIT_ID));
+        given(jwtTokenProvider.createAuthenticationByApplicant(applicant)).willReturn(authentication);
+
+        // when
+        Authentication result = authService.loginWithPin(TEST_EMAIL, TEST_PIN, TEST_RECRUIT_ID);
+
+        // then
+        assertThat(result).isEqualTo(authentication);
+    }
+
+    @Test
+    @DisplayName("다른 공고에 작성 중인 지원서가 있으면 충돌 예외가 발생한다")
+    void 다른_공고에_작성_중인_지원서가_있으면_충돌_예외가_발생한다() {
+        // given
+        Long existingRecruitId = 21L;
+        Applicant applicant = Applicant.builder()
+                .id(TEST_APPLICANT_ID)
+                .email(TEST_EMAIL)
+                .pin(TEST_ENCODED_PIN)
+                .role(Role.SEMESTER)
+                .status(MemberStatus.ACTIVE)
+                .build();
+
+        given(applicantRepository.findByEmailAndSemesterId(TEST_EMAIL, TEST_SEMESTER_ID))
+                .willReturn(Optional.of(applicant));
+        given(passwordEncoder.matches(TEST_PIN, TEST_ENCODED_PIN)).willReturn(true);
+        given(applyQueryService.getRecruitIdByApplicantId(TEST_APPLICANT_ID))
+                .willReturn(Optional.of(existingRecruitId));
+
+        // when & then
+        assertThatThrownBy(() -> authService.loginWithPin(TEST_EMAIL, TEST_PIN, TEST_RECRUIT_ID))
+                .isInstanceOf(ApplyException.class)
+                .extracting(exception -> ((ApplyException) exception).getErrorCode())
+                .isEqualTo(APPLY_EXISTS_IN_OTHER_RECRUIT);
     }
     
     @Test
@@ -233,6 +293,7 @@ class AuthServiceTest {
             .isInstanceOf(AuthException.class)
             .extracting(e -> ((AuthException) e).getErrorCode())
             .isEqualTo(INVALID_CREDENTIALS);
+        verifyNoInteractions(applyQueryService);
     }
     
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #643

## 📝 문제

- 같은 기수의 다른 공고에 작성 중인 지원서가 있어도 PIN 로그인을 진행함
- 로그인 후 요청한 공고의 지원서를 찾지 못해 사용자가 원인을 알기 어려웠음

## 🛠 조치

- PIN 검증 후 현재 기수 Applicant의 기존 지원 공고와 요청 공고를 비교
- 다른 공고에 지원 중이면 `409 Conflict`와 `APPLY-12` 반환

## ✅ 변경 후 동작

- Apply 없음: 정상 로그인 후 프로필 작성
- 현재 공고 Apply 있음: 정상 로그인 후 이어쓰기
- 다른 공고 Apply 있음: `409 APPLY-12`로 작성 중인 지원서 안내
- 이전 기수 Apply: 현재 기수 로그인에 영향 없음

## API 계약 변경

- `POST /auth/login/pin` 요청 형식 변경 없음
- 다른 공고에 지원 중인 경우 `409 APPLY-12` 응답 추가

## 🧪 검증

- 전체 테스트 통과
- JaCoCo 검증 통과
