### PR TITLE
feat: 운영 서포터즈 구성원 단건, 다건 삭제 API 구현

### DIFF
--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersApiSpec.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersApiSpec.java
@@ -1,7 +1,7 @@
 package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
-import org.ject.support.admin.member.dto.request.DeleteMemberMakersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
 import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
@@ -44,5 +44,5 @@ public interface AdminMemberMakersApiSpec {
 		summary = "메이커스팀 구성원 일괄 삭제",
 		description = "선택한 메이커스팀 구성원을 일괄 삭제합니다. 유효하지 않은 ID가 있으면 전체 요청이 실패합니다."
 	)
-	void deleteAdminMemberMakersList(@RequestBody @Valid DeleteMemberMakersRequest request);
+	void deleteAdminMemberMakersList(@RequestBody @Valid DeleteMembersRequest request);
 }

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberMakersController.java
@@ -1,7 +1,7 @@
 package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
-import org.ject.support.admin.member.dto.request.DeleteMemberMakersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
 import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
@@ -56,7 +56,7 @@ public class AdminMemberMakersController implements AdminMemberMakersApiSpec {
 
 	@Override
 	@DeleteMapping
-	public void deleteAdminMemberMakersList(@RequestBody @Valid DeleteMemberMakersRequest request) {
+	public void deleteAdminMemberMakersList(@RequestBody @Valid DeleteMembersRequest request) {
 		adminMemberMakersUseCase.deleteMemberMakersList(request);
 	}
 

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersApiSpec.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersApiSpec.java
@@ -1,6 +1,7 @@
 package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.admin.member.dto.request.MemberSupportersListRequest;
 import org.ject.support.admin.member.dto.response.MemberSupportersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberSupportersListResponse;
@@ -33,4 +34,16 @@ public interface AdminMemberSupportersApiSpec {
 		description = "운영 서포터즈 구성원을 상세 조회합니다."
 	)
 	MemberSupportersDetailResponse getAdminMemberSupportersDetail(@PathVariable Long memberActivityId);
+
+	@Operation(
+		summary = "운영 서포터즈 구성원 삭제",
+		description = "전달한 활동 ID에 해당하는 운영 서포터즈 구성원을 삭제합니다."
+	)
+	void deleteAdminMemberSupporters(@PathVariable Long memberActivityId);
+
+	@Operation(
+		summary = "운영 서포터즈 구성원 일괄 삭제",
+		description = "선택한 운영 서포터즈 구성원을 일괄 삭제합니다. 유효하지 않은 ID가 있으면 전체 요청이 실패합니다."
+	)
+	void deleteAdminMemberSupportersList(@RequestBody @Valid DeleteMembersRequest request);
 }

--- a/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersController.java
+++ b/src/main/java/org/ject/support/admin/member/controller/AdminMemberSupportersController.java
@@ -1,12 +1,14 @@
 package org.ject.support.admin.member.controller;
 
 import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.admin.member.dto.request.MemberSupportersListRequest;
 import org.ject.support.admin.member.dto.response.MemberSupportersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberSupportersListResponse;
 import org.ject.support.admin.member.service.AdminMemberSupportersUseCase;
 import org.ject.support.common.response.CursorPageResponse;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,7 +38,7 @@ public class AdminMemberSupportersController implements AdminMemberSupportersApi
 	@Override
 	@GetMapping
 	public CursorPageResponse<MemberSupportersListResponse> getAdminMemberSupportersList(
-		@ParameterObject  @ModelAttribute @Valid MemberSupportersListRequest request) {
+		@ParameterObject @ModelAttribute @Valid MemberSupportersListRequest request) {
 		return adminMemberSupportersUseCase.getMemberSupportersList(request);
 	}
 
@@ -44,5 +46,17 @@ public class AdminMemberSupportersController implements AdminMemberSupportersApi
 	@GetMapping("/{memberActivityId}")
 	public MemberSupportersDetailResponse getAdminMemberSupportersDetail(@PathVariable Long memberActivityId) {
 		return adminMemberSupportersUseCase.getMemberSupportersDetail(memberActivityId);
+	}
+
+	@Override
+	@DeleteMapping("/{memberActivityId}")
+	public void deleteAdminMemberSupporters(@PathVariable Long memberActivityId) {
+		adminMemberSupportersUseCase.deleteMemberSupporters(memberActivityId);
+	}
+
+	@Override
+	@DeleteMapping
+	public void deleteAdminMemberSupportersList(@RequestBody @Valid DeleteMembersRequest request) {
+		adminMemberSupportersUseCase.deleteMemberSupportersList(request);
 	}
 }

--- a/src/main/java/org/ject/support/admin/member/dto/request/DeleteMembersRequest.java
+++ b/src/main/java/org/ject/support/admin/member/dto/request/DeleteMembersRequest.java
@@ -6,9 +6,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
-@Schema(description = "메이커스팀 구성원 일괄 삭제 요청")
-public record DeleteMemberMakersRequest(
-	@Schema(description = "삭제할 메이커스팀 구성원 활동 ID 목록", example = "[1, 2, 3]")
+@Schema(description = "구성원 일괄 삭제 요청")
+public record DeleteMembersRequest(
+	@Schema(description = "삭제할 구성원 활동 ID 목록", example = "[1, 2, 3]")
 	@NotEmpty Set<@NotNull Long> memberActivityIds
 ) {
 }

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberMakersUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberMakersUseCase.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
-import org.ject.support.admin.member.dto.request.DeleteMemberMakersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
 import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
@@ -65,7 +65,7 @@ public class AdminMemberMakersUseCase {
 
 	// 메이커스팀 구성원 일괄 삭제
 	@Transactional
-	public void deleteMemberMakersList(DeleteMemberMakersRequest request) {
+	public void deleteMemberMakersList(DeleteMembersRequest request) {
 		Set<Long> memberIds = adminMemberActivityService.deleteMemberActivities(
 			request.memberActivityIds(),
 			MemberType.MAKERS

--- a/src/main/java/org/ject/support/admin/member/service/AdminMemberSupportersUseCase.java
+++ b/src/main/java/org/ject/support/admin/member/service/AdminMemberSupportersUseCase.java
@@ -1,13 +1,17 @@
 package org.ject.support.admin.member.service;
 
+import java.util.Set;
+
 import org.ject.support.admin.member.dto.projection.MemberSupportersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberSupportersListProjection;
 import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.admin.member.dto.request.MemberSupportersListRequest;
 import org.ject.support.admin.member.dto.response.MemberSupportersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberSupportersListResponse;
 import org.ject.support.admin.member.dto.result.MemberPageResult;
 import org.ject.support.common.response.CursorPageResponse;
+import org.ject.support.domain.member.MemberType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,5 +53,22 @@ public class AdminMemberSupportersUseCase {
 	public MemberSupportersDetailResponse getMemberSupportersDetail(Long memberActivityId) {
 		MemberSupportersDetailProjection projection = adminMemberActivityService.getMemberSupportersDetail(memberActivityId);
 		return MemberSupportersDetailResponse.from(projection);
+	}
+
+	// 운영 서포터즈 구성원 단건 삭제
+	@Transactional
+	public void deleteMemberSupporters(Long memberActivityId) {
+		Long memberId = adminMemberActivityService.deleteMemberActivity(memberActivityId, MemberType.SUPPORTERS);
+		adminMemberService.deleteMemberIfNoActivity(memberId);
+	}
+
+	// 운영 서포터즈 구성원 일괄 삭제
+	@Transactional
+	public void deleteMemberSupportersList(DeleteMembersRequest request) {
+		Set<Long> memberIds = adminMemberActivityService.deleteMemberActivities(
+			request.memberActivityIds(),
+			MemberType.SUPPORTERS
+		);
+		adminMemberService.deleteMembersIfNoActivity(memberIds);
 	}
 }

--- a/src/main/java/org/ject/support/domain/member/entity/MemberMakers.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberMakers.java
@@ -11,6 +11,7 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 import org.ject.support.domain.base.BaseTimeEntity;
 import org.ject.support.domain.member.Availability;
 import org.ject.support.domain.member.MakersTeam;
@@ -20,6 +21,7 @@ import org.ject.support.domain.member.CareerLevel;
 @Getter
 @Builder
 @Table(name = "member_makers")
+@SQLDelete(sql = "UPDATE member_makers SET id = id WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberMakers extends BaseTimeEntity {

--- a/src/main/java/org/ject/support/domain/member/entity/MemberSemester.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberSemester.java
@@ -9,12 +9,14 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 import org.ject.support.domain.base.BaseTimeEntity;
 
 @Entity
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 @Table(name = "member_semester")
+@SQLDelete(sql = "UPDATE member_semester SET id = id WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberSemester extends BaseTimeEntity {

--- a/src/main/java/org/ject/support/domain/member/entity/MemberSupporters.java
+++ b/src/main/java/org/ject/support/domain/member/entity/MemberSupporters.java
@@ -9,12 +9,14 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 import org.ject.support.domain.base.BaseTimeEntity;
 
 @Entity
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 @Table(name = "member_supporters")
+@SQLDelete(sql = "UPDATE member_supporters SET id = id WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberSupporters extends BaseTimeEntity {

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberMakersControllerTest.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Set;
 import org.ject.support.admin.member.dto.request.CreateMemberMakersRequest;
-import org.ject.support.admin.member.dto.request.DeleteMemberMakersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.Availability;
 import org.ject.support.domain.member.CareerDetails;
@@ -320,7 +320,7 @@ class AdminMemberMakersControllerTest {
 		// given
 		MemberActivity first = saveMakersActivity(uniqueEmail("bulk1"), JobFamily.FE, MakersTeam.TEAM_1);
 		MemberActivity second = saveMakersActivity(uniqueEmail("bulk2"), JobFamily.BE, MakersTeam.TEAM_2);
-		DeleteMemberMakersRequest request = new DeleteMemberMakersRequest(Set.of(first.getId(), second.getId()));
+		DeleteMembersRequest request = new DeleteMembersRequest(Set.of(first.getId(), second.getId()));
 
 		// when
 		mockMvc.perform(delete("/admin/members/makers")
@@ -339,7 +339,7 @@ class AdminMemberMakersControllerTest {
 	void 일괄_삭제_대상에_존재하지_않는_활동이_있으면_아무도_삭제하지_않는다() throws Exception {
 		// given
 		MemberActivity memberActivity = saveMakersActivity(uniqueEmail("bulk-invalid"), JobFamily.FE, MakersTeam.TEAM_1);
-		DeleteMemberMakersRequest request = new DeleteMemberMakersRequest(Set.of(memberActivity.getId(), 999999999L));
+		DeleteMembersRequest request = new DeleteMembersRequest(Set.of(memberActivity.getId(), 999999999L));
 
 		// when
 		mockMvc.perform(delete("/admin/members/makers")
@@ -360,7 +360,7 @@ class AdminMemberMakersControllerTest {
 		MemberActivity makers = saveMakersActivity(uniqueEmail("bulk-makers"), JobFamily.FE, MakersTeam.TEAM_1);
 		Member member = memberRepository.save(member().email(uniqueEmail("bulk-semester")).build());
 		MemberActivity semester = memberActivityRepository.saveAndFlush(semesterActivity().memberId(member.getId()).build());
-		DeleteMemberMakersRequest request = new DeleteMemberMakersRequest(Set.of(makers.getId(), semester.getId()));
+		DeleteMembersRequest request = new DeleteMembersRequest(Set.of(makers.getId(), semester.getId()));
 
 		// when
 		mockMvc.perform(delete("/admin/members/makers")

--- a/src/test/java/org/ject/support/admin/member/controller/AdminMemberSupportersControllerTest.java
+++ b/src/test/java/org/ject/support/admin/member/controller/AdminMemberSupportersControllerTest.java
@@ -2,14 +2,19 @@ package org.ject.support.admin.member.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ject.support.domain.member.fixture.MemberFixture.member;
+import static org.ject.support.domain.member.fixture.SemesterActivityFixture.semesterActivity;
 import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Set;
 import org.ject.support.admin.member.dto.request.CreateMemberSupportersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.domain.member.ActivityStatus;
 import org.ject.support.domain.member.JobFamily;
 import org.ject.support.domain.member.MemberType;
@@ -205,6 +210,151 @@ class AdminMemberSupportersControllerTest {
 			.andExpect(jsonPath("$.status").value(MemberErrorCode.NOT_FOUND_MEMBER.getCode()));
 	}
 
+	@Test
+	@DisplayName("운영 서포터즈 구성원을 삭제하고 남은 활동이 없으면 구성원도 삭제한다")
+	void 운영_서포터즈_구성원을_삭제하고_남은_활동이_없으면_구성원도_삭제한다() throws Exception {
+		// given
+		MemberActivity memberActivity = saveSupportersActivity(uniqueEmail("delete"), ActivityStatus.ENDED);
+
+		// when
+		mockMvc.perform(delete("/admin/members/supporters/{memberActivityId}", memberActivity.getId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("SUCCESS"));
+
+		// then
+		assertThat(memberActivityRepository.findById(memberActivity.getId())).isEmpty();
+		assertThat(memberRepository.findById(memberActivity.getMemberId())).isEmpty();
+	}
+
+	@Test
+	@DisplayName("운영 서포터즈 활동을 삭제해도 다른 활동이 남아 있으면 구성원을 유지한다")
+	void 운영_서포터즈_활동을_삭제해도_다른_활동이_남아_있으면_구성원을_유지한다() throws Exception {
+		// given
+		Member member = memberRepository.save(member().email(uniqueEmail("remain")).build());
+		MemberActivity supporters = saveSupportersActivity(member.getId(), ActivityStatus.ENDED);
+		MemberActivity semester = memberActivityRepository.saveAndFlush(
+			semesterActivity()
+				.memberId(member.getId())
+				.build()
+		);
+
+		// when
+		mockMvc.perform(delete("/admin/members/supporters/{memberActivityId}", supporters.getId()))
+			.andExpect(status().isOk());
+
+		// then
+		assertThat(memberActivityRepository.findById(supporters.getId())).isEmpty();
+		assertThat(memberActivityRepository.findById(semester.getId())).isPresent();
+		assertThat(memberRepository.findById(member.getId())).isPresent();
+	}
+
+	@Test
+	@DisplayName("운영 서포터즈가 아닌 구성원은 삭제할 수 없다")
+	void 운영_서포터즈가_아닌_구성원은_삭제할_수_없다() throws Exception {
+		// given
+		Member member = memberRepository.save(member().email(uniqueEmail("invalid-type")).build());
+		MemberActivity semester = memberActivityRepository.saveAndFlush(
+			semesterActivity()
+				.memberId(member.getId())
+				.build()
+		);
+
+		// when & then
+		mockMvc.perform(delete("/admin/members/supporters/{memberActivityId}", semester.getId()))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.status").value(MemberErrorCode.NOT_FOUND_MEMBER_SUPPORTERS_ACTIVITY.getCode()));
+		assertThat(memberActivityRepository.findById(semester.getId())).isPresent();
+		assertThat(memberRepository.findById(member.getId())).isPresent();
+	}
+
+	@Test
+	@DisplayName("선택한 운영 서포터즈 구성원을 모두 삭제한다")
+	void 선택한_운영_서포터즈_구성원을_모두_삭제한다() throws Exception {
+		// given
+		MemberActivity first = saveSupportersActivity(uniqueEmail("bulk1"), ActivityStatus.ENDED);
+		MemberActivity second = saveSupportersActivity(uniqueEmail("bulk2"), ActivityStatus.ENDED);
+		DeleteMembersRequest request = new DeleteMembersRequest(Set.of(first.getId(), second.getId()));
+
+		// when
+		mockMvc.perform(delete("/admin/members/supporters")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("SUCCESS"));
+
+		// then
+		assertThat(memberActivityRepository.findAllById(List.of(first.getId(), second.getId()))).isEmpty();
+		assertThat(memberRepository.findAllById(List.of(first.getMemberId(), second.getMemberId()))).isEmpty();
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 구성원이 포함되면 모든 운영 서포터즈 구성원을 유지한다")
+	void 유효하지_않은_구성원이_포함되면_모든_운영_서포터즈_구성원을_유지한다() throws Exception {
+		// given
+		MemberActivity memberActivity = saveSupportersActivity(uniqueEmail("bulk-invalid"), ActivityStatus.ENDED);
+		DeleteMembersRequest request = new DeleteMembersRequest(
+			Set.of(memberActivity.getId(), 999999999L)
+		);
+
+		// when
+		mockMvc.perform(delete("/admin/members/supporters")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.status").value(MemberErrorCode.NOT_FOUND_MEMBER_SUPPORTERS_ACTIVITY.getCode()));
+
+		// then
+		assertThat(memberActivityRepository.findById(memberActivity.getId())).isPresent();
+		assertThat(memberRepository.findById(memberActivity.getMemberId())).isPresent();
+	}
+
+	@Test
+	@DisplayName("운영 서포터즈가 아닌 구성원이 포함되면 모든 구성원을 유지한다")
+	void 운영_서포터즈가_아닌_구성원이_포함되면_모든_구성원을_유지한다() throws Exception {
+		// given
+		MemberActivity supporters = saveSupportersActivity(uniqueEmail("bulk-supporters"), ActivityStatus.ENDED);
+		Member member = memberRepository.save(member().email(uniqueEmail("bulk-semester")).build());
+		MemberActivity semester = memberActivityRepository.saveAndFlush(
+			semesterActivity()
+				.memberId(member.getId())
+				.build()
+		);
+		DeleteMembersRequest request = new DeleteMembersRequest(
+			Set.of(supporters.getId(), semester.getId())
+		);
+
+		// when
+		mockMvc.perform(delete("/admin/members/supporters")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.status").value(MemberErrorCode.NOT_FOUND_MEMBER_SUPPORTERS_ACTIVITY.getCode()));
+
+		// then
+		assertThat(memberActivityRepository.findById(supporters.getId())).isPresent();
+		assertThat(memberActivityRepository.findById(semester.getId())).isPresent();
+	}
+
+	@Test
+	@DisplayName("삭제할 운영 서포터즈 구성원이 없으면 요청에 실패한다")
+	void 삭제할_운영_서포터즈_구성원이_없으면_요청에_실패한다() throws Exception {
+		mockMvc.perform(delete("/admin/members/supporters")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"memberActivityIds\":[]}"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
+	}
+
+	@Test
+	@DisplayName("삭제할 운영 서포터즈 구성원 ID에 빈 값이 있으면 요청에 실패한다")
+	void 삭제할_운영_서포터즈_구성원_ID에_빈_값이_있으면_요청에_실패한다() throws Exception {
+		mockMvc.perform(delete("/admin/members/supporters")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"memberActivityIds\":[null]}"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("GLOBAL-15"));
+	}
+
 	private CreateMemberSupportersRequest createMemberSupportersRequest(String email, JobFamily jobFamily, String memo) {
 		return new CreateMemberSupportersRequest(
 			"김서포터",
@@ -232,8 +382,12 @@ class AdminMemberSupportersControllerTest {
 
 	private MemberActivity saveSupportersActivity(String email, ActivityStatus activityStatus) {
 		Member member = memberRepository.save(member().email(email).build());
+		return saveSupportersActivity(member.getId(), activityStatus);
+	}
+
+	private MemberActivity saveSupportersActivity(Long memberId, ActivityStatus activityStatus) {
 		return memberActivityRepository.saveAndFlush(MemberActivity.createSupportersActivity(
-			member.getId(),
+			memberId,
 			JobFamily.OPS,
 			RecruitTypeDetail.REGULAR,
 			activityStatus,

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberActivityServiceTest.java
@@ -451,6 +451,68 @@ class AdminMemberActivityServiceTest {
 	}
 
 	@Test
+	@DisplayName("운영 서포터즈 구성원을 삭제한다")
+	void 운영_서포터즈_구성원을_삭제한다() {
+		// given
+		Long memberActivityId = 1L;
+		MemberActivity memberActivity = mock(MemberActivity.class);
+		given(memberActivity.getMemberId()).willReturn(10L);
+		given(memberActivityRepository.findByIdAndMemberType(memberActivityId, MemberType.SUPPORTERS))
+			.willReturn(Optional.of(memberActivity));
+
+		// when
+		Long memberId = adminMemberActivityService.deleteMemberActivity(memberActivityId, MemberType.SUPPORTERS);
+
+		// then
+		assertThat(memberId).isEqualTo(10L);
+		verify(memberActivityRepository).delete(memberActivity);
+	}
+
+	@Test
+	@DisplayName("선택한 운영 서포터즈 구성원을 모두 삭제한다")
+	void 선택한_운영_서포터즈_구성원을_모두_삭제한다() {
+		// given
+		Set<Long> memberActivityIds = Set.of(1L, 2L);
+		MemberActivity first = memberActivity(1L, 10L);
+		MemberActivity second = memberActivity(2L, 20L);
+		List<MemberActivity> memberActivities = List.of(first, second);
+		given(memberActivityRepository.findAllByIdInAndMemberType(memberActivityIds, MemberType.SUPPORTERS))
+			.willReturn(memberActivities);
+
+		// when
+		Set<Long> memberIds = adminMemberActivityService.deleteMemberActivities(
+			memberActivityIds,
+			MemberType.SUPPORTERS
+		);
+
+		// then
+		assertThat(memberIds).containsExactlyInAnyOrder(10L, 20L);
+		verify(memberActivityRepository).deleteAll(memberActivities);
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 구성원이 포함되면 모든 운영 서포터즈 구성원을 유지한다")
+	void 유효하지_않은_구성원이_포함되면_모든_운영_서포터즈_구성원을_유지한다() {
+		// given
+		Set<Long> memberActivityIds = Set.of(1L, 2L);
+		MemberActivity memberActivity = memberActivity(1L);
+		given(memberActivityRepository.findAllByIdInAndMemberType(memberActivityIds, MemberType.SUPPORTERS))
+			.willReturn(List.of(memberActivity));
+
+		// when
+		Throwable throwable = catchThrowable(() ->
+			adminMemberActivityService.deleteMemberActivities(memberActivityIds, MemberType.SUPPORTERS)
+		);
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(MemberException.class)
+			.extracting("errorCode")
+			.isEqualTo(MemberErrorCode.NOT_FOUND_MEMBER_SUPPORTERS_ACTIVITY);
+		verify(memberActivityRepository, never()).deleteAll(any());
+	}
+
+	@Test
 	@DisplayName("선택한 메이커스팀 활동을 모두 삭제한다")
 	void 선택한_메이커스팀_활동을_모두_삭제한다() {
 		// given

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberMakersUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberMakersUseCaseTest.java
@@ -9,7 +9,7 @@ import java.util.Set;
 
 import org.ject.support.admin.member.dto.projection.MemberMakersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberMakersListProjection;
-import org.ject.support.admin.member.dto.request.DeleteMemberMakersRequest;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.admin.member.dto.request.MemberMakersListRequest;
 import org.ject.support.admin.member.dto.response.MemberMakersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberMakersListResponse;
@@ -138,7 +138,7 @@ class AdminMemberMakersUseCaseTest {
 	@DisplayName("선택한 메이커스팀 구성원을 모두 삭제한다")
 	void 선택한_메이커스팀_구성원을_모두_삭제한다() {
 		// given
-		DeleteMemberMakersRequest request = new DeleteMemberMakersRequest(Set.of(1L, 2L));
+		DeleteMembersRequest request = new DeleteMembersRequest(Set.of(1L, 2L));
 		Set<Long> memberIds = Set.of(10L, 20L);
 		given(adminMemberActivityService.deleteMemberActivities(request.memberActivityIds(), MemberType.MAKERS))
 			.willReturn(memberIds);

--- a/src/test/java/org/ject/support/admin/member/service/AdminMemberSupportersUseCaseTest.java
+++ b/src/test/java/org/ject/support/admin/member/service/AdminMemberSupportersUseCaseTest.java
@@ -5,9 +5,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 
 import java.util.List;
+import java.util.Set;
 
 import org.ject.support.admin.member.dto.projection.MemberSupportersDetailProjection;
 import org.ject.support.admin.member.dto.projection.MemberSupportersListProjection;
+import org.ject.support.admin.member.dto.request.DeleteMembersRequest;
 import org.ject.support.admin.member.dto.request.MemberSupportersListRequest;
 import org.ject.support.admin.member.dto.response.MemberSupportersDetailResponse;
 import org.ject.support.admin.member.dto.response.MemberSupportersListResponse;
@@ -105,6 +107,38 @@ class AdminMemberSupportersUseCaseTest {
 		// then
 		assertThat(response).isEqualTo(MemberSupportersDetailResponse.from(projection));
 		verify(adminMemberActivityService).getMemberSupportersDetail(memberActivityId);
+	}
+
+	@Test
+	@DisplayName("운영 서포터즈 구성원을 삭제하고 남은 활동이 없으면 구성원도 삭제한다")
+	void 운영_서포터즈_구성원을_삭제하고_남은_활동이_없으면_구성원도_삭제한다() {
+		// given
+		Long memberActivityId = 1L;
+		Long memberId = 10L;
+		given(adminMemberActivityService.deleteMemberActivity(memberActivityId, MemberType.SUPPORTERS))
+			.willReturn(memberId);
+
+		// when
+		adminMemberSupportersUseCase.deleteMemberSupporters(memberActivityId);
+
+		// then
+		verify(adminMemberService).deleteMemberIfNoActivity(memberId);
+	}
+
+	@Test
+	@DisplayName("선택한 운영 서포터즈 구성원을 모두 삭제한다")
+	void 선택한_운영_서포터즈_구성원을_모두_삭제한다() {
+		// given
+		DeleteMembersRequest request = new DeleteMembersRequest(Set.of(1L, 2L));
+		Set<Long> memberIds = Set.of(10L, 20L);
+		given(adminMemberActivityService.deleteMemberActivities(request.memberActivityIds(), MemberType.SUPPORTERS))
+			.willReturn(memberIds);
+
+		// when
+		adminMemberSupportersUseCase.deleteMemberSupportersList(request);
+
+		// then
+		verify(adminMemberService).deleteMembersIfNoActivity(memberIds);
 	}
 
 	private MemberSupportersListProjection supportersProjection(Long memberActivityId, String name) {

--- a/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
+++ b/src/test/java/org/ject/support/domain/member/repository/MemberActivityRepositoryTest.java
@@ -27,6 +27,7 @@ import org.ject.support.domain.member.dto.TeamMemberNames;
 import org.ject.support.domain.member.entity.Member;
 import org.ject.support.domain.member.entity.MemberActivity;
 import org.ject.support.domain.member.entity.MemberSemester;
+import org.ject.support.domain.member.entity.MemberSupporters;
 import org.ject.support.domain.recruit.domain.RecruitTypeDetail;
 import org.ject.support.testconfig.QueryDslTestConfig;
 import org.junit.jupiter.api.DisplayName;
@@ -1321,4 +1322,55 @@ class MemberActivityRepositoryTest {
 		// when & then
 		assertThat(memberActivityRepository.findMemberIdsWithActivity(Set.of(member.getId()))).isEmpty();
 	}
+
+	@Test
+	@DisplayName("운영 서포터즈 활동을 삭제해도 활동 관리 항목은 유지한다")
+	void 운영_서포터즈_활동을_삭제해도_활동_관리_항목은_유지한다() {
+		// given
+		Member member = memberRepository.save(member().email("supporters-delete@test.com").build());
+		MemberActivity memberActivity = saveSupportersActivity(member.getId(), "SP-DELETE");
+
+		// when
+		memberActivityRepository.delete(memberActivity);
+		memberActivityRepository.flush();
+		entityManager.clear();
+
+		// then
+		assertThat(memberActivityRepository.findById(memberActivity.getId())).isEmpty();
+		assertThat(entityManager.find(MemberSupporters.class, memberActivity.getId())).isNotNull();
+	}
+
+	@Test
+	@DisplayName("운영 서포터즈 활동 여러 건을 삭제해도 활동 관리 항목은 유지한다")
+	void 운영_서포터즈_활동_여러_건을_삭제해도_활동_관리_항목은_유지한다() {
+		// given
+		Member firstMember = memberRepository.save(member().email("supporters-bulk1@test.com").build());
+		Member secondMember = memberRepository.save(member().email("supporters-bulk2@test.com").build());
+		MemberActivity first = saveSupportersActivity(firstMember.getId(), "SP-BULK-1");
+		MemberActivity second = saveSupportersActivity(secondMember.getId(), "SP-BULK-2");
+
+		// when
+		memberActivityRepository.deleteAll(List.of(first, second));
+		memberActivityRepository.flush();
+		entityManager.clear();
+
+		// then
+		assertThat(memberActivityRepository.findAllById(List.of(first.getId(), second.getId()))).isEmpty();
+		assertThat(entityManager.find(MemberSupporters.class, first.getId())).isNotNull();
+		assertThat(entityManager.find(MemberSupporters.class, second.getId())).isNotNull();
+	}
+
+	private MemberActivity saveSupportersActivity(Long memberId, String activityCertNumber) {
+		return memberActivityRepository.saveAndFlush(MemberActivity.createSupportersActivity(
+			memberId,
+			JobFamily.OPS,
+			RecruitTypeDetail.REGULAR,
+			ActivityStatus.ENDED,
+			null,
+			null,
+			activityCertNumber,
+			"memo"
+		));
+	}
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #635

## 📝 작업 내용

- 운영 서포터즈 구성원 단건 삭제 API를 구현했습니다.
- 운영 서포터즈 구성원 다건 삭제 API를 구현했습니다.
- 구성원 활동 삭제 후 남은 활동이 없으면 구성원도 삭제하도록 처리했습니다.
- 삭제 대상에 유효하지 않은 운영 서포터즈 구성원이 포함되면 전체 삭제를 중단하도록 처리했습니다.
- 구성원 활동은 소프트 삭제하고 운영 서포터즈 활동 관리 항목은 유지하도록 삭제 정책을 적용했습니다.
- Controller, UseCase, Service, Repository 테스트를 추가했습니다.

## ✅ 검증 결과

- 운영 서포터즈 단건·다건 삭제 API 호출 확인
- 구성원 활동과 구성원 소프트 삭제 확인
- 운영 서포터즈 활동 관리 항목 유지 확인
- 관련 테스트 4개 클래스 통과

## 🙏 리뷰 요구사항 (선택)

- 구성원 활동 삭제 시 하위 활동 관리 항목을 유지하기 위한 `@SQLDelete` 정책을 확인해주세요.
- 단건·다건 삭제의 전체 실패 조건과 구성원 정리 흐름을 확인해주세요.
